### PR TITLE
Always select matching CipherSuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jeffrey Stoke (Jeff Ctor)](https://github.com/jeffreystoke) - *Fragmentbuffer Fix*
 * [Frank Olbricht](https://github.com/folbricht)
 * [ZHENK](https://github.com/scorpionknifes)
+* [Carson Hoffman](https://github.com/CarsonHoffman)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -28,11 +28,9 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 
 	state.remoteRandom = clientHello.random
 
-	if _, ok := findMatchingCipherSuite(clientHello.cipherSuites, cfg.localCipherSuites); !ok {
+	if state.cipherSuite, ok = findMatchingCipherSuite(clientHello.cipherSuites, cfg.localCipherSuites); !ok {
 		return 0, &alert{alertLevelFatal, alertInsufficientSecurity}, errCipherSuiteNoIntersection
 	}
-
-	state.cipherSuite = clientHello.cipherSuites[0]
 
 	for _, extension := range clientHello.extensions {
 		switch e := extension.(type) {


### PR DESCRIPTION
#### Description
Currently, the server checks to see if *any* of the client's cipher suites match *any* of its own, but always selects the first that the client offered. This can lead to a situation where the server selects a cipher suite it does not support; for example, if the client offers suites `[A, B]` and the server supports only `[B]`, the server will see the match of `B`, but will then select `A`, which it does not support.

This PR makes the server always select a matching cipher suite, and adds a test to confirm this functionality; `HEAD` currently fails the test.
