### PR TITLE
Support context.Context based cancellation

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,21 +83,13 @@ type Config struct {
 
 	LoggerFactory logging.LoggerFactory
 
-	// ConnectTimeout is the timeout threshold for new connection handshakes
-	// to complete (default is 30 seconds)
-	ConnectTimeout *time.Duration
-
 	// MTU is the length at which handshake messages will be fragmented to
 	// fit within the maximum transmission unit (default is 1200 bytes)
 	MTU int
 }
 
-const defaultConnectTimeout = 30 * time.Second
-
-// ConnectTimeoutOption simply provides a wrapper for creating a *time.Duration
-func ConnectTimeoutOption(timeout time.Duration) *time.Duration {
-	return &timeout
-}
+// DefaultConnectTimeout is a timeout duration used in Dial(), Client() and Server().
+const DefaultConnectTimeout = 30 * time.Second
 
 const defaultMTU = 1200 // bytes
 

--- a/conn.go
+++ b/conn.go
@@ -216,30 +216,30 @@ func createConn(ctx context.Context, nextConn net.Conn, flightHandler flightHand
 }
 
 // Dial connects to the given network address and establishes a DTLS connection on top.
-// Connection handshake will timeout in DefaultConnectTimeout.
+// Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use DialWithContext() instead.
 func Dial(network string, raddr *net.UDPAddr, config *Config) (*Conn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultConnectTimeout)
+	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
 	return DialWithContext(ctx, network, raddr, config)
 }
 
 // Client establishes a DTLS connection over an existing connection.
-// Connection handshake will timeout in DefaultConnectTimeout.
+// Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use ClientWithContext() instead.
 func Client(conn net.Conn, config *Config) (*Conn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultConnectTimeout)
+	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
 	return ClientWithContext(ctx, conn, config)
 }
 
 // Server listens for incoming DTLS connections.
-// Connection handshake will timeout in DefaultConnectTimeout.
+// Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use ServerWithContext() instead.
 func Server(conn net.Conn, config *Config) (*Conn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultConnectTimeout)
+	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
 	return ServerWithContext(ctx, conn, config)

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -1,0 +1,146 @@
+// +build !js
+
+package dtls
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
+)
+
+func TestContextConfig(t *testing.T) {
+	addrListen, err := net.ResolveUDPAddr("udp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Dummy listener
+	listen, err := net.ListenUDP("udp", addrListen)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer func() {
+		_ = listen.Close()
+	}()
+	addr := listen.LocalAddr().(*net.UDPAddr)
+
+	cert, err := selfsign.GenerateSelfSigned()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	config := &Config{
+		ConnectContextMaker: func() (context.Context, func()) {
+			return context.WithTimeout(context.Background(), 40*time.Millisecond)
+		},
+		Certificates: []tls.Certificate{cert},
+	}
+
+	dials := map[string]struct {
+		f     func() (net.Conn, error)
+		order []byte
+	}{
+		"Dial": {
+			f: func() (net.Conn, error) {
+				return Dial("udp", addr, config)
+			},
+			order: []byte{0, 1, 2},
+		},
+		"DialWithContext": {
+			f: func() (net.Conn, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+				defer cancel()
+				return DialWithContext(ctx, "udp", addr, config)
+			},
+			order: []byte{0, 2, 1},
+		},
+		"Client": {
+			f: func() (net.Conn, error) {
+				ca, _ := net.Pipe()
+				defer func() {
+					_ = ca.Close()
+				}()
+				return Client(ca, config)
+			},
+			order: []byte{0, 1, 2},
+		},
+		"ClientWithContext": {
+			f: func() (net.Conn, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+				defer cancel()
+				ca, _ := net.Pipe()
+				defer func() {
+					_ = ca.Close()
+				}()
+				return ClientWithContext(ctx, ca, config)
+			},
+			order: []byte{0, 2, 1},
+		},
+		"Server": {
+			f: func() (net.Conn, error) {
+				ca, _ := net.Pipe()
+				defer func() {
+					_ = ca.Close()
+				}()
+				return Server(ca, config)
+			},
+			order: []byte{0, 1, 2},
+		},
+		"ServerWithContext": {
+			f: func() (net.Conn, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+				defer cancel()
+				ca, _ := net.Pipe()
+				defer func() {
+					_ = ca.Close()
+				}()
+				return ServerWithContext(ctx, ca, config)
+			},
+			order: []byte{0, 2, 1},
+		},
+	}
+
+	for name, dial := range dials {
+		dial := dial
+		t.Run(name, func(t *testing.T) {
+			done := make(chan struct{})
+
+			go func() {
+				conn, err := dial.f()
+				if err != errConnectTimeout {
+					t.Errorf("Expected error: '%v', got: '%v'", errConnectTimeout, err)
+					close(done)
+					return
+				}
+				done <- struct{}{}
+				_ = conn.Close()
+			}()
+
+			var order []byte
+			early := time.After(30 * time.Millisecond)
+			late := time.After(50 * time.Millisecond)
+			func() {
+				for len(order) < 3 {
+					select {
+					case <-early:
+						order = append(order, 0)
+					case _, ok := <-done:
+						if !ok {
+							return
+						}
+						order = append(order, 1)
+					case <-late:
+						order = append(order, 2)
+					}
+				}
+			}()
+			if !bytes.Equal(dial.order, order) {
+				t.Errorf("Invalid cancel timing, expected: %v, got: %v", dial.order, order)
+			}
+		})
+	}
+}

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -102,7 +102,7 @@ func TestPionE2ELossy(t *testing.T) {
 			DoClientAuth:    true,
 		},
 	} {
-		name := fmt.Sprintf("Loss%dMTU%d", test.LossChanceRange, test.MTU)
+		name := fmt.Sprintf("Loss%d_MTU%d", test.LossChanceRange, test.MTU)
 		if test.DoClientAuth {
 			name += "_WithCliAuth"
 		}

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,11 @@
 package dtls
 
-import "errors"
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/xerrors"
+)
 
 // Typed errors
 var (
@@ -50,11 +55,13 @@ var (
 	errNoAvailableCipherSuites           = errors.New("dtls: Connection can not be created, no CipherSuites satisfy this Config")
 	errInvalidClientKeyExchange          = errors.New("dtls: Unable to determine if ClientKeyExchange is a public key or PSK Identity")
 	errNoSupportedEllipticCurves         = errors.New("dtls: Client requested zero or more elliptic curves that are not supported by the server")
-	errConnectTimeout                    = errors.New("dtls: The connection timed out during the handshake")
 	errRequestedButNoSRTPExtension       = errors.New("dtls: SRTP support was requested but server did not respond with use_srtp extension")
 	errClientNoMatchingSRTPProfile       = errors.New("dtls: Server responded with SRTP Profile we do not support")
 	errServerNoMatchingSRTPProfile       = errors.New("dtls: Client requested SRTP but we have no matching profiles")
 	errServerRequiredButNoClientEMS      = errors.New("dtls: Server requires the Extended Master Secret extension, but the client does not support it")
 	errClientRequiredButNoServerEMS      = errors.New("dtls: Client required Extended Master Secret extension, but server does not support it")
 	errInvalidCertificate                = errors.New("dtls: No certificate provided")
+
+	// Wrapped errors
+	errConnectTimeout = xerrors.Errorf("dtls: The connection timed out during the handshake: %w", context.DeadlineExceeded)
 )

--- a/examples/dial-psk/main.go
+++ b/examples/dial-psk/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -26,11 +27,12 @@ func main() {
 		PSKIdentityHint:      []byte("Pion DTLS Server"),
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	dtlsConn, err := dtls.DialWithContext(ctx, "udp", addr, config)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/dial/main.go
+++ b/examples/dial/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -28,11 +29,12 @@ func main() {
 		Certificates:         []tls.Certificate{certificate},
 		InsecureSkipVerify:   true,
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	dtlsConn, err := dtls.DialWithContext(ctx, "udp", addr, config)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/pion/dtls/v2"
 	"github.com/pion/dtls/v2/examples/util"
@@ -26,7 +25,6 @@ func main() {
 		PSKIdentityHint:      []byte("Pion DTLS Client"),
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/pion/dtls/v2"
 	"github.com/pion/dtls/v2/examples/util"
@@ -27,7 +26,6 @@ func main() {
 	config := &dtls.Config{
 		Certificates:         []tls.Certificate{certificate},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		ConnectTimeout:       dtls.ConnectTimeoutOption(30 * time.Second),
 	}
 
 	// Connect to a DTLS server

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/pion/transport v0.8.10
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/listener.go
+++ b/listener.go
@@ -22,7 +22,7 @@ func Listen(network string, laddr *net.UDPAddr, config *Config) (net.Listener, e
 	}, nil
 }
 
-// Listener represents a DTLS listener
+// listener represents a DTLS listener
 type listener struct {
 	config *Config
 	parent *udp.Listener
@@ -30,6 +30,8 @@ type listener struct {
 
 // Accept waits for and returns the next connection to the listener.
 // You have to either close or read on all connection that are created.
+// Connection handshake will timeout using ConnectContextMaker in the Config.
+// If you want to specify the timeout duration, set ConnectContextMaker.
 func (l *listener) Accept() (net.Conn, error) {
 	c, err := l.parent.Accept()
 	if err != nil {

--- a/resume.go
+++ b/resume.go
@@ -1,6 +1,7 @@
 package dtls
 
 import (
+	"context"
 	"net"
 )
 
@@ -27,7 +28,7 @@ func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
 		return nil, nil
 	}
 
-	c, err := createConn(conn, flightHandler, handshakeHandler, config, state.isClient)
+	c, err := createConn(context.Background(), conn, flightHandler, handshakeHandler, config, state.isClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`DialWithContext()`, `ClientWithContext()` and `ServerWithContext()`
are added. Instead, `ConnectTimeout` is dropped from `Config`.

### Reference issue
Closes #189 
