### PR TITLE
Write lock flight6 since updating localVerifyData

### DIFF
--- a/server_handlers.go
+++ b/server_handlers.go
@@ -374,7 +374,8 @@ func serverFlightHandler(c *Conn) (bool, error) {
 		c.lock.RUnlock()
 
 	case flight6:
-		c.lock.RLock()
+		// Hold write lock since we're setting localVerifyData
+		c.lock.Lock()
 		c.internalSend(&recordLayer{
 			recordLayerHeader: recordLayerHeader{
 				sequenceNumber:  c.state.localSequenceNumber,
@@ -420,7 +421,7 @@ func serverFlightHandler(c *Conn) (bool, error) {
 					verifyData: c.localVerifyData,
 				}},
 		}, true)
-		c.lock.RUnlock()
+		c.lock.Unlock()
 
 		// TODO: Better way to end handshake
 		c.signalHandshakeComplete()


### PR DESCRIPTION
Cause of the race:
- The `flightHandler` is called concurrently from `handleIncomingPacket` and by the `workerTicker` in `startHandshakeOutbound`.
- It both reads and writes to `localVerifyData` in `flight6`.

Resolves #55

Likely also the cause for #56 since the `handshakeMessageFinished` is filled with `localVerifyData`:
https://github.com/pion/dtls/blob/2fbf4ca16c10f4cc3bd8530e0e839863466362e2/server_handlers.go#L419-L421