### PR TITLE
Remove CCM from default cipher suites

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -119,8 +119,6 @@ func defaultCipherSuites() []cipherSuite {
 		&cipherSuiteTLSEcdheRsaWithAes128GcmSha256{},
 		&cipherSuiteTLSEcdheEcdsaWithAes256CbcSha{},
 		&cipherSuiteTLSEcdheRsaWithAes256CbcSha{},
-		newCipherSuiteTLSEcdheEcdsaWithAes128Ccm(),
-		newCipherSuiteTLSEcdheEcdsaWithAes128Ccm8(),
 	}
 }
 


### PR DESCRIPTION
If users want CCM they need to explicitly request it.

Resolves #199