### PR TITLE
Fix CipherSuite handlings

### DIFF
--- a/client_handlers.go
+++ b/client_handlers.go
@@ -35,10 +35,6 @@ func initalizeCipherSuite(c *Conn, h *handshakeMessageServerKeyExchange) (*alert
 		}
 	}
 
-	if err = c.state.cipherSuite.init(c.state.masterSecret, clientRandom, serverRandom /* isClient */, true); err != nil {
-		return &alert{alertLevelFatal, alertInternalError}, err
-	}
-
 	if c.localPSKCallback == nil {
 		expectedHash := valueKeySignature(clientRandom, serverRandom, h.publicKey, h.namedCurve, h.hashAlgorithm)
 		if err = verifyKeySignature(expectedHash, h.signature, h.hashAlgorithm, c.state.remoteCertificate); err != nil {
@@ -55,6 +51,10 @@ func initalizeCipherSuite(c *Conn, h *handshakeMessageServerKeyExchange) (*alert
 				return &alert{alertLevelFatal, alertBadCertificate}, err
 			}
 		}
+	}
+
+	if err = c.state.cipherSuite.init(c.state.masterSecret, clientRandom, serverRandom /* isClient */, true); err != nil {
+		return &alert{alertLevelFatal, alertInternalError}, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
### Verify key before initializing CipherSuite
As soon as running c.state.cipherSuite.init(),
CipherSuite.isInitialized() returns true.
Incoming packets arriving before finishing initalizeCipherSuite()
was decrypted before verifying PSK.

### Fix data race in CipherSuites
init() and decrypt()/encrypt() could be concurrently called.
Protect concurrent access to cbc/gcm/ccm pointer.