### PR TITLE
Upgrade golangci-lint to 1.19.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,12 +7,13 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - maligned
-    - lll
     - dupl
-    - gocyclo
-    - gochecknoglobals
     - funlen
+    - gochecknoglobals
+    - gocyclo
+    - godox
+    - lll
+    - maligned
 
 issues:
   exclude-use-default: false
@@ -22,6 +23,10 @@ issues:
       text: "L' should not be capitalized"
       linters:
         - gocritic
+    - path: cipher_suite
+      text: "should not use ALL_CAPS in Go names; use CamelCase instead"
+      linters:
+        - stylecheck
     - path: cipher_suite
       text: "don't use ALL_CAPS in Go names; use CamelCase"
       linters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   include:
     - stage: lint
       before_script:
-        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
+        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.19.1
       install: skip
       script:
         - bash .github/assert-contributors.sh

--- a/change_cipher_spec_test.go
+++ b/change_cipher_spec_test.go
@@ -27,5 +27,4 @@ func TestChangeCipherSpecInvalid(t *testing.T) {
 	if err := c.Unmarshal([]byte{0x00}); err != errInvalidCipherSpec {
 		t.Errorf("ChangeCipherSpec invalid assert: got %#v, want %#v", err, errInvalidCipherSpec)
 	}
-
 }

--- a/cipher_suite_test.go
+++ b/cipher_suite_test.go
@@ -20,5 +20,4 @@ func TestDecodeCipherSuites(t *testing.T) {
 		}
 		// todo: compare result
 	}
-
 }

--- a/compression_method_test.go
+++ b/compression_method_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestDecodeCompressionMethods(t *testing.T) {
-
 	testCases := []struct {
 		buf    []byte
 		result []*compressionMethod
@@ -21,5 +20,4 @@ func TestDecodeCompressionMethods(t *testing.T) {
 		}
 		// todo: compare result
 	}
-
 }

--- a/conn.go
+++ b/conn.go
@@ -688,7 +688,6 @@ func (c *Conn) notify(level alertLevel, desc alertDescription) error {
 	}
 
 	return c.flushPacketBuffer()
-
 }
 
 func (c *Conn) setHandshakeCompletedSuccessfully() {

--- a/conn_test.go
+++ b/conn_test.go
@@ -255,7 +255,6 @@ func TestPSK(t *testing.T) {
 			ServerIdentity: nil,
 		},
 	} {
-
 		clientIdentity := []byte("Client Identity")
 		clientErr := make(chan error, 1)
 
@@ -738,7 +737,6 @@ func TestExtendedMasterSecret(t *testing.T) {
 					t.Errorf("Server error expected: \"%v\" but got \"%v\"", tt.expectedServerErr, err)
 				}
 			}
-
 		})
 	}
 }
@@ -829,7 +827,6 @@ func TestServerCertificate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestCipherSuiteConfiguration(t *testing.T) {

--- a/dtls.go
+++ b/dtls.go
@@ -1,0 +1,2 @@
+// Package dtls implements Datagram Transport Layer Security (DTLS) 1.2
+package dtls

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -205,7 +205,6 @@ func TestPionE2ESimple(t *testing.T) {
 			ConnectTimeout:     dtls.ConnectTimeoutOption(2 * time.Second),
 		}
 		assertE2ECommunication(cfg, cfg, serverPort, t)
-
 	}
 }
 

--- a/examples/util/util.go
+++ b/examples/util/util.go
@@ -1,3 +1,4 @@
+// Package util provides auxiliary utilities used in examples
 package util
 
 import (

--- a/extension_supported_point_formats_test.go
+++ b/extension_supported_point_formats_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestExtensionSupportedPointFormats(t *testing.T) {
-
 	rawExtensionSupportedPointFormats := []byte{0x00, 0x0b, 0x00, 0x02, 0x01, 0x00}
 	parsedExtensionSupportedPointFormats := &extensionSupportedPointFormats{
 		pointFormats: []ellipticCurvePointFormat{ellipticCurvePointFormatUncompressed},

--- a/extension_supported_signature_algorithms_test.go
+++ b/extension_supported_signature_algorithms_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestExtensionSupportedSignatureAlgorithms(t *testing.T) {
-
 	rawExtensionSupportedSignatureAlgorithms := []byte{
 		0x00, 0x0d,
 		0x00, 0x08,

--- a/internal/udp/conn.go
+++ b/internal/udp/conn.go
@@ -1,3 +1,4 @@
+// Package udp provides a connection-oriented listener over a UDP PacketConn
 package udp
 
 import (


### PR DESCRIPTION
Fix whitespace and stylecheck error.
Disable godox.

preparing https://github.com/pion/.goassets/pull/4