### PR TITLE
Limit retransmit interval of last flight

### DIFF
--- a/handshaker.go
+++ b/handshaker.go
@@ -283,6 +283,7 @@ func (s *handshakeFSM) finish(ctx context.Context, c flightConn) (handshakeState
 		return handshakeErrored, errFlight
 	}
 
+	retransmitTimer := time.NewTimer(s.cfg.retransmitInterval)
 	select {
 	case done := <-c.recvHandshake():
 		nextFlight, alert, err := parse(ctx, c, s.state, s.cache, s.cfg)
@@ -300,6 +301,7 @@ func (s *handshakeFSM) finish(ctx context.Context, c flightConn) (handshakeState
 		if nextFlight == 0 {
 			break
 		}
+		<-retransmitTimer.C
 		// Retransmit last flight
 		return handshakeSending, nil
 

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pion/transport/test"
 )
 
+const nonZeroRetransmitInterval = 100 * time.Millisecond
+
 func TestHandshaker(t *testing.T) {
 	// Check for leaking routines
 	report := test.CheckRoutines(t)
@@ -37,6 +39,7 @@ func TestHandshaker(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
+
 	ctxCliFinished, cancelCli := context.WithCancel(ctx)
 	ctxSrvFinished, cancelSrv := context.WithCancel(ctx)
 	go func() {
@@ -51,6 +54,7 @@ func TestHandshaker(t *testing.T) {
 					cancelCli()
 				}
 			},
+			retransmitInterval: nonZeroRetransmitInterval,
 		}
 
 		fsm := newHandshakeFSM(&ca.state, ca.handshakeCache, cfg, flight1)


### PR DESCRIPTION
Also fix retransmit interval parameter in TestHandshaker. It sometimes caused WASM test failure.
