### PR TITLE
Fix E2E test stability

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -220,8 +220,6 @@ func testPionE2ESimple(t *testing.T, server, client func(*comm)) {
 	report := test.CheckRoutines(t)
 	defer report()
 
-	serverPort := randomPort(t)
-
 	for _, cipherSuite := range []dtls.CipherSuiteID{
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
@@ -241,6 +239,7 @@ func testPionE2ESimple(t *testing.T, server, client func(*comm)) {
 				CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
 				InsecureSkipVerify: true,
 			}
+			serverPort := randomPort(t)
 			comm := newComm(ctx, cfg, cfg, serverPort, server, client)
 			comm.assert(t)
 		})
@@ -253,8 +252,6 @@ func testPionE2ESimplePSK(t *testing.T, server, client func(*comm)) {
 
 	report := test.CheckRoutines(t)
 	defer report()
-
-	serverPort := randomPort(t)
 
 	for _, cipherSuite := range []dtls.CipherSuiteID{
 		dtls.TLS_PSK_WITH_AES_128_CCM,
@@ -273,6 +270,7 @@ func testPionE2ESimplePSK(t *testing.T, server, client func(*comm)) {
 				PSKIdentityHint: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
 				CipherSuites:    []dtls.CipherSuiteID{cipherSuite},
 			}
+			serverPort := randomPort(t)
 			comm := newComm(ctx, cfg, cfg, serverPort, server, client)
 			comm.assert(t)
 		})
@@ -285,8 +283,6 @@ func testPionE2EMTUs(t *testing.T, server, client func(*comm)) {
 
 	report := test.CheckRoutines(t)
 	defer report()
-
-	serverPort := randomPort(t)
 
 	for _, mtu := range []int{
 		10000,
@@ -309,6 +305,7 @@ func testPionE2EMTUs(t *testing.T, server, client func(*comm)) {
 				InsecureSkipVerify: true,
 				MTU:                mtu,
 			}
+			serverPort := randomPort(t)
 			comm := newComm(ctx, cfg, cfg, serverPort, server, client)
 			comm.assert(t)
 		})

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -112,19 +112,16 @@ func (c *comm) assert(t *testing.T) {
 	go c.server(c)
 
 	defer func() {
-		c.clientMutex.Lock()
-		c.serverMutex.Lock()
-		defer c.clientMutex.Unlock()
-		defer c.serverMutex.Unlock()
-
-		if err := c.clientConn.Close(); err != nil {
-			t.Fatal(err)
+		if c.clientConn != nil {
+			if err := c.clientConn.Close(); err != nil {
+				t.Fatal(err)
+			}
 		}
-
-		if err := c.serverConn.Close(); err != nil {
-			t.Fatal(err)
+		if c.serverConn != nil {
+			if err := c.serverConn.Close(); err != nil {
+				t.Fatal(err)
+			}
 		}
-
 		if c.serverListener != nil {
 			if err := c.serverListener.Close(); err != nil {
 				t.Fatal(err)

--- a/e2e/e2e_v113_test.go
+++ b/e2e/e2e_v113_test.go
@@ -26,8 +26,6 @@ func testPionE2ESimpleED25519(t *testing.T, server, client func(*comm)) {
 	report := test.CheckRoutines(t)
 	defer report()
 
-	serverPort := randomPort(t)
-
 	for _, cipherSuite := range []dtls.CipherSuiteID{
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
@@ -53,6 +51,7 @@ func testPionE2ESimpleED25519(t *testing.T, server, client func(*comm)) {
 				CipherSuites:       []dtls.CipherSuiteID{cipherSuite},
 				InsecureSkipVerify: true,
 			}
+			serverPort := randomPort(t)
 			comm := newComm(ctx, cfg, cfg, serverPort, server, client)
 			comm.assert(t)
 		})


### PR DESCRIPTION
- Fix panic on E2E test failure
    Fix deadlock and nil pointer dereference on server/client initialization failure.
- Minimize the chance of port conflict on E2E tests
    Select port immediately before starting the test.

### Reference issue
Fixes #178