### PR TITLE
Fix alert regression from #95

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -504,7 +504,7 @@ func (c *Conn) setHandshakeCompletedSuccessfully() {
 }
 
 func (c *Conn) isHandshakeCompletedSuccessfully() bool {
-	boolean, _ := c.connErr.Load().(struct{ bool })
+	boolean, _ := c.handshakeCompletedSuccessfully.Load().(struct{ bool })
 	return boolean.bool
 }
 


### PR DESCRIPTION
#### Description
A regression from #95 led to all alerts being sent as unencrypted. This meant, once a handshake was completed, but an unencrypted alert was sent, the server failed to parse the alert and the close would not take place. Previously the Close functionality was untested so it managed to slip through. I am updating the E2E tests to exercise the close functionality on both the client and the server, but those will land in a separate PR.

#### Reference issue
Fixes regression from #95
