### PR TITLE
Make Listener compatible with net.Listener

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -71,7 +71,7 @@ func assertE2ECommunication(clientConfig, serverConfig *dtls.Config, serverPort 
 		clientConn       net.Conn
 		serverMutex      sync.Mutex
 		serverConn       net.Conn
-		serverListener   *dtls.Listener
+		serverListener   net.Listener
 		serverReady      = make(chan struct{})
 		errChan          = make(chan error)
 		clientChan       = make(chan string)
@@ -141,7 +141,7 @@ func assertE2ECommunication(clientConfig, serverConfig *dtls.Config, serverPort 
 			t.Fatal(err)
 		}
 
-		if err := serverListener.Close(2 * time.Second); err != nil {
+		if err := serverListener.Close(); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -33,7 +33,7 @@ func main() {
 	listener, err := dtls.Listen("udp", addr, config)
 	util.Check(err)
 	defer func() {
-		util.Check(listener.Close(5 * time.Second))
+		util.Check(listener.Close())
 	}()
 
 	fmt.Println("Listening")

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -34,7 +34,7 @@ func main() {
 	listener, err := dtls.Listen("udp", addr, config)
 	util.Check(err)
 	defer func() {
-		util.Check(listener.Close(5 * time.Second))
+		util.Check(listener.Close())
 	}()
 
 	fmt.Println("Listening")

--- a/listener.go
+++ b/listener.go
@@ -2,13 +2,12 @@ package dtls
 
 import (
 	"net"
-	"time"
 
 	"github.com/pion/dtls/v2/internal/udp"
 )
 
 // Listen creates a DTLS listener
-func Listen(network string, laddr *net.UDPAddr, config *Config) (*Listener, error) {
+func Listen(network string, laddr *net.UDPAddr, config *Config) (net.Listener, error) {
 	if err := validateConfig(config); err != nil {
 		return nil, err
 	}
@@ -17,21 +16,21 @@ func Listen(network string, laddr *net.UDPAddr, config *Config) (*Listener, erro
 	if err != nil {
 		return nil, err
 	}
-	return &Listener{
+	return &listener{
 		config: config,
 		parent: parent,
 	}, nil
 }
 
 // Listener represents a DTLS listener
-type Listener struct {
+type listener struct {
 	config *Config
 	parent *udp.Listener
 }
 
 // Accept waits for and returns the next connection to the listener.
 // You have to either close or read on all connection that are created.
-func (l *Listener) Accept() (net.Conn, error) {
+func (l *listener) Accept() (net.Conn, error) {
 	c, err := l.parent.Accept()
 	if err != nil {
 		return nil, err
@@ -42,11 +41,11 @@ func (l *Listener) Accept() (net.Conn, error) {
 // Close closes the listener.
 // Any blocked Accept operations will be unblocked and return errors.
 // Already Accepted connections are not closed.
-func (l *Listener) Close(shutdownTimeout time.Duration) error {
-	return l.parent.Close(shutdownTimeout)
+func (l *listener) Close() error {
+	return l.parent.Close()
 }
 
 // Addr returns the listener's network address.
-func (l *Listener) Addr() net.Addr {
+func (l *listener) Addr() net.Addr {
 	return l.parent.Addr()
 }


### PR DESCRIPTION
Breaking changes:

1. Remove timeout argument from `listener.Close`
Already accepted connections should be active after `listener.Close()`.
Previously, the connections were broken after the timeout.
In the new implementation, `readLoop` routine is remained after
`listener.Close()` and automatically stopped after closing
all connections. The final `conn.Close()` returns after stopping
the routine.

2. ~Return "use of closed connection" error~
~Double `Close()` calls returned `nil`, and `Write()` to closed connection
returned `io.EOF`. Return `"use of closed connection"` error on them to
make the behaviour close to `tls.Conn`.~

3. Unexpose listener implementation
Return as `net.Listener` interface instead of `*dtls.Listener`.

### Reference issue
Part of #148
