### PR TITLE
Disable disallowed-func-lint line by line

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -3,7 +3,7 @@ set -e
 
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude fuzz\.go --exclude-dir=vendor --exclude-dir=.github --exclude-dir=ccm "
+EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github"
 DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 

--- a/fuzz.go
+++ b/fuzz.go
@@ -20,16 +20,18 @@ func FuzzRecordLayer(data []byte) int {
 		return 1
 	}
 	if len(buf) == 0 {
-		panic("zero buff")
+		panic("zero buff") // nolint
 	}
 	var nr recordLayer
 	if err = nr.Unmarshal(data); err != nil {
-		panic(err)
+		panic(err) // nolint
 	}
 	if partialHeaderMismatch(nr.recordLayerHeader, r.recordLayerHeader) {
-		panic(fmt.Sprintf("header mismatch: %+v != %+v",
-			nr.recordLayerHeader, r.recordLayerHeader,
-		))
+		panic( // nolint
+			fmt.Sprintf("header mismatch: %+v != %+v",
+				nr.recordLayerHeader, r.recordLayerHeader,
+			),
+		)
 	}
 
 	return 1

--- a/internal/crypto/ccm/ccm.go
+++ b/internal/crypto/ccm/ccm.go
@@ -191,7 +191,7 @@ func (c *ccm) Seal(dst, nonce, plaintext, adata []byte) []byte {
 	tag, err := c.tag(nonce, plaintext, adata)
 	if err != nil {
 		// The cipher.AEAD interface doesn't allow for an error return.
-		panic(err)
+		panic(err) // nolint
 	}
 
 	var iv, s0 [ccmBlockSize]byte


### PR DESCRIPTION
instead of excluding whole file.

This change allow to unify lint script among the repositories.

ref: https://github.com/pion/dtls/pull/166#discussion_r364023754