### PR TITLE
Fix request client certificate handling of empty certificate response

### DIFF
--- a/handshake_message_certificate.go
+++ b/handshake_message_certificate.go
@@ -26,12 +26,15 @@ func (h *handshakeMessageCertificate) Marshal() ([]byte, error) {
 }
 
 func (h *handshakeMessageCertificate) Unmarshal(data []byte) error {
-	if len(data) < 6 {
+	if len(data) < 3 {
 		return errBufferTooSmall
 	}
 
 	certificateBodyLen := int(bigEndianUint24(data))
 	certificateLen := int(bigEndianUint24(data[3:]))
+	if certificateLen == 0 {
+		return nil
+	}
 	if certificateBodyLen+3 != len(data) {
 		return errLengthMismatch
 	} else if certificateLen+6 != len(data) {

--- a/handshake_message_certificate_test.go
+++ b/handshake_message_certificate_test.go
@@ -74,3 +74,22 @@ func TestHandshakeMessageCertificate(t *testing.T) {
 		t.Errorf("handshakeMessageCertificate marshal: got %#v, want %#v", raw, rawCertificate)
 	}
 }
+
+func TestEmptyHandshakeMessageCertificate(t *testing.T) {
+	rawCertificate := []byte{
+		0x00, 0x00, 0x00,
+	}
+
+	expectedCertificate := &handshakeMessageCertificate{
+		certificate: nil,
+	}
+
+	c := &handshakeMessageCertificate{}
+	if err := c.Unmarshal(rawCertificate); err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(c, expectedCertificate) {
+		t.Errorf("handshakeMessageCertificate unmarshal: got %#v, want %#v", c, expectedCertificate)
+	}
+}


### PR DESCRIPTION
#### Description
Currently when RequestClientCert option is used in the server, the  client is allowed to send a response with an empty certificate (zero length), but dTLS will error with "errBufferTooSmall". This changes that behavior so this library will handle certificate messages with a zero length certificate.

#### Reference issue
Fixes #100
