### PR TITLE
Compact handshake records into less datagrams

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -1,0 +1,7 @@
+package dtls
+
+type packet struct {
+	record                   *recordLayer
+	shouldEncrypt            bool
+	resetLocalSequenceNumber bool
+}


### PR DESCRIPTION
#### Description
Currently each record during the handshake process is sent as a separate datagram.

The dTLS spec allows for combining records into a single datagram so long as the datagram fits within the MTU.

Here we implement this improvement, compacting records during the handshake process into less packets. The number of packets sent for a complete handshake before this change was 12. With this change the number is reduced to 7.

While improvements are likely hard to measure, this should theoretically reduce tail handshake latency in lossy networks.

Note: This PR is more easily viewed with `?w=1`

#### Reference issue
