### PR TITLE
Fix signature verification not being called

### DIFF
--- a/client_handlers.go
+++ b/client_handlers.go
@@ -38,11 +38,11 @@ func initalizeCipherSuite(c *Conn, h *handshakeMessageServerKeyExchange) (*alert
 	}
 
 	if c.localPSKCallback == nil {
+		expectedHash := valueKeySignature(clientRandom, serverRandom, h.publicKey, h.namedCurve, h.hashAlgorithm)
+		if err := verifyKeySignature(expectedHash, h.signature, h.hashAlgorithm, c.state.remoteCertificate); err != nil {
+			return &alert{alertLevelFatal, alertBadCertificate}, err
+		}
 		if !c.insecureSkipVerify {
-			expectedHash := valueKeySignature(clientRandom, serverRandom, h.publicKey, h.namedCurve, h.hashAlgorithm)
-			if err := verifyKeySignature(expectedHash, h.signature, h.hashAlgorithm, c.state.remoteCertificate); err != nil {
-				return &alert{alertLevelFatal, alertBadCertificate}, err
-			}
 			if err := verifyServerCert(c.state.remoteCertificate, c.rootCAs, c.serverName); err != nil {
 				return &alert{alertLevelFatal, alertBadCertificate}, err
 			}


### PR DESCRIPTION
`InsecureSkipVerify` should not skip the signature verification

#### Description

`InsecureSkipVerify` should only skip the verification of certificate properties such as server name, expiration, matching CAs... but not the signature verification.

In addition crypto/tls also seems to do it this way:
https://github.com/golang/go/blob/master/src/crypto/tls/handshake_client.go#L823
