### PR TITLE
CI: Don't build branch and PR on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+branches:
+  only:
+  - master
+
 go:
   - "1.x" # use the latest Go release
 


### PR DESCRIPTION
When you push to a branch that has a PR open Travis-CI will now perform
two builds, one for the branch and one for the PR:
https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests

> If you see two build status icons on your GitHub pull request, it means
> there is one build for the branch, and one build for the pull request
> itself (actually the build for the merge of the head branch with the base
> branch specified in the pull request).

This is a bit annoying and a waste of resources since we're running the
test suite twice.

Instead, this limits push builds to the master branch. PRs will still be
built b/c we have Travis-CI configured to "Build pushed pull requests"
in the CI settings for this repo.