### PR TITLE
Revert "Replacing crypto/ed25519 with compatible wrapper"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ We would love contributes that fall under the 'Planned Features' and fixing any 
 
 ### Using
 
+Go 1.13 is required as the minimum Go version.
+
 #### Pion DTLS
 For a DTLS 1.2 Server that listens on 127.0.0.1:4444
 ```sh

--- a/config.go
+++ b/config.go
@@ -2,11 +2,10 @@ package dtls
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/tls"
 	"crypto/x509"
 	"time"
-
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/pion/logging"
 )

--- a/crypto.go
+++ b/crypto.go
@@ -3,6 +3,7 @@ package dtls
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -11,8 +12,6 @@ import (
 	"encoding/binary"
 	"math/big"
 	"time"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 type ecdsaSignature struct {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/tls"
 	"errors"
@@ -10,8 +11,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/pion/dtls/v2"
 	"github.com/pion/transport/test"

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package dtls
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/tls"
@@ -12,8 +13,6 @@ import (
 	"encoding/hex"
 	"math/big"
 	"time"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // Parse a big endian uint24


### PR DESCRIPTION
This reverts commit 0958495f8bfba4c6c2ce23cd851cda89deb972c5.

As discussed here: https://github.com/pion/dtls/pull/154#issuecomment-561936942

> This package uses conditional compiling for go1.13, see here:
> https://github.com/golang/crypto/tree/master/ed25519
>
> Once there is 1.14 out, it won't use the stdlib anymore if the wrapper
> itself is not updated. I would recommend to rely only on the stdlib
> here. Also, this change is pretty much useless, since the crypto/x509
> methods do not support ed25519 keys below go 1.13:
>
> https://pkg.go.dev/crypto/x509@go1.12.13?tab=doc#MarshalPKCS8PrivateKey
> https://pkg.go.dev/crypto/x509?tab=doc#MarshalPKCS8PrivateKey