### PR TITLE
Fix connect timeout doesn't stop outgoing handshake routine

### DIFF
--- a/client_handlers.go
+++ b/client_handlers.go
@@ -235,7 +235,7 @@ func clientHandshakeHandler(c *Conn) (*alert, error) {
 
 		c.setLocalEpoch(1)
 		c.state.localSequenceNumber = 1
-		c.signalHandshakeComplete()
+		c.handshakeDoneSignal.Close()
 	default:
 		return &alert{alertLevelFatal, alertUnexpectedMessage}, fmt.Errorf("client asked to handle unknown flight (%d)", c.currFlight.get())
 	}

--- a/closer.go
+++ b/closer.go
@@ -1,0 +1,39 @@
+package dtls
+
+import (
+	"context"
+)
+
+// Closer allows for each signaling a channel for shutdown
+type Closer struct {
+	ctx       context.Context
+	closeFunc func()
+}
+
+// NewCloser creates a new instance of Closer
+func NewCloser() *Closer {
+	ctx, closeFunc := context.WithCancel(context.Background())
+	return &Closer{
+		ctx:       ctx,
+		closeFunc: closeFunc,
+	}
+}
+
+// NewCloserWithParent creates a new instance of Closer with a parent context
+func NewCloserWithParent(ctx context.Context) *Closer {
+	ctx, closeFunc := context.WithCancel(ctx)
+	return &Closer{
+		ctx:       ctx,
+		closeFunc: closeFunc,
+	}
+}
+
+// Done returns a channel signaling when it is done
+func (c *Closer) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+// Close sends a signal to trigger the ctx done channel
+func (c *Closer) Close() {
+	c.closeFunc()
+}

--- a/resume.go
+++ b/resume.go
@@ -18,7 +18,7 @@ func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
 	// Custom flight handler that sets imported data and signals as handshaked
 	flightHandler := func(c *Conn) (bool, *alert, error) {
 		c.state = *state
-		c.signalHandshakeComplete()
+		c.handshakeDoneSignal.Close()
 		return true, nil, nil
 	}
 

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -502,8 +502,7 @@ func serverFlightHandler(c *Conn) (bool, *alert, error) {
 				}},
 		}, true)
 
-		// TODO: Better way to end handshake
-		c.signalHandshakeComplete()
+		c.handshakeDoneSignal.Close()
 		return true, nil, nil
 	default:
 		return false, &alert{alertLevelFatal, alertUnexpectedMessage}, fmt.Errorf("unhandled flight %s", c.currFlight.get())


### PR DESCRIPTION
### Description
Recently a ConnectTimeout option was added which waits for the handshake to complete in the given timeframe or otherwise moves on. However, the outbound handshake goroutine was never cancelled when a timeout occurs. This PR refactors the previous signaling mechanism and adds a call to `c.handshakeDoneSignal.Close()` at timeout, so that the outgoing handshake goroutine receives the signal and stops.

#### Reference issue
Fixes regression from #94