### PR TITLE
Fix flaky test on WASM environment

### DIFF
--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -172,6 +172,9 @@ func (c *flightTestConn) writePackets(ctx context.Context, pkts []*packet) error
 		}
 	}()
 
+	// Avoid deadlock on JS/WASM environment due to context switch problem.
+	time.Sleep(10 * time.Millisecond)
+
 	return nil
 }
 


### PR DESCRIPTION
In JS/WASM environment, select loop without sleep seems causing deadlock. Add sleep to trigger context switch.

### Reference issue
Same fix as #173
