### PR TITLE
Allow user to specify PSK

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -88,7 +88,7 @@ func encodeCipherSuites(c []cipherSuite) []byte {
 	return out
 }
 
-func parseCipherSuites(userSelectedSuites []CipherSuiteID, psk []byte) ([]cipherSuite, error) {
+func parseCipherSuites(userSelectedSuites []CipherSuiteID, excludePSK, excludeNonPSK bool) ([]cipherSuite, error) {
 	cipherSuitesForIDs := func(ids []CipherSuiteID) ([]cipherSuite, error) {
 		cipherSuites := []cipherSuite{}
 		for _, id := range ids {
@@ -116,10 +116,11 @@ func parseCipherSuites(userSelectedSuites []CipherSuiteID, psk []byte) ([]cipher
 	}
 
 	for _, c := range cipherSuites {
-		if (psk != nil && c.isPSK()) || (psk == nil && !c.isPSK()) {
-			cipherSuites[i] = c
-			i++
+		if excludePSK && c.isPSK() || excludeNonPSK && !c.isPSK() {
+			continue
 		}
+		cipherSuites[i] = c
+		i++
 	}
 
 	cipherSuites = cipherSuites[:i]

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
@@ -26,6 +26,10 @@ func (c cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) hashFunc() func() hash.Hash
 	return sha256.New
 }
 
+func (c cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) isPSK() bool {
+	return false
+}
+
 func (c *cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
 	const (
 		prfMacLen = 0

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -26,6 +26,10 @@ func (c cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) hashFunc() func() hash.Hash {
 	return sha256.New
 }
 
+func (c cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) isPSK() bool {
+	return false
+}
+
 func (c *cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
 	const (
 		prfMacLen = 20

--- a/config.go
+++ b/config.go
@@ -39,10 +39,15 @@ type Config struct {
 
 	// PSK sets the pre-shared key used by this DTLS connection
 	// If PSK is non-nil only PSK CipherSuites will be used
-	PSK []byte
+	PSK             PSKCallback
+	PSKIdentityHint []byte
 
 	LoggerFactory logging.LoggerFactory
 }
+
+// PSKCallback is called once we have the remote's PSKIdentityHint.
+// If the remote provided none it will be nil
+type PSKCallback func([]byte) ([]byte, error)
 
 // ClientAuthType declares the policy the server will follow for
 // TLS Client Authentication.

--- a/config.go
+++ b/config.go
@@ -11,10 +11,9 @@ import (
 // Config is used to configure a DTLS client or server.
 // After a Config is passed to a DTLS function it must not be modified.
 type Config struct {
-	// Certificates contains certificate chain to present to
-	// the other side of the connection. Server MUST set this,
-	// client SHOULD sets this so CertificateRequests
-	// can be handled
+	// Certificates contains certificate chain to present to the other side of the connection.
+	// Server MUST set this if PSK is non-nil
+	// client SHOULD sets this so CertificateRequests can be handled if PSK is non-nil
 	Certificate *x509.Certificate
 
 	// PrivateKey contains matching private key for the certificate
@@ -37,6 +36,10 @@ type Config struct {
 	// FlightInterval controls how often we send outbound handshake messages
 	// defaults to time.Second
 	FlightInterval time.Duration
+
+	// PSK sets the pre-shared key used by this DTLS connection
+	// If PSK is non-nil only PSK CipherSuites will be used
+	PSK []byte
 
 	LoggerFactory logging.LoggerFactory
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -371,8 +371,8 @@ func TestPSKConfiguration(t *testing.T) {
 		Name                 string
 		ClientHasCertificate bool
 		ServerHasCertificate bool
-		ClientPSK            []byte
-		ServerPSK            []byte
+		ClientPSK            PSKCallback
+		ServerPSK            PSKCallback
 		WantClientError      error
 		WantServerError      error
 	}{
@@ -380,8 +380,8 @@ func TestPSKConfiguration(t *testing.T) {
 			Name:                 "PSK specified",
 			ClientHasCertificate: false,
 			ServerHasCertificate: false,
-			ClientPSK:            []byte{0x00, 0x01, 0x02},
-			ServerPSK:            []byte{0x00, 0x01, 0x02},
+			ClientPSK:            func([]byte) ([]byte, error) { return []byte{0x00, 0x01, 0x02}, nil },
+			ServerPSK:            func([]byte) ([]byte, error) { return []byte{0x00, 0x01, 0x02}, nil },
 			WantClientError:      errNoAvailableCipherSuites, // TODO (should be nil when PSK CipherSuite is added)
 			WantServerError:      errNoAvailableCipherSuites, // TODO (should be nil when PSK CipherSuite is added)
 		},
@@ -389,8 +389,8 @@ func TestPSKConfiguration(t *testing.T) {
 			Name:                 "PSK and certificate specified",
 			ClientHasCertificate: true,
 			ServerHasCertificate: true,
-			ClientPSK:            []byte{0x00, 0x01, 0x02},
-			ServerPSK:            []byte{0x00, 0x01, 0x02},
+			ClientPSK:            func([]byte) ([]byte, error) { return []byte{0x00, 0x01, 0x02}, nil },
+			ServerPSK:            func([]byte) ([]byte, error) { return []byte{0x00, 0x01, 0x02}, nil },
 			WantClientError:      errPSKAndCertificate,
 			WantServerError:      errPSKAndCertificate,
 		},

--- a/errors.go
+++ b/errors.go
@@ -44,4 +44,7 @@ var (
 	errServerMustHaveCertificate         = errors.New("dtls: Certificate is mandatory for server")
 	errUnableToMarshalFragmented         = errors.New("dtls: unable to marshal fragmented handshakes")
 	errVerifyDataMismatch                = errors.New("dtls: Expected and actual verify data does not match")
+	errNoConfigProvided                  = errors.New("dtls: No config provided")
+	errPSKAndCertificate                 = errors.New("dtls: Certificate and PSK provided")
+	errNoAvailableCipherSuites           = errors.New("dtls: Connection can not be created, no CipherSuites satisfy this Config")
 )

--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,6 @@ var (
 	errUnableToMarshalFragmented         = errors.New("dtls: unable to marshal fragmented handshakes")
 	errVerifyDataMismatch                = errors.New("dtls: Expected and actual verify data does not match")
 	errNoConfigProvided                  = errors.New("dtls: No config provided")
-	errPSKAndCertificate                 = errors.New("dtls: Certificate and PSK provided")
+	errPSKAndCertificate                 = errors.New("dtls: Certificate and PSK or PSK Identity Hint provided")
 	errNoAvailableCipherSuites           = errors.New("dtls: Connection can not be created, no CipherSuites satisfy this Config")
 )


### PR DESCRIPTION
Add configuration option for user to pass PSK. When a user
passes a PSK then we only allow CipherSuites that do PSK.

If user passes a PSK and a certificate return an error.

Relates to #45
