### PR TITLE
Fix ChangeCipherSpec handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -557,7 +557,11 @@ func (c *Conn) handleIncomingPacket(buf []byte) (*alert, error) {
 		return nil, fmt.Errorf("alert: %v", content)
 	case *changeCipherSpec:
 		c.log.Trace("<- ChangeCipherSpec")
-		c.setRemoteEpoch(c.getRemoteEpoch() + 1)
+
+		newRemoteEpoch := h.epoch + 1
+		if c.getRemoteEpoch() < newRemoteEpoch {
+			c.setRemoteEpoch(newRemoteEpoch)
+		}
 	case *applicationData:
 		if h.epoch == 0 {
 			return &alert{alertLevelFatal, alertUnexpectedMessage}, fmt.Errorf("ApplicationData with epoch of 0")


### PR DESCRIPTION
Before when we received a ChangeCipherSpec we just incremented the remote epoch.
This would break if a retranmission happened and would cause Pion to become desynchronized
with the peer.

Instead actually use the epoch the ChangeCipherSpec declares.
