### PR TITLE
Verify server and client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author*
 * [Michiel De Backker](https://github.com/backkem) - *Public API*
 * [Chris Hiszpanski](https://github.com/thinkski) - *Support Signature Algorithms Extension*
-* [Iñigo Garcia Olaizola](https://github.com/igolaizola) - *Support serialization and resumption"*
+* [Iñigo Garcia Olaizola](https://github.com/igolaizola) - *Serialization & resumption, cert verification*
 * [Daniele Sluijters](https://github.com/daenney) - *AES-CCM support*
 * [Jin Lei](https://github.com/jinleileiking) - *Logging*
 * [Hugo Arregui](https://github.com/hugoArregui)

--- a/bench_test.go
+++ b/bench_test.go
@@ -16,9 +16,10 @@ func TestSimpleReadWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	config := &Config{
-		Certificate:   certificate,
-		PrivateKey:    privateKey,
-		LoggerFactory: logging.NewDefaultLoggerFactory(),
+		Certificate:        certificate,
+		PrivateKey:         privateKey,
+		LoggerFactory:      logging.NewDefaultLoggerFactory(),
+		InsecureSkipVerify: true,
 	}
 	gotHello := make(chan struct{})
 
@@ -54,7 +55,7 @@ func benchmarkConn(b *testing.B, n int64) {
 	b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 		ca, cb := net.Pipe()
 		certificate, privateKey, err := GenerateSelfSigned()
-		config := &Config{Certificate: certificate, PrivateKey: privateKey}
+		config := &Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
 		server := make(chan *Conn)
 		go func() {
 			s, sErr := testServer(cb, config, false)

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -2,9 +2,7 @@ package dtls
 
 import (
 	"bytes"
-	"crypto/x509"
 	"fmt"
-	"time"
 )
 
 func clientHandshakeHandler(c *Conn) error {
@@ -52,14 +50,7 @@ func clientHandshakeHandler(c *Conn) error {
 				if err := verifyKeySignature(expectedHash, h.signature, h.hashAlgorithm, c.state.remoteCertificate); err != nil {
 					return err
 				}
-				opts := x509.VerifyOptions{
-					Roots:       c.rootCAs,
-					CurrentTime: time.Now(),
-					// TODO: Add server name validation
-					// DNSName:       c.serverName,
-					Intermediates: x509.NewCertPool(),
-				}
-				if _, err := c.state.remoteCertificate.Verify(opts); err != nil {
+				if err := verifyServerCert(c.state.remoteCertificate, c.rootCAs, c.serverName); err != nil {
 					return err
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -42,6 +42,32 @@ type Config struct {
 	PSK             PSKCallback
 	PSKIdentityHint []byte
 
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name.
+	// If InsecureSkipVerify is true, TLS accepts any certificate
+	// presented by the server and any host name in that certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	// This should be used only for testing.
+	InsecureSkipVerify bool
+
+	// VerifyPeerCertificate, if not nil, is called after normal
+	// certificate verification by either a client or server. It
+	// receives the certificate provided by the peer and also a flag
+	// that tells if normal verification has succeedded. If it returns a
+	// non-nil error, the handshake is aborted and that error results.
+	//
+	// If normal verification fails then the handshake will abort before
+	// considering this callback. If normal verification is disabled by
+	// setting InsecureSkipVerify, or (for a server) when ClientAuth is
+	// RequestClientCert or RequireAnyClientCert, then this callback will
+	// be considered but the verified flag will always be false.
+	VerifyPeerCertificate func(cer *x509.Certificate, verified bool) error
+
+	// RootCAs defines the set of root certificate authorities
+	// that one peer uses when verifying the other peer's certificates.
+	// If RootCAs is nil, TLS uses the host's root CA set.
+	RootCAs *x509.CertPool
+
 	LoggerFactory logging.LoggerFactory
 }
 
@@ -58,4 +84,6 @@ const (
 	NoClientCert ClientAuthType = iota
 	RequestClientCert
 	RequireAnyClientCert
+	VerifyClientCertIfGiven
+	RequireAndVerifyClientCert
 )

--- a/config.go
+++ b/config.go
@@ -68,6 +68,10 @@ type Config struct {
 	// If RootCAs is nil, TLS uses the host's root CA set.
 	RootCAs *x509.CertPool
 
+	// ServerName is used to verify the hostname on the returned
+	// certificates unless InsecureSkipVerify is given.
+	ServerName string
+
 	LoggerFactory logging.LoggerFactory
 }
 

--- a/conn.go
+++ b/conn.go
@@ -64,6 +64,10 @@ type Conn struct {
 	localKeySignature         []byte // cached keySignature
 	remoteCertificateVerified bool
 
+	insecureSkipVerify    bool
+	verifyPeerCertificate func(cer *x509.Certificate, verified bool) error
+	rootCAs               *x509.CertPool
+
 	handshakeMessageHandler handshakeMessageHandler
 	flightHandler           flightHandler
 	handshakeCompleted      chan bool
@@ -115,6 +119,9 @@ func createConn(nextConn net.Conn, flightHandler flightHandler, handshakeMessage
 		localCertificate:            config.Certificate,
 		localPrivateKey:             config.PrivateKey,
 		clientAuth:                  config.ClientAuth,
+		insecureSkipVerify:          config.InsecureSkipVerify,
+		verifyPeerCertificate:       config.VerifyPeerCertificate,
+		rootCAs:                     config.RootCAs,
 		localSRTPProtectionProfiles: config.SRTPProtectionProfiles,
 		localCipherSuites:           cipherSuites,
 		namedCurve:                  defaultNamedCurve,

--- a/conn_test.go
+++ b/conn_test.go
@@ -568,6 +568,15 @@ func TestServerCertificate(t *testing.T) {
 			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
 			wantErr:   true,
 		},
+		"server_name": {
+			clientCfg: &Config{RootCAs: caPool, ServerName: cert.Subject.CommonName},
+			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+		},
+		"server_name_error": {
+			clientCfg: &Config{RootCAs: caPool, ServerName: "barfoo"},
+			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			wantErr:   true,
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/conn_test.go
+++ b/conn_test.go
@@ -113,6 +113,7 @@ func testClient(c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error
 		cfg.PrivateKey = clientKey
 		cfg.Certificate = clientCert
 	}
+	cfg.InsecureSkipVerify = true
 	return Client(c, cfg)
 }
 

--- a/crypto.go
+++ b/crypto.go
@@ -10,6 +10,7 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"math/big"
+	"time"
 )
 
 type ecdsaSignature struct {
@@ -119,6 +120,32 @@ func verifyCertificateVerify(handshakeBodies []byte, hashAlgorithm HashAlgorithm
 	}
 
 	return errKeySignatureVerifyUnimplemented
+}
+
+func verifyClientCert(cert *x509.Certificate, roots *x509.CertPool) error {
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		CurrentTime:   time.Now(),
+		Intermediates: x509.NewCertPool(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if _, err := cert.Verify(opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyServerCert(cert *x509.Certificate, roots *x509.CertPool, serverName string) error {
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		CurrentTime:   time.Now(),
+		DNSName:       serverName,
+		Intermediates: x509.NewCertPool(),
+	}
+	if _, err := cert.Verify(opts); err != nil {
+		return err
+	}
+	return nil
 }
 
 func generateAEADAdditionalData(h *recordLayerHeader, payloadLen int) []byte {

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -89,8 +89,9 @@ func TestPionE2ELossy(t *testing.T) {
 
 		go func() {
 			cfg := &dtls.Config{
-				FlightInterval: flightInterval,
-				CipherSuites:   test.CipherSuites,
+				FlightInterval:     flightInterval,
+				CipherSuites:       test.CipherSuites,
+				InsecureSkipVerify: true,
 			}
 			if test.DoClientAuth {
 				cfg.Certificate = clientCert

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -172,7 +172,12 @@ func TestPionE2ESimple(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cfg := &dtls.Config{Certificate: cert, PrivateKey: key, CipherSuites: []dtls.CipherSuiteID{cipherSuite}}
+		cfg := &dtls.Config{
+			Certificate:        cert,
+			PrivateKey:         key,
+			CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
+			InsecureSkipVerify: true,
+		}
 		assertE2ECommunication(cfg, cfg, t)
 
 	}

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,6 @@ var (
 	ErrConnClosed = errors.New("dtls: conn is closed")
 
 	errBufferTooSmall                    = errors.New("dtls: buffer is too small")
-	errCertificateUnset                  = errors.New("dtls: handshakeMessageCertificate can not be marshalled without a certificate")
 	errClientCertificateRequired         = errors.New("dtls: server required client verification, but got none")
 	errClientCertificateNotVerified      = errors.New("dtls: client sent certificate but did not verify it")
 	errCertificateVerifyNoCertificate    = errors.New("dtls: client sent certificate verify but we have no certificate to verify")

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -21,7 +21,7 @@ func main() {
 	//
 
 	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{Certificate: certificate, PrivateKey: privateKey}
+	config := &dtls.Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
 
 	// Connect to a DTLS server
 	dtlsConn, err := dtls.Dial("udp", addr, config)

--- a/resume_test.go
+++ b/resume_test.go
@@ -41,7 +41,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 			t.Fatal(err)
 		}
 	}()
-	config := &Config{Certificate: certificate, PrivateKey: privateKey}
+	config := &Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
 	go func() {
 		var remote *Conn
 		var errR error

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -2,9 +2,7 @@ package dtls
 
 import (
 	"bytes"
-	"crypto/x509"
 	"fmt"
-	"time"
 )
 
 func serverHandshakeHandler(c *Conn) error {
@@ -81,13 +79,7 @@ func serverHandshakeHandler(c *Conn) error {
 					return err
 				}
 				if c.clientAuth >= VerifyClientCertIfGiven {
-					opts := x509.VerifyOptions{
-						Roots:         c.rootCAs,
-						CurrentTime:   time.Now(),
-						Intermediates: x509.NewCertPool(),
-						KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-					}
-					if _, err := c.state.remoteCertificate.Verify(opts); err != nil {
+					if err := verifyClientCert(c.state.remoteCertificate, c.rootCAs); err != nil {
 						return err
 					}
 					verified = true


### PR DESCRIPTION
Description:
- Verify certificates using CAs `Config.RootCAs`, current time and an optional callback `Config.VerifyPeerCertificate`
- Verification for server certificates is enabled by default and for client certificates based on `Config.ClientAuth (VerifyClientCertIfGiven, RequireAndVerifyClientCert)`
- Verification can be disabled by `Config.InsecureSkipVerify`
- Config parameters are inspired on `crypto/tls`

TODO: Verify server name
