### PR TITLE
Send close_notify as warning level

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -778,7 +778,7 @@ func (c *Conn) startHandshakeOutbound() {
 
 func (c *Conn) close() error {
 	if c.connectionClosed.Err() == nil && c.handshakeErr.load() == nil {
-		c.notify(alertLevelFatal, alertCloseNotify) //nolint
+		c.notify(alertLevelWarning, alertCloseNotify) //nolint
 	}
 
 	c.workerTicker.Stop()


### PR DESCRIPTION
OpenSSL sends close_notify as warning level and expects that incoming close_notify is warning level, so, OpenSSL showed close_notify from pion/dtls as an error.

close_notify was specified as warning level in TLS 1.0 RFC2246. Later TLS 1.1/1.2 RFC4346/5246 doesn't explicitly specify the level of close_notify, but they don't deny TLS 1.0's spec.

### Reference issue
Fixes #195
