### PR TITLE
add support for certificate chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Lander Noterman](https://github.com/LanderN)
 * [Aleksandr Razumov](https://github.com/ernado) - *Fuzzing*
 * [Ryan Gordon](https://github.com/ryangordon)
+* [Jozef Kralik](https://github.com/jkralik)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/bench_test.go
+++ b/bench_test.go
@@ -11,13 +11,12 @@ import (
 
 func TestSimpleReadWrite(t *testing.T) {
 	ca, cb := net.Pipe()
-	certificate, privateKey, err := GenerateSelfSigned()
+	certificate, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
 	config := &Config{
 		Certificate:        certificate,
-		PrivateKey:         privateKey,
 		LoggerFactory:      logging.NewDefaultLoggerFactory(),
 		InsecureSkipVerify: true,
 	}
@@ -54,8 +53,8 @@ func TestSimpleReadWrite(t *testing.T) {
 func benchmarkConn(b *testing.B, n int64) {
 	b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 		ca, cb := net.Pipe()
-		certificate, privateKey, err := GenerateSelfSigned()
-		config := &Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
+		certificate, err := GenerateSelfSigned()
+		config := &Config{Certificate: certificate, InsecureSkipVerify: true}
 		server := make(chan *Conn)
 		go func() {
 			s, sErr := testServer(cb, config, false)

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -303,7 +303,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 						messageSequence: uint16(c.state.localSequenceNumber),
 					},
 					handshakeMessage: &handshakeMessageCertificate{
-						certificate: c.localCertificate,
+						certificate: c.localCertificate.Certificate,
 					}},
 			}, false)
 			sequenceNumber++
@@ -335,7 +335,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 		// If the client has sent a certificate with signing ability, a digitally-signed
 		// CertificateVerify message is sent to explicitly verify possession of the
 		// private key in the certificate.
-		if c.remoteRequestedCertificate && c.localCertificate != nil {
+		if c.remoteRequestedCertificate && c.localCertificate.PrivateKey != nil {
 			if len(c.localCertificateVerify) == 0 {
 				plainText := c.handshakeCache.pullAndMerge(
 					handshakeCachePullRule{handshakeTypeClientHello, true},
@@ -348,7 +348,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 					handshakeCachePullRule{handshakeTypeClientKeyExchange, true},
 				)
 
-				certVerify, err := generateCertificateVerify(plainText, c.localPrivateKey)
+				certVerify, err := generateCertificateVerify(plainText, c.localCertificate.PrivateKey)
 				if err != nil {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package dtls
 
 import (
-	"crypto"
+	"crypto/tls"
 	"crypto/x509"
 	"time"
 
@@ -14,11 +14,7 @@ type Config struct {
 	// Certificates contains certificate chain to present to the other side of the connection.
 	// Server MUST set this if PSK is non-nil
 	// client SHOULD sets this so CertificateRequests can be handled if PSK is non-nil
-	Certificate *x509.Certificate
-
-	// PrivateKey contains matching private key for the certificate
-	// only ECDSA is supported
-	PrivateKey crypto.PrivateKey
+	Certificate tls.Certificate
 
 	// CipherSuites is a list of supported cipher suites.
 	// If CipherSuites is nil, a default list is used
@@ -61,7 +57,7 @@ type Config struct {
 	// setting InsecureSkipVerify, or (for a server) when ClientAuth is
 	// RequestClientCert or RequireAnyClientCert, then this callback will
 	// be considered but the verified flag will always be false.
-	VerifyPeerCertificate func(cer *x509.Certificate, verified bool) error
+	VerifyPeerCertificate func(rawCert [][]byte, verified bool) error
 
 	// RootCAs defines the set of root certificate authorities
 	// that one peer uses when verifying the other peer's certificates.

--- a/crypto.go
+++ b/crypto.go
@@ -48,7 +48,15 @@ func generateKeySignature(clientRandom, serverRandom, publicKey []byte, namedCur
 	return nil, errKeySignatureGenerateUnimplemented
 }
 
-func verifyKeySignature(hash, remoteKeySignature []byte, hashAlgorithm HashAlgorithm, certificate *x509.Certificate) error {
+func verifyKeySignature(hash, remoteKeySignature []byte, hashAlgorithm HashAlgorithm, rawCertificates [][]byte) error {
+	if len(rawCertificates) == 0 {
+		return errLengthMismatch
+	}
+	certificate, err := x509.ParseCertificate(rawCertificates[0])
+	if err != nil {
+		return err
+	}
+
 	switch p := certificate.PublicKey.(type) {
 	case *ecdsa.PublicKey:
 		ecdsaSig := &ecdsaSignature{}
@@ -97,7 +105,15 @@ func generateCertificateVerify(handshakeBodies []byte, privateKey crypto.Private
 	return nil, errInvalidSignatureAlgorithm
 }
 
-func verifyCertificateVerify(handshakeBodies []byte, hashAlgorithm HashAlgorithm, remoteKeySignature []byte, certificate *x509.Certificate) error {
+func verifyCertificateVerify(handshakeBodies []byte, hashAlgorithm HashAlgorithm, remoteKeySignature []byte, rawCertificates [][]byte) error {
+	if len(rawCertificates) == 0 {
+		return errLengthMismatch
+	}
+	certificate, err := x509.ParseCertificate(rawCertificates[0])
+	if err != nil {
+		return err
+	}
+
 	hash := hashAlgorithm.digest(handshakeBodies)
 	switch p := certificate.PublicKey.(type) {
 	case *ecdsa.PublicKey:
@@ -122,27 +138,58 @@ func verifyCertificateVerify(handshakeBodies []byte, hashAlgorithm HashAlgorithm
 	return errKeySignatureVerifyUnimplemented
 }
 
-func verifyClientCert(cert *x509.Certificate, roots *x509.CertPool) error {
+func loadCerts(rawCertificates [][]byte) ([]*x509.Certificate, error) {
+	certs := make([]*x509.Certificate, 0, 16)
+	if len(rawCertificates) == 0 {
+		return nil, errLengthMismatch
+	}
+	for _, rawCert := range rawCertificates {
+		cert, err := x509.ParseCertificate(rawCert)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+func verifyClientCert(rawCertificates [][]byte, roots *x509.CertPool) error {
+	certificate, err := loadCerts(rawCertificates)
+	if err != nil {
+		return err
+	}
+	intermediateCAPool := x509.NewCertPool()
+	for _, cert := range certificate[1:] {
+		intermediateCAPool.AddCert(cert)
+	}
 	opts := x509.VerifyOptions{
 		Roots:         roots,
 		CurrentTime:   time.Now(),
-		Intermediates: x509.NewCertPool(),
+		Intermediates: intermediateCAPool,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
-	if _, err := cert.Verify(opts); err != nil {
+	if _, err := certificate[0].Verify(opts); err != nil {
 		return err
 	}
 	return nil
 }
 
-func verifyServerCert(cert *x509.Certificate, roots *x509.CertPool, serverName string) error {
+func verifyServerCert(rawCertificates [][]byte, roots *x509.CertPool, serverName string) error {
+	certificate, err := loadCerts(rawCertificates)
+	if err != nil {
+		return err
+	}
+	intermediateCAPool := x509.NewCertPool()
+	for _, cert := range certificate[1:] {
+		intermediateCAPool.AddCert(cert)
+	}
 	opts := x509.VerifyOptions{
 		Roots:         roots,
 		CurrentTime:   time.Now(),
 		DNSName:       serverName,
-		Intermediates: x509.NewCertPool(),
+		Intermediates: intermediateCAPool,
 	}
-	if _, err := cert.Verify(opts); err != nil {
+	if _, err := certificate[0].Verify(opts); err != nil {
 		return err
 	}
 	return nil

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -18,12 +18,12 @@ const (
   DTLS Client/Server over a lossy transport, just asserts it can handle at increasing increments
 */
 func TestPionE2ELossy(t *testing.T) {
-	serverCert, serverKey, err := dtls.GenerateSelfSigned()
+	serverCert, err := dtls.GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	clientCert, clientKey, err := dtls.GenerateSelfSigned()
+	clientCert, err := dtls.GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,6 @@ func TestPionE2ELossy(t *testing.T) {
 			}
 			if test.DoClientAuth {
 				cfg.Certificate = clientCert
-				cfg.PrivateKey = clientKey
 			}
 
 			if _, err := dtls.Client(br.GetConn0(), cfg); err != nil {
@@ -108,7 +107,6 @@ func TestPionE2ELossy(t *testing.T) {
 		go func() {
 			cfg := &dtls.Config{
 				Certificate:    serverCert,
-				PrivateKey:     serverKey,
 				FlightInterval: flightInterval,
 			}
 			if test.DoClientAuth {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -167,14 +167,13 @@ func TestPionE2ESimple(t *testing.T) {
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 	} {
-		cert, key, err := dtls.GenerateSelfSigned()
+		cert, err := dtls.GenerateSelfSigned()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		cfg := &dtls.Config{
 			Certificate:        cert,
-			PrivateKey:         key,
 			CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
 			InsecureSkipVerify: true,
 		}

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -14,7 +14,7 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	certificate, genErr := dtls.GenerateSelfSigned()
 	util.Check(genErr)
 
 	//
@@ -24,7 +24,6 @@ func main() {
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
 		Certificate:        certificate,
-		PrivateKey:         privateKey,
 		InsecureSkipVerify: true,
 		ConnectTimeout:     dtls.ConnectTimeoutOption(30 * time.Second),
 	}

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -14,7 +14,7 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	certificate, genErr := dtls.GenerateSelfSigned()
 	util.Check(genErr)
 
 	//
@@ -24,7 +24,6 @@ func main() {
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
 		Certificate:    certificate,
-		PrivateKey:     privateKey,
 		ConnectTimeout: dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 

--- a/handshake_message_certificate.go
+++ b/handshake_message_certificate.go
@@ -1,11 +1,7 @@
 package dtls
 
-import (
-	"crypto/x509"
-)
-
 type handshakeMessageCertificate struct {
-	certificate *x509.Certificate
+	certificate [][]byte
 }
 
 func (h handshakeMessageCertificate) handshakeType() handshakeType {
@@ -13,16 +9,26 @@ func (h handshakeMessageCertificate) handshakeType() handshakeType {
 }
 
 func (h *handshakeMessageCertificate) Marshal() ([]byte, error) {
-	var raw []byte
-	if h.certificate != nil {
-		raw = h.certificate.Raw
+	certTotalLen := 0
+	for _, r := range h.certificate {
+		certTotalLen += len(r)
 	}
-
-	out := make([]byte, 6)
-	putBigEndianUint24(out, uint32(len(raw))+3)
-	putBigEndianUint24(out[3:], uint32(len(raw)))
-
-	return append(out, raw...), nil
+	outLen := len(h.certificate)*3 + certTotalLen
+	if outLen < 6 {
+		out := make([]byte, 6)
+		putBigEndianUint24(out, 3)
+		return out, nil
+	}
+	out := make([]byte, outLen+3)
+	putBigEndianUint24(out, uint32(outLen))
+	iter := out[3:]
+	for _, r := range h.certificate {
+		putBigEndianUint24(iter, uint32(len(r)))
+		iter = iter[3:]
+		copy(iter, r)
+		iter = iter[len(r):]
+	}
+	return out, nil
 }
 
 func (h *handshakeMessageCertificate) Unmarshal(data []byte) error {
@@ -31,19 +37,26 @@ func (h *handshakeMessageCertificate) Unmarshal(data []byte) error {
 	}
 
 	certificateBodyLen := int(bigEndianUint24(data))
-	certificateLen := int(bigEndianUint24(data[3:]))
 	if certificateBodyLen+3 != len(data) {
 		return errLengthMismatch
-	} else if certificateLen+6 != len(data) {
-		return errLengthMismatch
+	}
+	iter := data[3:]
+
+	for len(iter) != 0 {
+		certificateLen := int(bigEndianUint24(iter))
+		iter = iter[3:]
+		if certificateLen > len(iter) {
+			return errLengthMismatch
+		}
+		if certificateLen == 0 {
+			if len(iter) > 0 {
+				return errLengthMismatch
+			}
+			return nil
+		}
+		h.certificate = append(h.certificate, iter[:certificateLen])
+		iter = iter[certificateLen:]
 	}
 
-	if len(data) > 6 {
-		cert, err := x509.ParseCertificate(data[6:])
-		if err != nil {
-			return err
-		}
-		h.certificate = cert
-	}
 	return nil
 }

--- a/handshake_message_certificate_test.go
+++ b/handshake_message_certificate_test.go
@@ -43,26 +43,29 @@ func TestHandshakeMessageCertificate(t *testing.T) {
 		0x80, 0xa4, 0xd4, 0xb7, 0x7f, 0x7d, 0x78, 0xb3, 0xfb, 0xf3, 0x95, 0xfb, 0x02, 0x21, 0x00, 0xc0,
 		0x73, 0x30, 0xda, 0x2b, 0xc0, 0x0c, 0x9e, 0xb2, 0x25, 0x0d, 0x46, 0xb0, 0xbc, 0x66, 0x7f, 0x71,
 		0x66, 0xbf, 0x16, 0xb3, 0x80, 0x78, 0xd0, 0x0c, 0xef, 0xcc, 0xf5, 0xc1, 0x15, 0x0f, 0x58}
-	parsedCertificate := &handshakeMessageCertificate{
-		certificate: &x509.Certificate{
-			Raw:                     rawCertificate[6:],
-			RawTBSCertificate:       rawCertificate[10:313],
-			RawSubjectPublicKeyInfo: rawCertificate[222:313],
-			RawSubject:              rawCertificate[48:119],
-			RawIssuer:               rawCertificate[48:119],
-			Signature:               rawCertificate[328:],
-			SignatureAlgorithm:      x509.ECDSAWithSHA256,
-			PublicKeyAlgorithm:      x509.ECDSA,
-			Version:                 1,
-		},
+
+	parsedCertificate := &x509.Certificate{
+		Raw:                     rawCertificate[6:],
+		RawTBSCertificate:       rawCertificate[10:313],
+		RawSubjectPublicKeyInfo: rawCertificate[222:313],
+		RawSubject:              rawCertificate[48:119],
+		RawIssuer:               rawCertificate[48:119],
+		Signature:               rawCertificate[328:],
+		SignatureAlgorithm:      x509.ECDSAWithSHA256,
+		PublicKeyAlgorithm:      x509.ECDSA,
+		Version:                 1,
 	}
 
 	c := &handshakeMessageCertificate{}
 	if err := c.Unmarshal(rawCertificate); err != nil {
 		t.Error(err)
 	} else {
-		copyCertificatePrivateMembers(c.certificate, parsedCertificate.certificate)
-		if !reflect.DeepEqual(c, parsedCertificate) {
+		certificate, err := x509.ParseCertificate(c.certificate[0])
+		if err != nil {
+			t.Error(err)
+		}
+		copyCertificatePrivateMembers(certificate, parsedCertificate)
+		if !reflect.DeepEqual(certificate, parsedCertificate) {
 			t.Errorf("handshakeMessageCertificate unmarshal: got %#v, want %#v", c, parsedCertificate)
 		}
 	}

--- a/resume_test.go
+++ b/resume_test.go
@@ -23,7 +23,7 @@ func fatal(t *testing.T, errChan chan error, err error) {
 }
 
 func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Conn, error)) {
-	certificate, privateKey, err := GenerateSelfSigned()
+	certificate, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 			t.Fatal(err)
 		}
 	}()
-	config := &Config{Certificate: certificate, PrivateKey: privateKey, InsecureSkipVerify: true}
+	config := &Config{Certificate: certificate, InsecureSkipVerify: true}
 	go func() {
 		var remote *Conn
 		var errR error

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -324,7 +324,7 @@ func serverFlightHandler(c *Conn) (bool, *alert, error) {
 						messageSequence: uint16(sequenceNumber),
 					},
 					handshakeMessage: &handshakeMessageCertificate{
-						certificate: c.localCertificate,
+						certificate: c.localCertificate.Certificate,
 					}},
 			}, false)
 			sequenceNumber++
@@ -339,7 +339,7 @@ func serverFlightHandler(c *Conn) (bool, *alert, error) {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}
 
-				signature, err := generateKeySignature(clientRandom, serverRandom, c.localKeypair.publicKey, c.namedCurve, c.localPrivateKey, HashAlgorithmSHA256)
+				signature, err := generateKeySignature(clientRandom, serverRandom, c.localKeypair.publicKey, c.namedCurve, c.localCertificate.PrivateKey, HashAlgorithmSHA256)
 				if err != nil {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}

--- a/state.go
+++ b/state.go
@@ -2,7 +2,6 @@ package dtls
 
 import (
 	"bytes"
-	"crypto/x509"
 	"encoding/gob"
 	"sync/atomic"
 )
@@ -16,7 +15,7 @@ type State struct {
 	cipherSuite               cipherSuite // nil if a cipherSuite hasn't been chosen
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
-	remoteCertificate     *x509.Certificate
+	remoteCertificate     [][]byte
 
 	isClient bool
 }


### PR DESCRIPTION
#### Description
This patch add support for parsing certificate chain.

#### Breaking changes:
* certificate, privateKey was replaced by certifciate (tls.Certificate)
* verifyPeerCertificates uses array of bytes for chain certificates
  instead of certificate(*x509.Certificate)

#### Tested
Handshake was tested against mbedtls (iotivity-lite).