### PR TITLE
Disable insecure hash algorithms by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	// This should be used only for testing.
 	InsecureSkipVerify bool
 
+	// InsecureHashes allows the use of hashing algorithms that are known
+	// to be vulnerable.
+	InsecureHashes bool
+
 	// VerifyPeerCertificate, if not nil, is called after normal
 	// certificate verification by either a client or server. It
 	// receives the certificate provided by the peer and also a flag

--- a/conn.go
+++ b/conn.go
@@ -83,7 +83,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		return nil, err
 	}
 
-	signatureSchemes, err := parseSignatureSchemes(config.SignatureSchemes)
+	signatureSchemes, err := parseSignatureSchemes(config.SignatureSchemes, config.InsecureHashes)
 	if err != nil {
 		return nil, err
 	}

--- a/hash_algorithm.go
+++ b/hash_algorithm.go
@@ -14,7 +14,7 @@ type hashAlgorithm uint16
 
 // Supported hash hash algorithms
 const (
-	// hashAlgorithmMD2    hashAlgorithm = 0 // Blacklisted
+	hashAlgorithmMD2     hashAlgorithm = 0 // Blacklisted
 	hashAlgorithmMD5     hashAlgorithm = 1 // Blacklisted
 	hashAlgorithmSHA1    hashAlgorithm = 2 // Blacklisted
 	hashAlgorithmSHA224  hashAlgorithm = 3
@@ -27,6 +27,8 @@ const (
 // String makes hashAlgorithm printable
 func (h hashAlgorithm) String() string {
 	switch h {
+	case hashAlgorithmMD2:
+		return "md2"
 	case hashAlgorithmMD5:
 		return "md5" // [RFC3279]
 	case hashAlgorithmSHA1:
@@ -42,7 +44,7 @@ func (h hashAlgorithm) String() string {
 	case hashAlgorithmEd25519:
 		return "null"
 	default:
-		return "unknown hash algorithm"
+		return "unknown or unsupported hash algorithm"
 	}
 }
 
@@ -71,6 +73,15 @@ func (h hashAlgorithm) digest(b []byte) []byte {
 	}
 }
 
+func (h hashAlgorithm) insecure() bool {
+	switch h {
+	case hashAlgorithmMD2, hashAlgorithmMD5, hashAlgorithmSHA1:
+		return true
+	default:
+		return false
+	}
+}
+
 func (h hashAlgorithm) cryptoHash() crypto.Hash {
 	switch h {
 	case hashAlgorithmMD5:
@@ -88,7 +99,7 @@ func (h hashAlgorithm) cryptoHash() crypto.Hash {
 	case hashAlgorithmEd25519:
 		return crypto.Hash(0)
 	default:
-		return 0
+		return crypto.Hash(0)
 	}
 }
 

--- a/signature_hash_algorithm_go113_test.go
+++ b/signature_hash_algorithm_go113_test.go
@@ -12,9 +12,10 @@ import (
 
 func TestParseSignatureSchemes_Ed25519(t *testing.T) {
 	cases := map[string]struct {
-		input    []tls.SignatureScheme
-		expected []signatureHashAlgorithm
-		err      error
+		input          []tls.SignatureScheme
+		expected       []signatureHashAlgorithm
+		err            error
+		insecureHashes bool
 	}{
 		"Translate": {
 			input: []tls.SignatureScheme{
@@ -23,14 +24,15 @@ func TestParseSignatureSchemes_Ed25519(t *testing.T) {
 			expected: []signatureHashAlgorithm{
 				{hashAlgorithmEd25519, signatureAlgorithmEd25519},
 			},
-			err: nil,
+			err:            nil,
+			insecureHashes: false,
 		},
 	}
 
 	for name, testCase := range cases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			output, err := parseSignatureSchemes(testCase.input)
+			output, err := parseSignatureSchemes(testCase.input, testCase.insecureHashes)
 			if testCase.err != nil && !xerrors.Is(err, testCase.err) {
 				t.Fatalf("Expected error: %v, got: %v", testCase.err, err)
 			}


### PR DESCRIPTION
We add a new option on the configuratio which toggles the use of hash
algorithms that are deemed insecure. We default to disallowing insecure
hash algorithms, MD2 (which we don't support at all), MD5 and SHA-1.

When parsing signature algorithms we check whether it's being passed an
insecure hash algorithm, and whether we are configured to allow it or
not. If we don't allow it, we omit adding it, to ensure we never
advertise this capability.