### PR TITLE
Validate DTLS config object before listening on port

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Aleksandr Razumov](https://github.com/ernado) - *Fuzzing*
 * [Ryan Gordon](https://github.com/ryangordon)
 * [Stefan Tatschner](https://rumpelsepp.org/contact.html)
+* [Hayden James](https://github.com/hjames9)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/listener.go
+++ b/listener.go
@@ -1,7 +1,6 @@
 package dtls
 
 import (
-	"errors"
 	"net"
 	"time"
 
@@ -10,9 +9,10 @@ import (
 
 // Listen creates a DTLS listener
 func Listen(network string, laddr *net.UDPAddr, config *Config) (*Listener, error) {
-	if config == nil {
-		return nil, errors.New("no config provided")
+	if err := validateConfig(config); err != nil {
+		return nil, err
 	}
+
 	parent, err := udp.Listen(network, laddr)
 	if err != nil {
 		return nil, err

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,33 @@
+package dtls
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+)
+
+func validateConfig(config *Config) error {
+	switch {
+	case config == nil:
+		return errNoConfigProvided
+	case config.Certificate != nil && config.PSK != nil:
+		return errPSKAndCertificate
+	case config.PSKIdentityHint != nil && config.PSK == nil:
+		return errIdentityNoPSK
+	}
+
+	if config.PrivateKey != nil {
+		switch config.PrivateKey.(type) {
+		case ed25519.PrivateKey:
+		case *ecdsa.PrivateKey:
+		default:
+			return errInvalidPrivateKey
+		}
+	}
+
+	_, err := parseCipherSuites(config.CipherSuites, config.PSK == nil, config.PSK != nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,71 @@
+package dtls
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+func TestValidateConfig(t *testing.T) {
+	//Empty config
+	if err := validateConfig(nil); err != errNoConfigProvided {
+		t.Fatalf("TestValidateConfig: Config validation error exp(%v) failed(%v)", errNoConfigProvided, err)
+	}
+
+	//PSK and Certificate
+	cert, key, err := GenerateSelfSigned()
+	if err != nil {
+		t.Fatalf("TestValidateConfig: Config validation error(%v), self signed certificate not generated", err)
+		return
+	}
+	config := &Config{
+		CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		PSK: func(hint []byte) ([]byte, error) {
+			return nil, nil
+		},
+		Certificate: cert,
+	}
+	if err = validateConfig(config); err != errPSKAndCertificate {
+		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", errPSKAndCertificate, err)
+	}
+
+	//PSK identity hint with not PSK
+	config = &Config{
+		CipherSuites:    []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		PSK:             nil,
+		PSKIdentityHint: []byte{},
+	}
+	if err = validateConfig(config); err != errIdentityNoPSK {
+		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", errIdentityNoPSK, err)
+	}
+
+	//Invalid private key
+	block, _ := pem.Decode([]byte(rawPrivateKey))
+	rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("TestValidateConfig: Config validation error(%v), parsing RSA private key", err)
+	}
+	config = &Config{
+		CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		PrivateKey:   rsaKey,
+	}
+	if err = validateConfig(config); err != errInvalidPrivateKey {
+		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", errInvalidPrivateKey, err)
+	}
+
+	//Invalid cipher suites
+	config = &Config{CipherSuites: []CipherSuiteID{0x0000}}
+	if err = validateConfig(config); err == nil {
+		t.Fatal("TestValidateConfig: Client error expected with invalid CipherSuiteID")
+	}
+
+	//Valid config
+	config = &Config{
+		CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		Certificate:  cert,
+		PrivateKey:   key,
+	}
+	if err = validateConfig(config); err != nil {
+		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", nil, err)
+	}
+}


### PR DESCRIPTION
Before successfully listening on a UDP port to receive DTLS messages,
we should validate that the configuration is in working condition to avoid
deferring any failures on incoming messages.

#### Reference issue
Fixes #139
