### PR TITLE
Start handshake only by handshake in Accept()

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -12,7 +12,20 @@ func Listen(network string, laddr *net.UDPAddr, config *Config) (net.Listener, e
 		return nil, err
 	}
 
-	parent, err := udp.Listen(network, laddr)
+	lc := udp.ListenConfig{
+		AcceptFilter: func(packet []byte) bool {
+			pkts, err := unpackDatagram(packet)
+			if err != nil || len(pkts) < 1 {
+				return false
+			}
+			h := &recordLayerHeader{}
+			if err := h.Unmarshal(pkts[0]); err != nil {
+				return false
+			}
+			return h.contentType == contentTypeHandshake
+		},
+	}
+	parent, err := lc.Listen(network, laddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Avoid returning error from Accept() when receiving unrelated packet.
It also avoid allocating resources for unrelated packets.

### Reference issue
#255 
