### PR TITLE
invoke flight handler earlier to speed up DataChannel handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Daniele Sluijters](https://github.com/daenney) - *AES-CCM support*
 * [Jin Lei](https://github.com/jinleileiking) - *Logging*
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Lander Noterman](https://github.com/LanderN)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn.go
+++ b/conn.go
@@ -448,6 +448,7 @@ func (c *Conn) startHandshakeOutbound() {
 			}
 		}
 	}()
+	c.currFlight.workerTrigger <- struct{}{}
 }
 
 func (c *Conn) stopWithError(err error) {

--- a/flight.go
+++ b/flight.go
@@ -79,7 +79,7 @@ func newFlight(isClient bool) *flight {
 	if isClient {
 		val = flight1
 	}
-	return &flight{val: val, workerTrigger: make(chan struct{})}
+	return &flight{val: val, workerTrigger: make(chan struct{}, 1)}
 }
 
 func (f *flight) get() flightVal {


### PR DESCRIPTION
#### Description
This PR speeds up DataChannel creation by about 1 second.
Connection flightHandler is invoked immediately on startHandshakeOutbound instead of waiting for the first tick of workerTicker.
