### PR TITLE
Fix routine leak on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Hayden James](https://github.com/hjames9)
 * [Jozef Kralik](https://github.com/jkralik)
 * [Robert Eperjesi](https://github.com/epes)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Read from channel was blocked if closed when there is unread data.
Unblock channel read on close.

https://github.com/pion/webrtc/issues/942 should be fixed by this.
pion/webrtc with this branch is tested at https://github.com/pion/webrtc/issues/942.