### PR TITLE
Fix panic when client and server share no supported elliptic curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Lander Noterman](https://github.com/LanderN)
 * [Aleksandr Razumov](https://github.com/ernado) - *Fuzzing*
+* [Ryan Gordon](https://github.com/ryangordon)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/errors.go
+++ b/errors.go
@@ -49,4 +49,5 @@ var (
 	errIdentityNoPSK                     = errors.New("dtls: Identity Hint provided but PSK is nil")
 	errNoAvailableCipherSuites           = errors.New("dtls: Connection can not be created, no CipherSuites satisfy this Config")
 	errInvalidClientKeyExchange          = errors.New("dtls: Unable to determine if ClientKeyExchange is a public key or PSK Identity")
+	errNoSupportedEllipticCurves         = errors.New("dtls: Client requested zero or more elliptic curves that are not supported by the server")
 )

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -35,6 +35,9 @@ func serverHandshakeHandler(c *Conn) error {
 			for _, extension := range h.extensions {
 				switch e := extension.(type) {
 				case *extensionSupportedEllipticCurves:
+					if len(e.ellipticCurves) == 0 {
+						return errNoSupportedEllipticCurves
+					}
 					c.namedCurve = e.ellipticCurves[0]
 				case *extensionUseSRTP:
 					profile, ok := findMatchingSRTPProfile(e.protectionProfiles, c.localSRTPProtectionProfiles)


### PR DESCRIPTION
#### Description
- Checks the length of supported `ellipticCurves` during handshake and returns an error if there are no overlapping supported elliptic curves.

#### Reference issue
Fixes #82 