### PR TITLE
Fix listen example error handling

### DIFF
--- a/examples/listen-psk/main.go
+++ b/examples/listen-psk/main.go
@@ -61,7 +61,9 @@ func main() {
 			// functions like `RemoteCertificate` etc.
 
 			// Register the connection with the chat hub
-			hub.Register(conn)
+			if err == nil {
+				hub.Register(conn)
+			}
 		}
 	}()
 

--- a/examples/listen/main.go
+++ b/examples/listen/main.go
@@ -62,7 +62,9 @@ func main() {
 			// functions like `RemoteCertificate` etc.
 
 			// Register the connection with the chat hub
-			hub.Register(conn)
+			if err == nil {
+				hub.Register(conn)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Don't call `hub.Register` if `Accept` returned error.

### Reference issue
Fixes #234
