### PR TITLE
Replacing crypto/ed25519 with compatible wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Stefan Tatschner](https://rumpelsepp.org/contact.html)
 * [Hayden James](https://github.com/hjames9)
 * [Jozef Kralik](https://github.com/jkralik)
+* [Robert Eperjesi](https://github.com/epes)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/config.go
+++ b/config.go
@@ -2,10 +2,11 @@ package dtls
 
 import (
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/tls"
 	"crypto/x509"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/pion/logging"
 )

--- a/crypto.go
+++ b/crypto.go
@@ -3,7 +3,6 @@ package dtls
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -12,6 +11,8 @@ import (
 	"encoding/binary"
 	"math/big"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 type ecdsaSignature struct {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
 	"io"
@@ -10,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/pion/dtls/v2"
 	"github.com/pion/transport/test"

--- a/util.go
+++ b/util.go
@@ -3,7 +3,6 @@ package dtls
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/tls"
@@ -13,6 +12,8 @@ import (
 	"encoding/hex"
 	"math/big"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // Parse a big endian uint24


### PR DESCRIPTION
https://golang.org/doc/go1.13#crypto/ed25519 added
the standalone crypto/ed25519 package but it does not
exist below Go 1.13. This change uses the previous /x/
package that in 1.13+ acts as a wrapper for the new
crypto/ed25519 package.

#### Description

#### Reference issue
Fixes #...
