### PR TITLE
Add ConnectionState to Conn to return State

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -335,11 +335,12 @@ func (c *Conn) Close() error {
 	return err
 }
 
-// RemoteCertificate exposes the remote certificate
-func (c *Conn) RemoteCertificate() [][]byte {
+// ConnectionState returns basic DTLS details about the connection.
+// Note that this replaced the `Export` function of v1.
+func (c *Conn) ConnectionState() State {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.state.remoteCertificate
+	return *c.state.clone()
 }
 
 // SelectedSRTPProtectionProfile returns the selected SRTPProtectionProfile

--- a/conn_test.go
+++ b/conn_test.go
@@ -810,7 +810,8 @@ func TestClientCertificate(t *testing.T) {
 				if res.err != nil {
 					t.Errorf("Client failed(%v)", res.err)
 				}
-				actualClientCert := server.RemoteCertificate()
+
+				actualClientCert := server.ConnectionState().PeerCertificates
 				if tt.serverCfg.ClientAuth == RequireAnyClientCert || tt.serverCfg.ClientAuth == RequireAndVerifyClientCert {
 					if actualClientCert == nil {
 						t.Errorf("Client did not provide a certificate")
@@ -826,7 +827,7 @@ func TestClientCertificate(t *testing.T) {
 					}
 				}
 
-				actualServerCert := res.c.RemoteCertificate()
+				actualServerCert := res.c.ConnectionState().PeerCertificates
 				if actualServerCert == nil {
 					t.Errorf("Server did not provide a certificate")
 				}

--- a/examples/listen/psk/main.go
+++ b/examples/listen/psk/main.go
@@ -58,7 +58,7 @@ func main() {
 
 			// `conn` is of type `net.Conn` but may be casted to `dtls.Conn`
 			// using `dtlsConn := conn.(*dtls.Conn)` in order to to expose
-			// functions like `RemoteCertificate` etc.
+			// functions like `ConnectionState` etc.
 
 			// Register the connection with the chat hub
 			if err == nil {

--- a/examples/listen/selfsign/main.go
+++ b/examples/listen/selfsign/main.go
@@ -59,7 +59,7 @@ func main() {
 
 			// `conn` is of type `net.Conn` but may be casted to `dtls.Conn`
 			// using `dtlsConn := conn.(*dtls.Conn)` in order to to expose
-			// functions like `RemoteCertificate` etc.
+			// functions like `ConnectionState` etc.
 
 			// Register the connection with the chat hub
 			if err == nil {

--- a/examples/listen/verify/main.go
+++ b/examples/listen/verify/main.go
@@ -68,7 +68,7 @@ func main() {
 
 			// `conn` is of type `net.Conn` but may be casted to `dtls.Conn`
 			// using `dtlsConn := conn.(*dtls.Conn)` in order to to expose
-			// functions like `RemoteCertificate` etc.
+			// functions like `ConnectionState` etc.
 
 			// Register the connection with the chat hub
 			hub.Register(conn)

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -64,7 +64,7 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	}
 
 	if h, ok := msgs[handshakeTypeCertificate].(*handshakeMessageCertificate); ok {
-		state.remoteCertificate = h.certificate
+		state.PeerCertificates = h.certificate
 	}
 
 	if h, ok := msgs[handshakeTypeServerKeyExchange].(*handshakeMessageServerKeyExchange); ok {

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -23,11 +23,11 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	}
 
 	if h, hasCert := msgs[handshakeTypeCertificate].(*handshakeMessageCertificate); hasCert {
-		state.remoteCertificate = h.certificate
+		state.PeerCertificates = h.certificate
 	}
 
 	if h, hasCertVerify := msgs[handshakeTypeCertificateVerify].(*handshakeMessageCertificateVerify); hasCertVerify {
-		if state.remoteCertificate == nil {
+		if state.PeerCertificates == nil {
 			return 0, &alert{alertLevelFatal, alertNoCertificate}, errCertificateVerifyNoCertificate
 		}
 
@@ -54,24 +54,24 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			return 0, &alert{alertLevelFatal, alertInsufficientSecurity}, errNoAvailableSignatureSchemes
 		}
 
-		if err := verifyCertificateVerify(plainText, h.hashAlgorithm, h.signature, state.remoteCertificate); err != nil {
+		if err := verifyCertificateVerify(plainText, h.hashAlgorithm, h.signature, state.PeerCertificates); err != nil {
 			return 0, &alert{alertLevelFatal, alertBadCertificate}, err
 		}
 		var chains [][]*x509.Certificate
 		var err error
 		var verified bool
 		if cfg.clientAuth >= VerifyClientCertIfGiven {
-			if chains, err = verifyClientCert(state.remoteCertificate, cfg.clientCAs); err != nil {
+			if chains, err = verifyClientCert(state.PeerCertificates, cfg.clientCAs); err != nil {
 				return 0, &alert{alertLevelFatal, alertBadCertificate}, err
 			}
 			verified = true
 		}
 		if cfg.verifyPeerCertificate != nil {
-			if err := cfg.verifyPeerCertificate(state.remoteCertificate, chains); err != nil {
+			if err := cfg.verifyPeerCertificate(state.PeerCertificates, chains); err != nil {
 				return 0, &alert{alertLevelFatal, alertBadCertificate}, err
 			}
 		}
-		state.remoteCertificateVerified = verified
+		state.peerCertificatesVerified = verified
 	}
 
 	if !state.cipherSuite.isInitialized() {
@@ -137,18 +137,18 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 
 	switch cfg.clientAuth {
 	case RequireAnyClientCert:
-		if state.remoteCertificate == nil {
+		if state.PeerCertificates == nil {
 			return 0, &alert{alertLevelFatal, alertNoCertificate}, errClientCertificateRequired
 		}
 	case VerifyClientCertIfGiven:
-		if state.remoteCertificate != nil && !state.remoteCertificateVerified {
+		if state.PeerCertificates != nil && !state.peerCertificatesVerified {
 			return 0, &alert{alertLevelFatal, alertBadCertificate}, errClientCertificateNotVerified
 		}
 	case RequireAndVerifyClientCert:
-		if state.remoteCertificate == nil {
+		if state.PeerCertificates == nil {
 			return 0, &alert{alertLevelFatal, alertNoCertificate}, errClientCertificateRequired
 		}
-		if !state.remoteCertificateVerified {
+		if !state.peerCertificatesVerified {
 			return 0, &alert{alertLevelFatal, alertBadCertificate}, errClientCertificateNotVerified
 		}
 	}

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -287,17 +287,17 @@ func initalizeCipherSuite(state *State, cache *handshakeCache, cfg *handshakeCon
 		}
 
 		expectedMsg := valueKeyMessage(clientRandom[:], serverRandom[:], h.publicKey, h.namedCurve)
-		if err = verifyKeySignature(expectedMsg, h.signature, h.hashAlgorithm, state.remoteCertificate); err != nil {
+		if err = verifyKeySignature(expectedMsg, h.signature, h.hashAlgorithm, state.PeerCertificates); err != nil {
 			return &alert{alertLevelFatal, alertBadCertificate}, err
 		}
 		var chains [][]*x509.Certificate
 		if !cfg.insecureSkipVerify {
-			if chains, err = verifyServerCert(state.remoteCertificate, cfg.rootCAs, cfg.serverName); err != nil {
+			if chains, err = verifyServerCert(state.PeerCertificates, cfg.rootCAs, cfg.serverName); err != nil {
 				return &alert{alertLevelFatal, alertBadCertificate}, err
 			}
 		}
 		if cfg.verifyPeerCertificate != nil {
-			if err = cfg.verifyPeerCertificate(state.remoteCertificate, chains); err != nil {
+			if err = cfg.verifyPeerCertificate(state.PeerCertificates, chains); err != nil {
 				return &alert{alertLevelFatal, alertBadCertificate}, err
 			}
 		}

--- a/resume.go
+++ b/resume.go
@@ -5,13 +5,7 @@ import (
 	"net"
 )
 
-// Export extracts dtls state and inner connection from an already handshaked dtls conn
-func (c *Conn) Export() (*State, net.Conn, error) {
-	state := c.state.clone()
-	return state, c.nextConn.Conn(), nil
-}
-
-// Resume imports an already stablished dtls connection using a specific dtls state
+// Resume imports an already established dtls connection using a specific dtls state
 func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
 	if err := state.initCipherSuite(); err != nil {
 		return nil, err

--- a/resume_test.go
+++ b/resume_test.go
@@ -108,18 +108,12 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 		fatal(t, errChan, fmt.Errorf("messages missmatch: %s != %s", message, recv[:n]))
 	}
 
-	// Export dtls connection
-	var state *State
-	var innerConn net.Conn
-	state, innerConn, err = local.Export()
-	if err != nil {
-		fatal(t, errChan, err)
-	}
-	if err = innerConn.Close(); err != nil {
+	if err = localConn1.Close(); err != nil {
 		fatal(t, errChan, err)
 	}
 
 	// Serialize and deserialize state
+	state := local.ConnectionState()
 	var b []byte
 	b, err = state.MarshalBinary()
 	if err != nil {

--- a/state.go
+++ b/state.go
@@ -17,7 +17,7 @@ type State struct {
 	cipherSuite               cipherSuite // nil if a cipherSuite hasn't been chosen
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
-	remoteCertificate     [][]byte
+	PeerCertificates      [][]byte
 
 	isClient bool
 
@@ -34,7 +34,7 @@ type State struct {
 	localCertificatesVerify    []byte // cache CertificateVerify
 	localVerifyData            []byte // cached VerifyData
 	localKeySignature          []byte // cached keySignature
-	remoteCertificateVerified  bool
+	peerCertificatesVerified   bool
 
 	replayDetector []replaydetector.ReplayDetector
 }
@@ -48,7 +48,7 @@ type serializedState struct {
 	MasterSecret          []byte
 	SequenceNumber        uint64
 	SRTPProtectionProfile uint16
-	RemoteCertificate     [][]byte
+	PeerCertificates      [][]byte
 	IsClient              bool
 }
 
@@ -75,7 +75,7 @@ func (s *State) serialize() *serializedState {
 		LocalRandom:           localRnd,
 		RemoteRandom:          remoteRnd,
 		SRTPProtectionProfile: uint16(s.srtpProtectionProfile),
-		RemoteCertificate:     s.remoteCertificate,
+		PeerCertificates:      s.PeerCertificates,
 		IsClient:              s.isClient,
 	}
 }
@@ -111,7 +111,7 @@ func (s *State) deserialize(serialized serializedState) {
 	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)
 
 	// Set remote certificate
-	s.remoteCertificate = serialized.RemoteCertificate
+	s.PeerCertificates = serialized.PeerCertificates
 }
 
 func (s *State) initCipherSuite() error {


### PR DESCRIPTION
The RemoteCertificate function is now deprecated and the
PeerCertificates property of State can be used to get the peer
certificates.
