### PR TITLE
Improve alerting during handshake

### DIFF
--- a/flight.go
+++ b/flight.go
@@ -88,7 +88,7 @@ func (f *flight) get() flightVal {
 	return f.val
 }
 
-func (f *flight) set(val flightVal) error {
+func (f *flight) set(val flightVal) {
 	f.Lock()
 	f.val = val // TODO ensure no invalid transitions
 	f.Unlock()
@@ -97,6 +97,4 @@ func (f *flight) set(val flightVal) error {
 	case f.workerTrigger <- struct{}{}:
 	default:
 	}
-
-	return nil
 }

--- a/resume.go
+++ b/resume.go
@@ -16,15 +16,15 @@ func (c *Conn) Export() (*State, net.Conn, error) {
 // Resume imports an already stablished dtls connection using a specific dtls state
 func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
 	// Custom flight handler that sets imported data and signals as handshaked
-	flightHandler := func(c *Conn) (bool, error) {
+	flightHandler := func(c *Conn) (bool, *alert, error) {
 		c.state = *state
 		c.signalHandshakeComplete()
-		return true, nil
+		return true, nil, nil
 	}
 
 	// Empty handshake handler, since handshake was already done
-	handshakeHandler := func(c *Conn) error {
-		return nil
+	handshakeHandler := func(c *Conn) (*alert, error) {
+		return nil, nil
 	}
 
 	c, err := createConn(conn, flightHandler, handshakeHandler, config, state.isClient)


### PR DESCRIPTION
#### Description
Previously, alerts would not be sent during handshake. This change adds unencrypted alerting during the handshake and encrypted alerts once the handshake completes. This allows the client to know to close and not rely on a given timeout.

Separately, if the connection was closed in the middle of a handshake (unlikely), a panic would occur because alerts were previously only sent as encrypted alerts even if the cipher suite was not yet initialized, leading to a panic.

This fixes issue #89 because the server will now properly send an alert to the client (or vice versa) indicating that there was a problem and that the connection should be closed immediately.

If there are any missing cases, or if the alert gets dropped during flight, then the connection timeout is the safety net (https://github.com/pion/dtls/pull/94).

#### Reference issue
Fixes #89
Fixes #5 
