### PR TITLE
Only set connErr once

### DIFF
--- a/atomic_error.go
+++ b/atomic_error.go
@@ -1,0 +1,22 @@
+package dtls
+
+import "sync"
+
+type atomicError struct {
+	mu  sync.Mutex
+	val error
+}
+
+func (a *atomicError) store(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.val = err
+}
+
+func (a *atomicError) load() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.val
+}

--- a/resume.go
+++ b/resume.go
@@ -32,5 +32,5 @@ func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
 		return nil, err
 	}
 
-	return c, c.getConnErr()
+	return c, c.handshakeErr.load()
 }


### PR DESCRIPTION
Don't store subsequent calls to stopWithError.
During a graceful shutdown we would overwrite the
original value with the value from the nextConn

Co-authored-by: Atsushi Watanabe <atsushi.w@ieee.org>

[0] https://github.com/pion/webrtc/pull/943#issuecomment-565801043
