### PR TITLE
Fix index out of range

### DIFF
--- a/handshake_message_server_key_exchange.go
+++ b/handshake_message_server_key_exchange.go
@@ -58,7 +58,10 @@ func (h *handshakeMessageServerKeyExchange) Unmarshal(data []byte) error {
 		return errInvalidEllipticCurveType
 	}
 
-	h.namedCurve = namedCurve(binary.BigEndian.Uint16(data[1:]))
+	if len(data[1:]) < 2 {
+		return errBufferTooSmall
+	}
+	h.namedCurve = namedCurve(binary.BigEndian.Uint16(data[1:3]))
 	if _, ok := namedCurves[h.namedCurve]; !ok {
 		return errInvalidNamedCurve
 	}


### PR DESCRIPTION
Check data length and make binary Uint16 call more explicit.
Found by go-fuzz.
