### PR TITLE
Improve listener.Closer guarantee

### DIFF
--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -33,7 +33,7 @@ func main() {
 	listener, err := dtls.Listen("udp", addr, config)
 	util.Check(err)
 	defer func() {
-		util.Check(listener.Close())
+		util.Check(listener.Close(5 * time.Second))
 	}()
 
 	fmt.Println("Listening")

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -33,7 +33,7 @@ func main() {
 	listener, err := dtls.Listen("udp", addr, config)
 	util.Check(err)
 	defer func() {
-		util.Check(listener.Close())
+		util.Check(listener.Close(5 * time.Second))
 	}()
 
 	fmt.Println("Listening")

--- a/listener.go
+++ b/listener.go
@@ -3,6 +3,7 @@ package dtls
 import (
 	"errors"
 	"net"
+	"time"
 
 	"github.com/pion/dtls/internal/udp"
 )
@@ -41,8 +42,8 @@ func (l *Listener) Accept() (net.Conn, error) {
 // Close closes the listener.
 // Any blocked Accept operations will be unblocked and return errors.
 // Already Accepted connections are not closed.
-func (l *Listener) Close() error {
-	return l.parent.Close()
+func (l *Listener) Close(shutdownTimeout time.Duration) error {
+	return l.parent.Close(shutdownTimeout)
 }
 
 // Addr returns the listener's network address.


### PR DESCRIPTION
## Description
Currently calling listener.Close there is no guarantee of the listener actually closing. This PR changes behavior so that Close guarantee's closure by waiting gracefully for connections to drop to zero or for the timeout to be reached, and the underlying connection then freed.

#### Reference issue
Followup to an issue discovered when fixing the regression from #103 