### PR TITLE
Update golangci-lint to 1.18.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - dupl
     - gocyclo
     - gochecknoglobals
+    - funlen
 
 issues:
   exclude-use-default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
   - master
 
 go:
-  - "1.12" # use the latest Go release
+  - "1.x" # use the latest Go release
 
 env:
   - GO111MODULE=on
@@ -19,7 +19,7 @@ jobs:
   include:
     - stage: lint
       before_script:
-        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.17.1
+        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
       install: skip
       script:
         - bash .github/assert-contributors.sh


### PR DESCRIPTION
Adds 1.13 compatibility, don't pin to 1.12 anymore