### PR TITLE
Fix hash algorithm selection

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,6 +24,9 @@ type Config struct {
 	// If CipherSuites is nil, a default list is used
 	CipherSuites []CipherSuiteID
 
+	// SignatureSchemes contains the signature and hash schemes that the peer requests to verify.
+	SignatureSchemes []tls.SignatureScheme
+
 	// SRTPProtectionProfiles are the supported protection profiles
 	// Clients will send this via use_srtp and assert that the server properly responds
 	// Servers will assert that clients send one of these profiles and will respond as needed

--- a/conn.go
+++ b/conn.go
@@ -84,6 +84,11 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		return nil, err
 	}
 
+	signatureSchemes, err := parseSignatureSchemes(config.SignatureSchemes)
+	if err != nil {
+		return nil, err
+	}
+
 	workerInterval := initialTickerInterval
 	if config.FlightInterval != 0 {
 		workerInterval = config.FlightInterval
@@ -150,6 +155,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		localPSKCallback:            config.PSK,
 		localPSKIdentityHint:        config.PSKIdentityHint,
 		localCipherSuites:           cipherSuites,
+		localSignatureSchemes:       signatureSchemes,
 		extendedMasterSecret:        config.ExtendedMasterSecret,
 		localSRTPProtectionProfiles: config.SRTPProtectionProfiles,
 		serverName:                  serverName,

--- a/e2e/e2e_openssl_v113_test.go
+++ b/e2e/e2e_openssl_v113_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPionOpenSSLE2ESimpleED25519(t *testing.T) {
-	t.Skip("TODO: make ED25519 test work with openssl")
+	t.Skip("TODO: waiting OpenSSL's DTLS Ed25519 support")
 	t.Run("OpenSSLServer", func(t *testing.T) {
 		testPionE2ESimpleED25519(t, serverOpenSSL, clientPion)
 	})

--- a/errors.go
+++ b/errors.go
@@ -54,6 +54,7 @@ var (
 	errKeySignatureMismatch             = &ErrFatal{errors.New("expected and actual key signature do not match")}
 	errNilNextConn                      = &ErrFatal{errors.New("Conn can not be created with a nil nextConn")}
 	errNoAvailableCipherSuites          = &ErrFatal{errors.New("connection can not be created, no CipherSuites satisfy this Config")}
+	errNoAvailableSignatureSchemes      = &ErrFatal{errors.New("connection can not be created, no SignatureScheme satisfy this Config")}
 	errNoCertificates                   = &ErrFatal{errors.New("no certificates configured")}
 	errNoConfigProvided                 = &ErrFatal{errors.New("no config provided")}
 	errNoSupportedEllipticCurves        = &ErrFatal{errors.New("client requested zero or more elliptic curves that are not supported by the server")}

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -49,14 +49,7 @@ func flight1Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 
 	extensions := []extension{
 		&extensionSupportedSignatureAlgorithms{
-			signatureHashAlgorithms: []signatureHashAlgorithm{
-				{hashAlgorithmSHA256, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA384, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA512, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA256, signatureAlgorithmRSA},
-				{hashAlgorithmSHA384, signatureAlgorithmRSA},
-				{hashAlgorithmSHA512, signatureAlgorithmRSA},
-			},
+			signatureHashAlgorithms: cfg.localSignatureSchemes,
 		},
 	}
 	if cfg.localPSKCallback == nil {

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -106,14 +106,7 @@ func handleServerKeyExchange(_ flightConn, state *State, cfg *handshakeConfig, h
 func flight3Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert, error) {
 	extensions := []extension{
 		&extensionSupportedSignatureAlgorithms{
-			signatureHashAlgorithms: []signatureHashAlgorithm{
-				{hashAlgorithmSHA256, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA384, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA512, signatureAlgorithmECDSA},
-				{hashAlgorithmSHA256, signatureAlgorithmRSA},
-				{hashAlgorithmSHA384, signatureAlgorithmRSA},
-				{hashAlgorithmSHA512, signatureAlgorithmRSA},
-			},
+			signatureHashAlgorithms: cfg.localSignatureSchemes,
 		},
 	}
 	if cfg.localPSKCallback == nil {

--- a/handshaker.go
+++ b/handshaker.go
@@ -87,7 +87,8 @@ type handshakeFSM struct {
 type handshakeConfig struct {
 	localPSKCallback            PSKCallback
 	localPSKIdentityHint        []byte
-	localCipherSuites           []cipherSuite            // Available CipherSuites, if empty use default list
+	localCipherSuites           []cipherSuite            // Available CipherSuites
+	localSignatureSchemes       []signatureHashAlgorithm // Available signature schemes
 	extendedMasterSecret        ExtendedMasterSecretType // Policy for the Extended Master Support extension
 	localSRTPProtectionProfiles []SRTPProtectionProfile  // Available SRTPProtectionProfiles, if empty no SRTP support
 	serverName                  string

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -45,10 +45,11 @@ func TestHandshaker(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		cfg := &handshakeConfig{
-			localCipherSuites:  cipherSuites,
-			localCertificates:  []tls.Certificate{clientCert},
-			insecureSkipVerify: true,
-			log:                logger,
+			localCipherSuites:     cipherSuites,
+			localCertificates:     []tls.Certificate{clientCert},
+			localSignatureSchemes: defaultSignatureSchemes(),
+			insecureSkipVerify:    true,
+			log:                   logger,
 			onFlightState: func(f flightVal, s handshakeState) {
 				if s == handshakeFinished {
 					cancelCli()
@@ -70,10 +71,11 @@ func TestHandshaker(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		cfg := &handshakeConfig{
-			localCipherSuites:  cipherSuites,
-			localCertificates:  []tls.Certificate{clientCert},
-			insecureSkipVerify: true,
-			log:                logger,
+			localCipherSuites:     cipherSuites,
+			localCertificates:     []tls.Certificate{clientCert},
+			localSignatureSchemes: defaultSignatureSchemes(),
+			insecureSkipVerify:    true,
+			log:                   logger,
 			onFlightState: func(f flightVal, s handshakeState) {
 				if s == handshakeFinished {
 					cancelSrv()

--- a/hash_algorithm.go
+++ b/hash_algorithm.go
@@ -15,12 +15,13 @@ type hashAlgorithm uint16
 // Supported hash hash algorithms
 const (
 	// hashAlgorithmMD2    hashAlgorithm = 0 // Blacklisted
-	hashAlgorithmMD5    hashAlgorithm = 1 // Blacklisted
-	hashAlgorithmSHA1   hashAlgorithm = 2 // Blacklisted
-	hashAlgorithmSHA224 hashAlgorithm = 3
-	hashAlgorithmSHA256 hashAlgorithm = 4
-	hashAlgorithmSHA384 hashAlgorithm = 5
-	hashAlgorithmSHA512 hashAlgorithm = 6
+	hashAlgorithmMD5     hashAlgorithm = 1 // Blacklisted
+	hashAlgorithmSHA1    hashAlgorithm = 2 // Blacklisted
+	hashAlgorithmSHA224  hashAlgorithm = 3
+	hashAlgorithmSHA256  hashAlgorithm = 4
+	hashAlgorithmSHA384  hashAlgorithm = 5
+	hashAlgorithmSHA512  hashAlgorithm = 6
+	hashAlgorithmEd25519 hashAlgorithm = 8
 )
 
 // String makes hashAlgorithm printable
@@ -38,6 +39,8 @@ func (h hashAlgorithm) String() string {
 		return "sha-384" // [RFC4055]
 	case hashAlgorithmSHA512:
 		return "sha-512" // [RFC4055]
+	case hashAlgorithmEd25519:
+		return "null"
 	default:
 		return "unknown hash algorithm"
 	}
@@ -82,16 +85,19 @@ func (h hashAlgorithm) cryptoHash() crypto.Hash {
 		return crypto.SHA384
 	case hashAlgorithmSHA512:
 		return crypto.SHA512
+	case hashAlgorithmEd25519:
+		return crypto.Hash(0)
 	default:
 		return 0
 	}
 }
 
 var hashAlgorithms = map[hashAlgorithm]struct{}{
-	hashAlgorithmMD5:    {},
-	hashAlgorithmSHA1:   {},
-	hashAlgorithmSHA224: {},
-	hashAlgorithmSHA256: {},
-	hashAlgorithmSHA384: {},
-	hashAlgorithmSHA512: {},
+	hashAlgorithmMD5:     {},
+	hashAlgorithmSHA1:    {},
+	hashAlgorithmSHA224:  {},
+	hashAlgorithmSHA256:  {},
+	hashAlgorithmSHA384:  {},
+	hashAlgorithmSHA512:  {},
+	hashAlgorithmEd25519: {},
 }

--- a/hash_algorithm_test.go
+++ b/hash_algorithm_test.go
@@ -8,6 +8,10 @@ import (
 
 func TestHashAlgorithm_StringRoundtrip(t *testing.T) {
 	for algo := range hashAlgorithms {
+		if algo == hashAlgorithmEd25519 {
+			// Ed25519 does hashing and signing in one time.
+			continue
+		}
 		str := algo.String()
 		hash1 := algo.cryptoHash()
 		hash2, err := fingerprint.HashFromString(str)

--- a/signature_algorithm.go
+++ b/signature_algorithm.go
@@ -4,11 +4,13 @@ package dtls
 type signatureAlgorithm uint16
 
 const (
-	signatureAlgorithmRSA   signatureAlgorithm = 1
-	signatureAlgorithmECDSA signatureAlgorithm = 3
+	signatureAlgorithmRSA     signatureAlgorithm = 1
+	signatureAlgorithmECDSA   signatureAlgorithm = 3
+	signatureAlgorithmEd25519 signatureAlgorithm = 7
 )
 
 var signatureAlgorithms = map[signatureAlgorithm]bool{
-	signatureAlgorithmRSA:   true,
-	signatureAlgorithmECDSA: true,
+	signatureAlgorithmRSA:     true,
+	signatureAlgorithmECDSA:   true,
+	signatureAlgorithmEd25519: true,
 }

--- a/signature_hash_algorithm.go
+++ b/signature_hash_algorithm.go
@@ -1,6 +1,80 @@
 package dtls
 
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/xerrors"
+)
+
 type signatureHashAlgorithm struct {
 	hash      hashAlgorithm
 	signature signatureAlgorithm
+}
+
+func defaultSignatureSchemes() []signatureHashAlgorithm {
+	return []signatureHashAlgorithm{
+		{hashAlgorithmSHA256, signatureAlgorithmECDSA},
+		{hashAlgorithmSHA384, signatureAlgorithmECDSA},
+		{hashAlgorithmSHA512, signatureAlgorithmECDSA},
+		{hashAlgorithmSHA256, signatureAlgorithmRSA},
+		{hashAlgorithmSHA384, signatureAlgorithmRSA},
+		{hashAlgorithmSHA512, signatureAlgorithmRSA},
+		{hashAlgorithmEd25519, signatureAlgorithmEd25519},
+	}
+}
+
+// select Signature Scheme returns most preferred and compatible scheme.
+func selectSignatureScheme(sigs []signatureHashAlgorithm, privateKey crypto.PrivateKey) (signatureHashAlgorithm, error) {
+	for _, ss := range sigs {
+		if ss.isCompatible(privateKey) {
+			return ss, nil
+		}
+	}
+	return signatureHashAlgorithm{}, errNoAvailableSignatureSchemes
+}
+
+// isCompatible checks that given private key is compatible with the signature scheme.
+func (s *signatureHashAlgorithm) isCompatible(privateKey crypto.PrivateKey) bool {
+	switch privateKey.(type) {
+	case ed25519.PrivateKey:
+		return s.signature == signatureAlgorithmEd25519
+	case *ecdsa.PrivateKey:
+		return s.signature == signatureAlgorithmECDSA
+	case *rsa.PrivateKey:
+		return s.signature == signatureAlgorithmRSA
+	default:
+		return false
+	}
+}
+
+// parseSignatureSchemes translates []tls.SignatureScheme to []signatureHashAlgorithm.
+// It returns default signature scheme list if no SignatureScheme is passed.
+func parseSignatureSchemes(sigs []tls.SignatureScheme) ([]signatureHashAlgorithm, error) {
+	if len(sigs) == 0 {
+		return defaultSignatureSchemes(), nil
+	}
+	out := []signatureHashAlgorithm{}
+	for _, ss := range sigs {
+		sig := signatureAlgorithm(ss & 0xFF)
+		if _, ok := signatureAlgorithms[sig]; !ok {
+			return nil, &ErrFatal{
+				xerrors.Errorf("SignatureScheme %04x: %w", ss, errInvalidSignatureAlgorithm),
+			}
+		}
+		h := hashAlgorithm(ss >> 8)
+		if _, ok := hashAlgorithms[h]; !ok {
+			return nil, &ErrFatal{
+				xerrors.Errorf("SignatureScheme %04x: %w", ss, errInvalidHashAlgorithm),
+			}
+		}
+		out = append(out, signatureHashAlgorithm{
+			hash:      h,
+			signature: sig,
+		})
+	}
+	return out, nil
 }

--- a/signature_hash_algorithm_go113_test.go
+++ b/signature_hash_algorithm_go113_test.go
@@ -1,0 +1,42 @@
+// +build go1.13
+
+package dtls
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+func TestParseSignatureSchemes_Ed25519(t *testing.T) {
+	cases := map[string]struct {
+		input    []tls.SignatureScheme
+		expected []signatureHashAlgorithm
+		err      error
+	}{
+		"Translate": {
+			input: []tls.SignatureScheme{
+				tls.Ed25519,
+			},
+			expected: []signatureHashAlgorithm{
+				{hashAlgorithmEd25519, signatureAlgorithmEd25519},
+			},
+			err: nil,
+		},
+	}
+
+	for name, testCase := range cases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			output, err := parseSignatureSchemes(testCase.input)
+			if testCase.err != nil && !xerrors.Is(err, testCase.err) {
+				t.Fatalf("Expected error: %v, got: %v", testCase.err, err)
+			}
+			if !reflect.DeepEqual(testCase.expected, output) {
+				t.Errorf("Expected signatureHashAlgorithm:\n%+v\ngot:\n%+v", testCase.expected, output)
+			}
+		})
+	}
+}

--- a/signature_hash_algorithm_test.go
+++ b/signature_hash_algorithm_test.go
@@ -1,0 +1,66 @@
+package dtls
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+func TestParseSignatureSchemes(t *testing.T) {
+	cases := map[string]struct {
+		input    []tls.SignatureScheme
+		expected []signatureHashAlgorithm
+		err      error
+	}{
+		"Translate": {
+			input: []tls.SignatureScheme{
+				tls.ECDSAWithP256AndSHA256,
+				tls.ECDSAWithP384AndSHA384,
+				tls.ECDSAWithP521AndSHA512,
+				tls.PKCS1WithSHA256,
+				tls.PKCS1WithSHA384,
+				tls.PKCS1WithSHA512,
+			},
+			expected: []signatureHashAlgorithm{
+				{hashAlgorithmSHA256, signatureAlgorithmECDSA},
+				{hashAlgorithmSHA384, signatureAlgorithmECDSA},
+				{hashAlgorithmSHA512, signatureAlgorithmECDSA},
+				{hashAlgorithmSHA256, signatureAlgorithmRSA},
+				{hashAlgorithmSHA384, signatureAlgorithmRSA},
+				{hashAlgorithmSHA512, signatureAlgorithmRSA},
+			},
+			err: nil,
+		},
+		"InvalidSignatureAlgorithm": {
+			input: []tls.SignatureScheme{
+				tls.ECDSAWithP256AndSHA256, // Valid
+				0x04FF,                     // Invalid: unknown signature with SHA-256
+			},
+			expected: nil,
+			err:      errInvalidSignatureAlgorithm,
+		},
+		"InvalidHashAlgorithm": {
+			input: []tls.SignatureScheme{
+				tls.ECDSAWithP256AndSHA256, // Valid
+				0x0003,                     // Invalid: ECDSA with MD2
+			},
+			expected: nil,
+			err:      errInvalidHashAlgorithm,
+		},
+	}
+
+	for name, testCase := range cases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			output, err := parseSignatureSchemes(testCase.input)
+			if testCase.err != nil && !xerrors.Is(err, testCase.err) {
+				t.Fatalf("Expected error: %v, got: %v", testCase.err, err)
+			}
+			if !reflect.DeepEqual(testCase.expected, output) {
+				t.Errorf("Expected signatureHashAlgorithm:\n%+v\ngot:\n%+v", testCase.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hash algorithm to verify the certificate was hardcoded to be SHA-256.
Fix to select valid hash which is compatible with the given key.
This also fixes Ed25519 signature calculation.
