### PR TITLE
Version lock CI to Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   - master
 
 go:
-  - "1.x" # use the latest Go release
+  - "1.12" # use the latest Go release
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
#### Description
All CI builds are currently failing. Locking CI to 1.12 until golangci-lint is fixed or we replace it with a different recommendation.

#### Reference issue

