### PR TITLE
V2 Release! First breaking change certificate chains.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,6 @@ linters:
 
 issues:
   exclude-use-default: false
-  max-per-linter: 0
-  max-same-issues: 50
 
   exclude-rules:
     - path: internal/crypto/ccm
@@ -28,3 +26,6 @@ issues:
       text: "don't use ALL_CAPS in Go names; use CamelCase"
       linters:
         - golint
+
+run:
+  skip-dirs-use-default: false

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Ryan Gordon](https://github.com/ryangordon)
 * [Stefan Tatschner](https://rumpelsepp.org/contact.html)
 * [Hayden James](https://github.com/hjames9)
+* [Jozef Kralik](https://github.com/jkralik)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/bench_test.go
+++ b/bench_test.go
@@ -15,7 +15,7 @@ func TestSimpleReadWrite(t *testing.T) {
 	defer report()
 
 	ca, cb := net.Pipe()
-	certificate, privateKey, err := GenerateSelfSigned()
+	certificate, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,6 @@ func TestSimpleReadWrite(t *testing.T) {
 	go func() {
 		server, sErr := testServer(cb, &Config{
 			Certificate:   certificate,
-			PrivateKey:    privateKey,
 			LoggerFactory: logging.NewDefaultLoggerFactory(),
 		}, false)
 		if sErr != nil {
@@ -65,12 +64,11 @@ func TestSimpleReadWrite(t *testing.T) {
 func benchmarkConn(b *testing.B, n int64) {
 	b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 		ca, cb := net.Pipe()
-		certificate, privateKey, err := GenerateSelfSigned()
+		certificate, err := GenerateSelfSigned()
 		server := make(chan *Conn)
 		go func() {
 			s, sErr := testServer(cb, &Config{
 				Certificate: certificate,
-				PrivateKey:  privateKey,
 			}, false)
 			if err != nil {
 				b.Error(sErr)

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -328,7 +328,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 							messageSequence: uint16(messageSequence),
 						},
 						handshakeMessage: &handshakeMessageCertificate{
-							certificate: c.localCertificate,
+							certificate: c.localCertificate.Certificate,
 						}},
 				},
 			})
@@ -392,7 +392,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 		// If the client has sent a certificate with signing ability, a digitally-signed
 		// CertificateVerify message is sent to explicitly verify possession of the
 		// private key in the certificate.
-		if c.remoteRequestedCertificate && c.localCertificate != nil {
+		if c.remoteRequestedCertificate && c.localCertificate.PrivateKey != nil {
 			if len(c.localCertificateVerify) == 0 {
 				plainText := c.handshakeCache.pullAndMerge(
 					handshakeCachePullRule{handshakeTypeClientHello, true},
@@ -405,7 +405,7 @@ func clientFlightHandler(c *Conn) (bool, *alert, error) {
 					handshakeCachePullRule{handshakeTypeClientKeyExchange, true},
 				)
 
-				certVerify, err := generateCertificateVerify(plainText, c.localPrivateKey)
+				certVerify, err := generateCertificateVerify(plainText, c.localCertificate.PrivateKey)
 				if err != nil {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package dtls
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
@@ -13,7 +14,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	//PSK and Certificate
-	cert, key, err := GenerateSelfSigned()
+	cert, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatalf("TestValidateConfig: Config validation error(%v), self signed certificate not generated", err)
 		return
@@ -47,7 +48,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 	config = &Config{
 		CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
-		PrivateKey:   rsaKey,
+		Certificate:  tls.Certificate{PrivateKey: rsaKey},
 	}
 	if err = validateConfig(config); err != errInvalidPrivateKey {
 		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", errInvalidPrivateKey, err)
@@ -63,7 +64,6 @@ func TestValidateConfig(t *testing.T) {
 	config = &Config{
 		CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 		Certificate:  cert,
-		PrivateKey:   key,
 	}
 	if err = validateConfig(config); err != nil {
 		t.Fatalf("TestValidateConfig: Client error exp(%v) failed(%v)", nil, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -106,11 +106,10 @@ func pipeMemory() (*Conn, *Conn, error) {
 
 func testClient(c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error) {
 	if generateCertificate {
-		clientCert, clientKey, err := GenerateSelfSigned()
+		clientCert, err := GenerateSelfSigned()
 		if err != nil {
 			return nil, err
 		}
-		cfg.PrivateKey = clientKey
 		cfg.Certificate = clientCert
 	}
 	cfg.InsecureSkipVerify = true
@@ -119,11 +118,10 @@ func testClient(c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error
 
 func testServer(c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error) {
 	if generateCertificate {
-		serverCert, serverKey, err := GenerateSelfSigned()
+		serverCert, err := GenerateSelfSigned()
 		if err != nil {
 			return nil, err
 		}
-		cfg.PrivateKey = serverKey
 		cfg.Certificate = serverCert
 	}
 	return Server(c, cfg)
@@ -417,19 +415,27 @@ func TestSRTPConfiguration(t *testing.T) {
 }
 
 func TestClientCertificate(t *testing.T) {
-	srvCert, srvKey, err := GenerateSelfSigned()
+	srvCert, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
 	srvCAPool := x509.NewCertPool()
-	srvCAPool.AddCert(srvCert)
+	srvCertificate, err := x509.ParseCertificate(srvCert.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	srvCAPool.AddCert(srvCertificate)
 
-	cert, key, err := GenerateSelfSigned()
+	cert, err := GenerateSelfSigned()
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		t.Fatal(err)
 	}
 	caPool := x509.NewCertPool()
-	caPool.AddCert(cert)
+	caPool.AddCert(certificate)
 
 	t.Parallel()
 	tests := map[string]struct {
@@ -441,24 +447,21 @@ func TestClientCertificate(t *testing.T) {
 			clientCfg: &Config{RootCAs: srvCAPool},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  NoClientCert,
 				RootCAs:     caPool,
 			},
 		},
 		"NoClientCert_cert": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequireAnyClientCert,
 			},
 		},
 		"RequestClientCert_cert": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequestClientCert,
 			},
 		},
@@ -466,16 +469,14 @@ func TestClientCertificate(t *testing.T) {
 			clientCfg: &Config{RootCAs: srvCAPool},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequestClientCert,
 				RootCAs:     caPool,
 			},
 		},
 		"RequireAnyClientCert": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequireAnyClientCert,
 			},
 		},
@@ -483,7 +484,6 @@ func TestClientCertificate(t *testing.T) {
 			clientCfg: &Config{RootCAs: srvCAPool},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequireAnyClientCert,
 			},
 			wantErr: true,
@@ -492,34 +492,30 @@ func TestClientCertificate(t *testing.T) {
 			clientCfg: &Config{RootCAs: srvCAPool},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  VerifyClientCertIfGiven,
 				RootCAs:     caPool,
 			},
 		},
 		"VerifyClientCertIfGiven_cert": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  VerifyClientCertIfGiven,
 				RootCAs:     caPool,
 			},
 		},
 		"VerifyClientCertIfGiven_error": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  VerifyClientCertIfGiven,
 			},
 			wantErr: true,
 		},
 		"RequireAndVerifyClientCert": {
-			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert, PrivateKey: key},
+			clientCfg: &Config{RootCAs: srvCAPool, Certificate: cert},
 			serverCfg: &Config{
 				Certificate: srvCert,
-				PrivateKey:  srvKey,
 				ClientAuth:  RequireAndVerifyClientCert,
 				RootCAs:     caPool,
 			},
@@ -563,7 +559,7 @@ func TestClientCertificate(t *testing.T) {
 					t.Errorf("TestClientCertificate: Client did not provide a certificate")
 				}
 
-				if !actualClientCert.Equal(tt.clientCfg.Certificate) {
+				if len(actualClientCert) != len(tt.clientCfg.Certificate.Certificate) || !bytes.Equal(tt.clientCfg.Certificate.Certificate[0], actualClientCert[0]) {
 					t.Errorf("TestClientCertificate: Client certificate was not communicated correctly")
 				}
 			}
@@ -578,7 +574,7 @@ func TestClientCertificate(t *testing.T) {
 				t.Errorf("TestClientCertificate: Server did not provide a certificate")
 			}
 
-			if !actualServerCert.Equal(tt.serverCfg.Certificate) {
+			if len(actualServerCert) != len(tt.serverCfg.Certificate.Certificate) || !bytes.Equal(tt.serverCfg.Certificate.Certificate[0], actualServerCert[0]) {
 				t.Errorf("TestClientCertificate: Server certificate was not communicated correctly")
 			}
 		})
@@ -721,12 +717,16 @@ func TestExtendedMasterSecret(t *testing.T) {
 func TestServerCertificate(t *testing.T) {
 	t.Parallel()
 
-	cert, key, err := GenerateSelfSigned()
+	cert, err := GenerateSelfSigned()
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		t.Fatal(err)
 	}
 	caPool := x509.NewCertPool()
-	caPool.AddCert(cert)
+	caPool.AddCert(certificate)
 
 	tests := map[string]struct {
 		clientCfg *Config
@@ -735,34 +735,34 @@ func TestServerCertificate(t *testing.T) {
 	}{
 		"no_ca": {
 			clientCfg: &Config{},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 			wantErr:   true,
 		},
 		"good_ca": {
 			clientCfg: &Config{RootCAs: caPool},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 		},
 		"no_ca_skip_verify": {
 			clientCfg: &Config{InsecureSkipVerify: true},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 		},
 		"good_ca_custom_verify_peer": {
 			clientCfg: &Config{
 				RootCAs: caPool,
-				VerifyPeerCertificate: func(*x509.Certificate, bool) error {
+				VerifyPeerCertificate: func([][]byte, bool) error {
 					return errors.New("wrong cert")
 				},
 			},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 			wantErr:   true,
 		},
 		"server_name": {
-			clientCfg: &Config{RootCAs: caPool, ServerName: cert.Subject.CommonName},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			clientCfg: &Config{RootCAs: caPool, ServerName: certificate.Subject.CommonName},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 		},
 		"server_name_error": {
 			clientCfg: &Config{RootCAs: caPool, ServerName: "barfoo"},
-			serverCfg: &Config{Certificate: cert, PrivateKey: key, ClientAuth: NoClientCert},
+			serverCfg: &Config{Certificate: cert, ClientAuth: NoClientCert},
 			wantErr:   true,
 		},
 	}

--- a/crypto_ccm.go
+++ b/crypto_ccm.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/pion/dtls/internal/crypto/ccm"
+	"github.com/pion/dtls/v2/internal/crypto/ccm"
 )
 
 const (

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/dtls"
+	"github.com/pion/dtls/v2"
 	transportTest "github.com/pion/transport/test"
 )
 

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -23,12 +23,12 @@ func TestPionE2ELossy(t *testing.T) {
 		err      error
 	}
 
-	serverCert, serverKey, err := dtls.GenerateSelfSigned()
+	serverCert, err := dtls.GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	clientCert, clientKey, err := dtls.GenerateSelfSigned()
+	clientCert, err := dtls.GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,6 @@ func TestPionE2ELossy(t *testing.T) {
 
 			if test.DoClientAuth {
 				cfg.Certificate = clientCert
-				cfg.PrivateKey = clientKey
 			}
 
 			client, startupErr := dtls.Client(br.GetConn0(), cfg)
@@ -129,7 +128,6 @@ func TestPionE2ELossy(t *testing.T) {
 		go func() {
 			cfg := &dtls.Config{
 				Certificate:    serverCert,
-				PrivateKey:     serverKey,
 				FlightInterval: flightInterval,
 				MTU:            test.MTU,
 			}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -194,14 +194,13 @@ func TestPionE2ESimple(t *testing.T) {
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 	} {
-		cert, key, err := dtls.GenerateSelfSigned()
+		cert, err := dtls.GenerateSelfSigned()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		cfg := &dtls.Config{
 			Certificate:        cert,
-			PrivateKey:         key,
 			CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
 			InsecureSkipVerify: true,
 			ConnectTimeout:     dtls.ConnectTimeoutOption(2 * time.Second),
@@ -235,7 +234,6 @@ func TestPionE2ESimpleED25519(t *testing.T) {
 
 		cfg := &dtls.Config{
 			Certificate:        cert,
-			PrivateKey:         key,
 			CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
 			InsecureSkipVerify: true,
 			ConnectTimeout:     dtls.ConnectTimeoutOption(5 * time.Second),
@@ -283,14 +281,13 @@ func TestPionE2EMTUs(t *testing.T) {
 		1000,
 		100,
 	} {
-		cert, key, err := dtls.GenerateSelfSigned()
+		cert, err := dtls.GenerateSelfSigned()
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		cfg := &dtls.Config{
 			Certificate:        cert,
-			PrivateKey:         key,
 			CipherSuites:       []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 			InsecureSkipVerify: true,
 			MTU:                mtu,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/dtls"
+	"github.com/pion/dtls/v2"
 	"github.com/pion/transport/test"
 )
 

--- a/examples/dial-psk/main.go
+++ b/examples/dial-psk/main.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/pion/dtls"
-	"github.com/pion/dtls/examples/util"
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/examples/util"
 )
 
 func main() {

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -14,7 +14,7 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	certificate, genErr := dtls.GenerateSelfSigned()
 	util.Check(genErr)
 
 	//
@@ -24,7 +24,6 @@ func main() {
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
 		Certificate:          certificate,
-		PrivateKey:           privateKey,
 		InsecureSkipVerify:   true,
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/pion/dtls"
-	"github.com/pion/dtls/examples/util"
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/examples/util"
 )
 
 func main() {

--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/pion/dtls"
-	"github.com/pion/dtls/examples/util"
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/examples/util"
 )
 
 func main() {

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/pion/dtls"
-	"github.com/pion/dtls/examples/util"
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/examples/util"
 )
 
 func main() {

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -14,7 +14,7 @@ func main() {
 	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
 
 	// Generate a certificate and private key to secure the connection
-	certificate, privateKey, genErr := dtls.GenerateSelfSigned()
+	certificate, genErr := dtls.GenerateSelfSigned()
 	util.Check(genErr)
 
 	//
@@ -24,7 +24,6 @@ func main() {
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
 		Certificate:          certificate,
-		PrivateKey:           privateKey,
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pion/dtls
+module github.com/pion/dtls/v2
 
 require (
 	github.com/pion/logging v0.2.2

--- a/handshake_message_certificate.go
+++ b/handshake_message_certificate.go
@@ -1,52 +1,55 @@
 package dtls
 
-import (
-	"crypto/x509"
-)
-
 type handshakeMessageCertificate struct {
-	certificate *x509.Certificate
+	certificate [][]byte
 }
 
 func (h handshakeMessageCertificate) handshakeType() handshakeType {
 	return handshakeTypeCertificate
 }
 
+const (
+	handshakeMessageCertificateLengthFieldSize = 3
+)
+
 func (h *handshakeMessageCertificate) Marshal() ([]byte, error) {
-	var raw []byte
-	if h.certificate != nil {
-		raw = h.certificate.Raw
+	out := make([]byte, handshakeMessageCertificateLengthFieldSize)
+
+	for _, r := range h.certificate {
+		// Certificate Length
+		out = append(out, make([]byte, handshakeMessageCertificateLengthFieldSize)...)
+		putBigEndianUint24(out[len(out)-handshakeMessageCertificateLengthFieldSize:], uint32(len(r)))
+
+		// Certificate body
+		out = append(out, append([]byte{}, r...)...)
 	}
 
-	out := make([]byte, 6)
-	putBigEndianUint24(out, uint32(len(raw))+3)
-	putBigEndianUint24(out[3:], uint32(len(raw)))
-
-	return append(out, raw...), nil
+	// Total Payload Size
+	putBigEndianUint24(out[0:], uint32(len(out[handshakeMessageCertificateLengthFieldSize:])))
+	return out, nil
 }
 
 func (h *handshakeMessageCertificate) Unmarshal(data []byte) error {
-	if len(data) < 3 {
+	if len(data) < handshakeMessageCertificateLengthFieldSize {
 		return errBufferTooSmall
 	}
 
-	certificateBodyLen := int(bigEndianUint24(data))
-	certificateLen := int(bigEndianUint24(data[3:]))
-	if certificateLen == 0 {
-		return nil
-	}
-	if certificateBodyLen+3 != len(data) {
-		return errLengthMismatch
-	} else if certificateLen+6 != len(data) {
+	if certificateBodyLen := int(bigEndianUint24(data)); certificateBodyLen+handshakeMessageCertificateLengthFieldSize != len(data) {
 		return errLengthMismatch
 	}
 
-	if len(data) > 6 {
-		cert, err := x509.ParseCertificate(data[6:])
-		if err != nil {
-			return err
+	offset := handshakeMessageCertificateLengthFieldSize
+	for offset < len(data) {
+		certificateLen := int(bigEndianUint24(data[offset:]))
+		offset += handshakeMessageCertificateLengthFieldSize
+
+		if offset+certificateLen > len(data) {
+			return errLengthMismatch
 		}
-		h.certificate = cert
+
+		h.certificate = append(h.certificate, append([]byte{}, data[offset:offset+certificateLen]...))
+		offset += certificateLen
 	}
+
 	return nil
 }

--- a/handshake_message_certificate_test.go
+++ b/handshake_message_certificate_test.go
@@ -43,26 +43,29 @@ func TestHandshakeMessageCertificate(t *testing.T) {
 		0x80, 0xa4, 0xd4, 0xb7, 0x7f, 0x7d, 0x78, 0xb3, 0xfb, 0xf3, 0x95, 0xfb, 0x02, 0x21, 0x00, 0xc0,
 		0x73, 0x30, 0xda, 0x2b, 0xc0, 0x0c, 0x9e, 0xb2, 0x25, 0x0d, 0x46, 0xb0, 0xbc, 0x66, 0x7f, 0x71,
 		0x66, 0xbf, 0x16, 0xb3, 0x80, 0x78, 0xd0, 0x0c, 0xef, 0xcc, 0xf5, 0xc1, 0x15, 0x0f, 0x58}
-	parsedCertificate := &handshakeMessageCertificate{
-		certificate: &x509.Certificate{
-			Raw:                     rawCertificate[6:],
-			RawTBSCertificate:       rawCertificate[10:313],
-			RawSubjectPublicKeyInfo: rawCertificate[222:313],
-			RawSubject:              rawCertificate[48:119],
-			RawIssuer:               rawCertificate[48:119],
-			Signature:               rawCertificate[328:],
-			SignatureAlgorithm:      x509.ECDSAWithSHA256,
-			PublicKeyAlgorithm:      x509.ECDSA,
-			Version:                 1,
-		},
+
+	parsedCertificate := &x509.Certificate{
+		Raw:                     rawCertificate[6:],
+		RawTBSCertificate:       rawCertificate[10:313],
+		RawSubjectPublicKeyInfo: rawCertificate[222:313],
+		RawSubject:              rawCertificate[48:119],
+		RawIssuer:               rawCertificate[48:119],
+		Signature:               rawCertificate[328:],
+		SignatureAlgorithm:      x509.ECDSAWithSHA256,
+		PublicKeyAlgorithm:      x509.ECDSA,
+		Version:                 1,
 	}
 
 	c := &handshakeMessageCertificate{}
 	if err := c.Unmarshal(rawCertificate); err != nil {
 		t.Error(err)
 	} else {
-		copyCertificatePrivateMembers(c.certificate, parsedCertificate.certificate)
-		if !reflect.DeepEqual(c, parsedCertificate) {
+		certificate, err := x509.ParseCertificate(c.certificate[0])
+		if err != nil {
+			t.Error(err)
+		}
+		copyCertificatePrivateMembers(certificate, parsedCertificate)
+		if !reflect.DeepEqual(certificate, parsedCertificate) {
 			t.Errorf("handshakeMessageCertificate unmarshal: got %#v, want %#v", c, parsedCertificate)
 		}
 	}

--- a/listener.go
+++ b/listener.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/pion/dtls/internal/udp"
+	"github.com/pion/dtls/v2/internal/udp"
 )
 
 // Listen creates a DTLS listener

--- a/resume_test.go
+++ b/resume_test.go
@@ -23,7 +23,7 @@ func fatal(t *testing.T, errChan chan error, err error) {
 }
 
 func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Conn, error)) {
-	certificate, privateKey, err := GenerateSelfSigned()
+	certificate, err := GenerateSelfSigned()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,6 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 	}()
 	config := &Config{
 		Certificate:          certificate,
-		PrivateKey:           privateKey,
 		InsecureSkipVerify:   true,
 		ExtendedMasterSecret: RequireExtendedMasterSecret,
 	}

--- a/server_handlers.go
+++ b/server_handlers.go
@@ -349,7 +349,7 @@ func serverFlightHandler(c *Conn) (bool, *alert, error) {
 							messageSequence: uint16(messageSequence),
 						},
 						handshakeMessage: &handshakeMessageCertificate{
-							certificate: c.localCertificate,
+							certificate: c.localCertificate.Certificate,
 						}},
 				},
 			})
@@ -365,7 +365,7 @@ func serverFlightHandler(c *Conn) (bool, *alert, error) {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}
 
-				signature, err := generateKeySignature(clientRandom, serverRandom, c.localKeypair.publicKey, c.namedCurve, c.localPrivateKey, HashAlgorithmSHA256)
+				signature, err := generateKeySignature(clientRandom, serverRandom, c.localKeypair.publicKey, c.namedCurve, c.localCertificate.PrivateKey, HashAlgorithmSHA256)
 				if err != nil {
 					return false, &alert{alertLevelFatal, alertInternalError}, err
 				}

--- a/state.go
+++ b/state.go
@@ -2,7 +2,6 @@ package dtls
 
 import (
 	"bytes"
-	"crypto/x509"
 	"encoding/gob"
 	"sync/atomic"
 )
@@ -16,7 +15,7 @@ type State struct {
 	cipherSuite               cipherSuite // nil if a cipherSuite hasn't been chosen
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
-	remoteCertificate     *x509.Certificate
+	remoteCertificate     [][]byte
 
 	isClient bool
 


### PR DESCRIPTION
Thank you so much @jkralik for this patch, sorry it took me so long :( but we are going to land this now and get in some other stuff!

-----

Breaking changes:
* certificate, privateKey was replaced
  by certificate (tls.Certificate)
* verifyPeerCertificates uses array of bytes for chain
  certificate instead of certificate(*x509.Certificate)