### PR TITLE
Fix connCtx.RemoteAddr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Julien Salleyron](https://github.com/juliens) - *Server Name Indication*
 * [Jeroen de Bruijn](https://github.com/vidavidorra)
+* [bjdgyc](https://github.com/bjdgyc)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/internal/net/connctx/connctx.go
+++ b/internal/net/connctx/connctx.go
@@ -148,7 +148,7 @@ func (c *connCtx) LocalAddr() net.Addr {
 }
 
 func (c *connCtx) RemoteAddr() net.Addr {
-	return c.nextConn.LocalAddr()
+	return c.nextConn.RemoteAddr()
 }
 
 func (c *connCtx) Conn() net.Conn {

--- a/internal/net/connctx/connctx_test.go
+++ b/internal/net/connctx/connctx_test.go
@@ -195,3 +195,36 @@ func TestWriteClosed(t *testing.T) {
 		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
 	}
 }
+
+// Test for TestLocalAddrAndRemoteAddr
+type stringAddr struct {
+	network string
+	addr    string
+}
+
+func (a stringAddr) Network() string { return a.network }
+func (a stringAddr) String() string  { return a.addr }
+
+type connAddrMock struct{}
+
+func (*connAddrMock) RemoteAddr() net.Addr               { return stringAddr{"remote_net", "remote_addr"} }
+func (*connAddrMock) LocalAddr() net.Addr                { return stringAddr{"local_net", "local_addr"} }
+func (*connAddrMock) Read(b []byte) (n int, err error)   { panic("unimplemented") }
+func (*connAddrMock) Write(b []byte) (n int, err error)  { panic("unimplemented") }
+func (*connAddrMock) Close() error                       { panic("unimplemented") }
+func (*connAddrMock) SetDeadline(t time.Time) error      { panic("unimplemented") }
+func (*connAddrMock) SetReadDeadline(t time.Time) error  { panic("unimplemented") }
+func (*connAddrMock) SetWriteDeadline(t time.Time) error { panic("unimplemented") }
+
+func TestLocalAddrAndRemoteAddr(t *testing.T) {
+	c := New(&connAddrMock{})
+	al := c.LocalAddr()
+	ar := c.RemoteAddr()
+
+	if al.String() != "local_addr" {
+		t.Error("Wrong LocalAddr implementation")
+	}
+	if ar.String() != "remote_addr" {
+		t.Error("Wrong RemoteAddr implementation")
+	}
+}


### PR DESCRIPTION
LocalAddr of the underlying conn was returned from RemoteAddr.
Add TestLocalAddrAndRemoteAddr.

Squash https://github.com/pion/dtls/pull/245 and https://github.com/pion/dtls/pull/246.
Lint errors are fixed.

closes #245 
closes #246