### PR TITLE
Fragmenting sent handshake messages

### DIFF
--- a/config.go
+++ b/config.go
@@ -81,6 +81,10 @@ type Config struct {
 	// ConnectTimeout is the timeout threshold for new connection handshakes
 	// to complete (default is 30 seconds)
 	ConnectTimeout *time.Duration
+
+	// MTU is the length at which handshake messages will be fragmented to
+	// fit within the maximum transmission unit (default is 1200 bytes)
+	MTU int
 }
 
 const defaultConnectTimeout = 30 * time.Second
@@ -89,6 +93,8 @@ const defaultConnectTimeout = 30 * time.Second
 func ConnectTimeoutOption(timeout time.Duration) *time.Duration {
 	return &timeout
 }
+
+const defaultMTU = 1200 // bytes
 
 // PSKCallback is called once we have the remote's PSKIdentityHint.
 // If the remote provided none it will be nil

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -32,6 +32,7 @@ func TestPionE2ELossy(t *testing.T) {
 		LossChanceRange int
 		DoClientAuth    bool
 		CipherSuites    []dtls.CipherSuiteID
+		MTU             int
 	}{
 		{
 			LossChanceRange: 0,
@@ -77,7 +78,23 @@ func TestPionE2ELossy(t *testing.T) {
 			LossChanceRange: 50,
 			CipherSuites:    []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA},
 		},
+		{
+			LossChanceRange: 10,
+			MTU:             100,
+			DoClientAuth:    true,
+		},
+		{
+			LossChanceRange: 20,
+			MTU:             100,
+			DoClientAuth:    true,
+		},
+		{
+			LossChanceRange: 50,
+			MTU:             100,
+			DoClientAuth:    true,
+		},
 	} {
+
 		rand.Seed(time.Now().UTC().UnixNano())
 		chosenLoss := rand.Intn(9) + test.LossChanceRange
 		serverDone := make(chan error)
@@ -92,7 +109,9 @@ func TestPionE2ELossy(t *testing.T) {
 				FlightInterval:     flightInterval,
 				CipherSuites:       test.CipherSuites,
 				InsecureSkipVerify: true,
+				MTU:                test.MTU,
 			}
+
 			if test.DoClientAuth {
 				cfg.Certificate = clientCert
 				cfg.PrivateKey = clientKey
@@ -110,10 +129,11 @@ func TestPionE2ELossy(t *testing.T) {
 				Certificate:    serverCert,
 				PrivateKey:     serverKey,
 				FlightInterval: flightInterval,
+				MTU:            test.MTU,
 			}
+
 			if test.DoClientAuth {
 				cfg.ClientAuth = dtls.RequireAnyClientCert
-
 			}
 
 			if _, err := dtls.Server(br.GetConn1(), cfg); err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -232,3 +232,33 @@ func TestPionE2ESimplePSK(t *testing.T) {
 		assertE2ECommunication(cfg, cfg, serverPort, t)
 	}
 }
+
+func TestPionE2EMTUs(t *testing.T) {
+	lim := test.TimeOut(time.Second * 30)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	serverPort := randomPort(t)
+
+	for _, mtu := range []int{
+		10000,
+		1000,
+		100,
+	} {
+		cert, key, err := dtls.GenerateSelfSigned()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &dtls.Config{
+			Certificate:        cert,
+			PrivateKey:         key,
+			CipherSuites:       []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+			InsecureSkipVerify: true,
+			MTU:                mtu,
+		}
+		assertE2ECommunication(cfg, cfg, serverPort, t)
+	}
+}

--- a/state.go
+++ b/state.go
@@ -75,7 +75,7 @@ func (s *State) serialize() (*serializedState, error) {
 		RemoteEpoch:           s.remoteEpoch.Load().(uint16),
 		CipherSuiteID:         uint16(s.cipherSuite.ID()),
 		MasterSecret:          s.masterSecret,
-		SequenceNumber:        s.localSequenceNumber,
+		SequenceNumber:        atomic.LoadUint64(&s.localSequenceNumber),
 		LocalRandom:           localRnd,
 		RemoteRandom:          remoteRnd,
 		SRTPProtectionProfile: uint16(s.srtpProtectionProfile),
@@ -117,7 +117,7 @@ func (s *State) deserialize(serialized serializedState) error {
 		return err
 	}
 
-	s.localSequenceNumber = serialized.SequenceNumber
+	atomic.StoreUint64(&s.localSequenceNumber, serialized.SequenceNumber)
 	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)
 
 	// Set remote certificate

--- a/util.go
+++ b/util.go
@@ -152,3 +152,18 @@ func findMatchingCipherSuite(a, b []cipherSuite) (cipherSuite, bool) {
 	}
 	return nil, false
 }
+
+func splitBytes(bytes []byte, splitLen int) [][]byte {
+	splitBytes := make([][]byte, 0)
+	numBytes := len(bytes)
+	for i := 0; i < numBytes; i += splitLen {
+		j := i + splitLen
+		if j > numBytes {
+			j = numBytes
+		}
+
+		splitBytes = append(splitBytes, bytes[i:j])
+	}
+
+	return splitBytes
+}


### PR DESCRIPTION
#### Description
Previously handshake messages being sent out would not be fragmented. Most handshake messages are pretty small but a couple of exceptions, such as Certificate, mean the packet size can be greater than the MTU, which then causes some packet loss and the handshake would never be able to complete. This changes the `internalSend` function to fragment handshakes to the set MTU.

We set `MTU` as a config option, which defaults to `1200`

#### Reference issue
