### PR TITLE
Refactor State.clone()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -369,20 +369,14 @@ func (c *Conn) ExportKeyingMaterial(label string, context []byte, length int) ([
 		return nil, errReservedExportKeyingMaterial
 	}
 
-	localRandom, err := c.state.localRandom.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	remoteRandom, err := c.state.remoteRandom.Marshal()
-	if err != nil {
-		return nil, err
-	}
+	localRandom := c.state.localRandom.marshalFixed()
+	remoteRandom := c.state.remoteRandom.marshalFixed()
 
 	seed := []byte(label)
 	if c.state.isClient {
-		seed = append(append(seed, localRandom...), remoteRandom...)
+		seed = append(append(seed, localRandom[:]...), remoteRandom[:]...)
 	} else {
-		seed = append(append(seed, remoteRandom...), localRandom...)
+		seed = append(append(seed, remoteRandom[:]...), localRandom[:]...)
 	}
 	return prfPHash(c.state.masterSecret, seed, length, c.state.cipherSuite.hashFunc())
 }

--- a/handshake_message_client_hello.go
+++ b/handshake_message_client_hello.go
@@ -36,11 +36,8 @@ func (h *handshakeMessageClientHello) Marshal() ([]byte, error) {
 	out[0] = h.version.major
 	out[1] = h.version.minor
 
-	rand, err := h.random.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	copy(out[2:], rand)
+	rand := h.random.marshalFixed()
+	copy(out[2:], rand[:])
 
 	out = append(out, 0x00) // SessionID
 
@@ -65,9 +62,9 @@ func (h *handshakeMessageClientHello) Unmarshal(data []byte) error {
 	h.version.major = data[0]
 	h.version.minor = data[1]
 
-	if err := h.random.Unmarshal(data[2 : 2+handshakeRandomLength]); err != nil {
-		return err
-	}
+	var random [handshakeRandomLength]byte
+	copy(random[:], data[2:])
+	h.random.unmarshalFixed(random)
 
 	// rest of packet has variable width sections
 	currOffset := handshakeMessageClientHelloVariableWidthStart

--- a/handshake_message_server_hello.go
+++ b/handshake_message_server_hello.go
@@ -37,11 +37,8 @@ func (h *handshakeMessageServerHello) Marshal() ([]byte, error) {
 	out[0] = h.version.major
 	out[1] = h.version.minor
 
-	rand, err := h.random.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	copy(out[2:], rand)
+	rand := h.random.marshalFixed()
+	copy(out[2:], rand[:])
 
 	out = append(out, 0x00) // SessionID
 
@@ -66,9 +63,9 @@ func (h *handshakeMessageServerHello) Unmarshal(data []byte) error {
 	h.version.major = data[0]
 	h.version.minor = data[1]
 
-	if err := h.random.Unmarshal(data[2 : 2+handshakeRandomLength]); err != nil {
-		return err
-	}
+	var random [handshakeRandomLength]byte
+	copy(random[:], data[2:])
+	h.random.unmarshalFixed(random)
 
 	currOffset := handshakeMessageServerHelloVariableWidthStart
 	currOffset += int(data[currOffset]) + 1 // SessionID

--- a/handshake_random.go
+++ b/handshake_random.go
@@ -15,23 +15,18 @@ type handshakeRandom struct {
 	randomBytes [randomBytesLength]byte
 }
 
-func (h *handshakeRandom) Marshal() ([]byte, error) {
-	out := make([]byte, handshakeRandomLength)
+func (h *handshakeRandom) marshalFixed() [handshakeRandomLength]byte {
+	var out [handshakeRandomLength]byte
 
 	binary.BigEndian.PutUint32(out[0:], uint32(h.gmtUnixTime.Unix()))
 	copy(out[4:], h.randomBytes[:])
 
-	return out, nil
+	return out
 }
 
-func (h *handshakeRandom) Unmarshal(data []byte) error {
-	if len(data) != handshakeRandomLength {
-		return errBufferTooSmall
-	}
+func (h *handshakeRandom) unmarshalFixed(data [handshakeRandomLength]byte) {
 	h.gmtUnixTime = time.Unix(int64(binary.BigEndian.Uint32(data[0:])), 0)
 	copy(h.randomBytes[:], data[4:])
-
-	return nil
 }
 
 // populate fills the handshakeRandom with random values

--- a/resume.go
+++ b/resume.go
@@ -7,15 +7,15 @@ import (
 
 // Export extracts dtls state and inner connection from an already handshaked dtls conn
 func (c *Conn) Export() (*State, net.Conn, error) {
-	state, err := c.state.clone()
-	if err != nil {
-		return nil, nil, err
-	}
+	state := c.state.clone()
 	return state, c.nextConn.Conn(), nil
 }
 
 // Resume imports an already stablished dtls connection using a specific dtls state
 func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
+	if err := state.initCipherSuite(); err != nil {
+		return nil, err
+	}
 	c, err := createConn(context.Background(), conn, config, state.isClient, state)
 	if err != nil {
 		return nil, err

--- a/resume_test.go
+++ b/resume_test.go
@@ -132,7 +132,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 
 	// Resume dtls connection
 	var resumed net.Conn
-	resumed, err = Resume(state, localConn2, config)
+	resumed, err = Resume(deserialized, localConn2, config)
 	if err != nil {
 		fatal(t, errChan, err)
 	}


### PR DESCRIPTION
Remove `error` from return value of `State.clone()`.
Fix `TestResume` which didn't used deserialized state.

Note: `State.MarshalBinary()` result is incompatible with the previous version.

Related to #237 
