### PR TITLE
Add packet validations

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -452,6 +452,12 @@ func (c *Conn) processPacket(p *packet) ([]byte, error) {
 		c.state.localSequenceNumber = append(c.state.localSequenceNumber, uint64(0))
 	}
 	seq := atomic.AddUint64(&c.state.localSequenceNumber[epoch], 1) - 1
+	if seq > maxSequenceNumber {
+		// RFC 6347 Section 4.1.0
+		// The implementation must either abandon an association or rehandshake
+		// prior to allowing the sequence number to wrap.
+		return nil, errSequenceNumberOverflow
+	}
 	p.record.recordLayerHeader.sequenceNumber = seq
 
 	rawPacket, err := p.record.Marshal()
@@ -484,6 +490,9 @@ func (c *Conn) processHandshakePacket(p *packet, h *handshake) ([][]byte, error)
 
 	for _, handshakeFragment := range handshakeFragments {
 		seq := atomic.AddUint64(&c.state.localSequenceNumber[epoch], 1) - 1
+		if seq > maxSequenceNumber {
+			return nil, errSequenceNumberOverflow
+		}
 
 		recordLayerHeader := &recordLayerHeader{
 			contentType:     p.record.recordLayerHeader.contentType,

--- a/errors.go
+++ b/errors.go
@@ -57,6 +57,7 @@ var (
 	errNoCertificates                   = &ErrFatal{errors.New("no certificates configured")}
 	errNoConfigProvided                 = &ErrFatal{errors.New("no config provided")}
 	errNoSupportedEllipticCurves        = &ErrFatal{errors.New("client requested zero or more elliptic curves that are not supported by the server")}
+	errUnsupportedProtocolVersion       = &ErrFatal{errors.New("unsupported protocol version")}
 	errPSKAndCertificate                = &ErrFatal{errors.New("Certificate and PSK provided")} // nolint:stylecheck
 	errPSKAndIdentityMustBeSetForClient = &ErrFatal{errors.New("PSK and PSK Identity Hint must both be set for client")}
 	errRequestedButNoSRTPExtension      = &ErrFatal{errors.New("SRTP support was requested but server did not respond with use_srtp extension")}

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -24,6 +24,10 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		return 0, &alert{alertLevelFatal, alertInternalError}, nil
 	}
 
+	if !clientHello.version.Equal(protocolVersion1_2) {
+		return 0, &alert{alertLevelFatal, alertProtocolVersion}, errUnsupportedProtocolVersion
+	}
+
 	state.remoteRandom = clientHello.random
 
 	if _, ok := findMatchingCipherSuite(clientHello.cipherSuites, cfg.localCipherSuites); !ok {

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -18,6 +18,9 @@ func flight1Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	state.handshakeRecvSequence = seq
 
 	if h, ok := msgs[handshakeTypeHelloVerifyRequest].(*handshakeMessageHelloVerifyRequest); ok {
+		if !h.version.Equal(protocolVersion1_2) {
+			return 0, &alert{alertLevelFatal, alertProtocolVersion}, errUnsupportedProtocolVersion
+		}
 		state.cookie = append([]byte{}, h.cookie...)
 		return flight3, nil, nil
 	}

--- a/flight2handler.go
+++ b/flight2handler.go
@@ -22,6 +22,10 @@ func flight2Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		return 0, &alert{alertLevelFatal, alertInternalError}, nil
 	}
 
+	if !clientHello.version.Equal(protocolVersion1_2) {
+		return 0, &alert{alertLevelFatal, alertProtocolVersion}, errUnsupportedProtocolVersion
+	}
+
 	if len(clientHello.cookie) == 0 {
 		return 0, nil, nil
 	}

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -31,6 +31,9 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	state.handshakeRecvSequence = seq
 
 	if h, ok := msgs[handshakeTypeServerHello].(*handshakeMessageServerHello); ok {
+		if !h.version.Equal(protocolVersion1_2) {
+			return 0, &alert{alertLevelFatal, alertProtocolVersion}, errUnsupportedProtocolVersion
+		}
 		for _, extension := range h.extensions {
 			switch e := extension.(type) {
 			case *extensionUseSRTP:

--- a/record_layer_header.go
+++ b/record_layer_header.go
@@ -29,6 +29,10 @@ type protocolVersion struct {
 	major, minor uint8
 }
 
+func (v protocolVersion) Equal(x protocolVersion) bool {
+	return v.major == x.major && v.minor == x.minor
+}
+
 func (r *recordLayerHeader) Marshal() ([]byte, error) {
 	if r.sequenceNumber > maxSequenceNumber {
 		return nil, errSequenceNumberOverflow


### PR DESCRIPTION
Branched from #209 in order to add an error.
- Close on outgoing sequence number overflow [RFC 6347 Section 4.1]
- Verify protocol version

### Reference issue
Fixes #3
