### PR TITLE
CI: Redo the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,5 @@ jobs:
       script:
         - go test -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
       after_success:
-        - bash <(curl -s https://codecov.io/bash)
+        - travis_retry bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ go:
 env:
   - GO111MODULE=on
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $GOPATH/pkg/mod
+
 jobs:
   include:
     - stage: lint
@@ -24,6 +29,10 @@ jobs:
     - stage: test
       before_script:
         - rm -rf examples # Remove examples, no test coverage for them
+      before_install:
+        - go mod download
+      install:
+        - go build ./...
       script:
         - go test -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,22 @@ go:
 env:
   - GO111MODULE=on
 
-before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.17.1
+jobs:
+  include:
+    - stage: lint
+      before_script:
+        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.17.1
+      install: skip
+      script:
+        - bash .github/assert-contributors.sh
+        - bash .github/lint-disallowed-functions-in-library.sh
+        - bash .github/lint-commit-message.sh
+        - golangci-lint run ./...
+    - stage: test
+      before_script:
+        - rm -rf examples # Remove examples, no test coverage for them
+      script:
+        - go test -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
 
-script:
-  - golangci-lint run ./...
-  - rm -rf examples # Remove examples, no test coverage for them
-  - go test -coverpkg=$(go list ./... | tr '\n' ',') -coverprofile=cover.out -v -race -covermode=atomic ./...
-  - bash <(curl -s https://codecov.io/bash)
-  - bash .github/assert-contributors.sh
-  - bash .github/lint-disallowed-functions-in-library.sh
-  - bash .github/lint-commit-message.sh


### PR DESCRIPTION
* Use Travis build stages: stages run sequentially but jobs within
  a stage can be parametrized to run things in parallel. This would allow us to run the `test` stage with multiple versions of Go
* Do all the linting first, tests after, it's really annoying to have
  the tests pass and then the commit linter etc fail you
* Move tooling installation into before_script
* Only upload code coverage on test success, if tests fail codecov
  really can't tell us anything useful
* Add caching of Go module download and build results to speed up subsequent runs of tests for the same PR