### PR TITLE
Make handshake errors from Accept() non-fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jeroen de Bruijn](https://github.com/vidavidorra)
 * [bjdgyc](https://github.com/bjdgyc)
 * [Jeffrey Stoke (Jeff Ctor)](https://github.com/jeffreystoke) - *Fragmentbuffer Fix*
+* [Frank Olbricht](https://github.com/folbricht)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -170,7 +170,7 @@ func parseCipherSuites(userSelectedSuites []CipherSuiteID, excludePSK, excludeNo
 		for _, id := range ids {
 			c := cipherSuiteForID(id)
 			if c == nil {
-				return nil, fmt.Errorf("CipherSuite with id(%d) is not valid", id)
+				return nil, &invalidCipherSuite{id}
 			}
 			cipherSuites = append(cipherSuites, c)
 		}

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -132,8 +132,8 @@ func TestContextConfig(t *testing.T) {
 				d, cancel := dial.f()
 				conn, err := d()
 				defer cancel()
-				if err != errHandshakeTimeout {
-					t.Errorf("Expected error: '%v', got: '%v'", errHandshakeTimeout, err)
+				if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+					t.Errorf("Client error exp(Temporary network error) failed(%v)", err)
 					close(done)
 					return
 				}

--- a/errors_test.go
+++ b/errors_test.go
@@ -32,6 +32,10 @@ func TestErrorUnwrap(t *testing.T) {
 			&TimeoutError{errExample},
 			[]error{errExample},
 		},
+		{
+			&HandshakeError{errExample},
+			[]error{errExample},
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -59,6 +63,8 @@ func TestErrorNetError(t *testing.T) {
 		{&TemporaryError{errExample}, "dtls temporary: an example error", false, true},
 		{&InternalError{errExample}, "dtls internal: an example error", false, false},
 		{&TimeoutError{errExample}, "dtls timeout: an example error", true, true},
+		{&HandshakeError{errExample}, "handshake error: an example error", false, false},
+		{&HandshakeError{&TimeoutError{errExample}}, "handshake error: dtls timeout: an example error", true, true},
 	}
 	for _, c := range cases {
 		c := c
@@ -72,6 +78,9 @@ func TestErrorNetError(t *testing.T) {
 			}
 			if ne.Temporary() != c.temporary {
 				t.Errorf("%T.Temporary() should be %v", c.err, c.temporary)
+			}
+			if ne.Error() != c.str {
+				t.Errorf("%T.Error() should be %v", c.err, c.str)
 			}
 		})
 	}


### PR DESCRIPTION
#### Description

Makes handshake errors non-fatal in Accept() to avoid servers stopping when one client fails to complete the handshake and open a connection.

First attempt, not exactly an elegant solution.

#### Reference issue
Fixes #255
