### PR TITLE
Fix handshake race condition

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -29,6 +29,7 @@ type cipherSuite interface {
 	certificateType() clientCertificateType
 	hashFunc() func() hash.Hash
 	isPSK() bool
+	isInitialized() bool
 
 	// Generate the internal encryption state
 	init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
@@ -30,6 +30,10 @@ func (c cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) isPSK() bool {
 	return false
 }
 
+func (c cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) isInitialized() bool {
+	return c.gcm != nil
+}
+
 func (c *cipherSuiteTLSEcdheEcdsaWithAes128GcmSha256) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
 	const (
 		prfMacLen = 0

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -30,6 +30,10 @@ func (c cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) isPSK() bool {
 	return false
 }
 
+func (c cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) isInitialized() bool {
+	return c.cbc != nil
+}
+
 func (c *cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
 	const (
 		prfMacLen = 20

--- a/cipher_suite_tls_psk_with_aes_128_ccm8.go
+++ b/cipher_suite_tls_psk_with_aes_128_ccm8.go
@@ -30,6 +30,10 @@ func (c cipherSuiteTLSPskWithAes128Ccm8) isPSK() bool {
 	return true
 }
 
+func (c cipherSuiteTLSPskWithAes128Ccm8) isInitialized() bool {
+	return c.ccm != nil
+}
+
 func (c *cipherSuiteTLSPskWithAes128Ccm8) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
 	const (
 		prfMacLen = 0

--- a/conn.go
+++ b/conn.go
@@ -408,7 +408,7 @@ func (c *Conn) handleIncomingPacket(buf []byte) (*alert, error) {
 	}
 
 	if h.epoch != 0 {
-		if c.state.cipherSuite == nil {
+		if c.state.cipherSuite == nil || !c.state.cipherSuite.isInitialized() {
 			c.log.Debug("handleIncoming: Handshake not finished, dropping packet")
 			return nil, nil
 		}


### PR DESCRIPTION
#### Description
Currently cipherSuite can be created (non-nil) but not "initialized" (flight2 vs flight4). If this race happens the program tries to process the packet and fails in the decrypt stage, rather than _slightly more gracefully_ dropping it at the correct spot.

This race condition happens from time to time during the lossy E2E test, when client application data gets received by the server before the final client handshake packets are received.

(Pulled this fix out of https://github.com/pion/dtls/pull/93)