### PR TITLE
Add support for secp384r1 elliptic curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We would love contributes that fall under the 'Planned Features' and fixing any 
 
 #### Current features
 * DTLS 1.2 Client/Server
-* Key Exchange via ECDHE(curve25519 and nistp256) and PSK
+* Key Exchange via ECDHE(curve25519, nistp256, nistp384) and PSK
 * Packet loss and re-ordering is handled during handshaking
 * Key export ([RFC 5705][rfc5705])
 * Serialization and Resumption of sessions

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -254,7 +254,7 @@ func clientFlightHandler(c *Conn) (bool, error) {
 		if c.localPSKCallback == nil {
 			extensions = append(extensions, []extension{
 				&extensionSupportedEllipticCurves{
-					ellipticCurves: []namedCurve{namedCurveX25519, namedCurveP256},
+					ellipticCurves: []namedCurve{namedCurveX25519, namedCurveP256, namedCurveP384},
 				},
 				&extensionSupportedPointFormats{
 					pointFormats: []ellipticCurvePointFormat{ellipticCurvePointFormatUncompressed},

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -289,7 +289,7 @@ func serverFlightHandler(c *Conn) (bool, error) {
 		if c.localPSKCallback == nil {
 			extensions = append(extensions, []extension{
 				&extensionSupportedEllipticCurves{
-					ellipticCurves: []namedCurve{namedCurveX25519, namedCurveP256},
+					ellipticCurves: []namedCurve{namedCurveX25519, namedCurveP256, namedCurveP384},
 				},
 				&extensionSupportedPointFormats{
 					pointFormats: []ellipticCurvePointFormat{ellipticCurvePointFormatUncompressed},


### PR DESCRIPTION
#### Description
- This adds support for the `secp384r1` elliptic curve
- `secp384r1` is still currently recommended per https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8

#### Reference issue
Fixes #84
