### PR TITLE
Adding connection timeout

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,6 +73,17 @@ type Config struct {
 	ServerName string
 
 	LoggerFactory logging.LoggerFactory
+
+	// ConnectTimeout is the timeout threshold for new connection handshakes
+	// to complete (default is 30 seconds)
+	ConnectTimeout *time.Duration
+}
+
+const defaultConnectTimeout = 30 * time.Second
+
+// ConnectTimeoutOption simply provides a wrapper for creating a *time.Duration
+func ConnectTimeoutOption(timeout time.Duration) *time.Duration {
+	return &timeout
 }
 
 // PSKCallback is called once we have the remote's PSKIdentityHint.

--- a/conn_test.go
+++ b/conn_test.go
@@ -311,6 +311,30 @@ func TestPSKHintFail(t *testing.T) {
 	}
 }
 
+func TestClientTimeout(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	clientErr := make(chan error, 1)
+
+	ca, _ := net.Pipe()
+	go func() {
+		conf := &Config{
+			ConnectTimeout: ConnectTimeoutOption(1 * time.Second),
+		}
+
+		_, err := testClient(ca, conf, true)
+		clientErr <- err
+	}()
+
+	// no server!
+
+	if err := <-clientErr; err != errConnectTimeout {
+		t.Fatalf("TestClientTimeout: Client error exp(%v) failed(%v)", errConnectTimeout, err)
+	}
+}
+
 func TestSRTPConfiguration(t *testing.T) {
 	for _, test := range []struct {
 		Name            string

--- a/errors.go
+++ b/errors.go
@@ -50,4 +50,5 @@ var (
 	errNoAvailableCipherSuites           = errors.New("dtls: Connection can not be created, no CipherSuites satisfy this Config")
 	errInvalidClientKeyExchange          = errors.New("dtls: Unable to determine if ClientKeyExchange is a public key or PSK Identity")
 	errNoSupportedEllipticCurves         = errors.New("dtls: Client requested zero or more elliptic curves that are not supported by the server")
+	errConnectTimeout                    = errors.New("dtls: The connection timed out during the handshake")
 )

--- a/examples/dial-psk/main.go
+++ b/examples/dial-psk/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/pion/dtls"
 	"github.com/pion/dtls/examples/util"
@@ -24,6 +25,7 @@ func main() {
 		},
 		PSKIdentityHint: []byte("Pion DTLS Server"),
 		CipherSuites:    []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
+		ConnectTimeout:  dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/pion/dtls"
 	"github.com/pion/dtls/examples/util"
@@ -21,7 +22,12 @@ func main() {
 	//
 
 	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
+	config := &dtls.Config{
+		Certificate:        certificate,
+		PrivateKey:         privateKey,
+		InsecureSkipVerify: true,
+		ConnectTimeout:     dtls.ConnectTimeoutOption(30 * time.Second),
+	}
 
 	// Connect to a DTLS server
 	dtlsConn, err := dtls.Dial("udp", addr, config)

--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/pion/dtls"
 	"github.com/pion/dtls/examples/util"
@@ -24,6 +25,7 @@ func main() {
 		},
 		PSKIdentityHint: []byte("Pion DTLS Client"),
 		CipherSuites:    []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
+		ConnectTimeout:  dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/pion/dtls"
 	"github.com/pion/dtls/examples/util"
@@ -21,7 +22,11 @@ func main() {
 	//
 
 	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{Certificate: certificate, PrivateKey: privateKey}
+	config := &dtls.Config{
+		Certificate:    certificate,
+		PrivateKey:     privateKey,
+		ConnectTimeout: dtls.ConnectTimeoutOption(30 * time.Second),
+	}
 
 	// Connect to a DTLS server
 	listener, err := dtls.Listen("udp", addr, config)


### PR DESCRIPTION
#### Description
This change adds a connection timeout (effectively a handshake timeout) that allows handshakes that never complete for any reason to be closed and not take up resources or retry indefinitely. Typically this logic should not be hit unless the client or server really does not complete the handshake in time.

This technically addressed #89 because once the timeout occurs, processing will be able to occur again, however further improvements are needed so that a single handshake does not block the progress of other handshakes, even if any of them get stuck or error out. This additional improvements will be covered in subsequent PRs

#### Reference issue
Partially fixes #89
Partially fixes #13 