### PR TITLE
New features for LPWAN devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ We would love contributes that fall under the 'Planned Features' and fixing any 
 * TLS_PSK_WITH_AES_128_CCM ([RFC 6655][rfc6655])
 * TLS_PSK_WITH_AES_128_CCM_8 ([RFC 6655][rfc6655])
 * TLS_PSK_WITH_AES_128_GCM_SHA256 ([RFC 5487][rfc5487])
+* TLS_PSK_WITH_AES_128_CBC_SHA256 ([RFC 5487][rfc5487])
 
 [rfc5289]: https://tools.ietf.org/html/rfc5289
 [rfc8422]: https://tools.ietf.org/html/rfc8422

--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -26,6 +26,7 @@ const (
 	TLS_PSK_WITH_AES_128_CCM        CipherSuiteID = 0xc0a4 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CCM_8      CipherSuiteID = 0xc0a8 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_GCM_SHA256 CipherSuiteID = 0x00a8 //nolint:golint,stylecheck
+	TLS_PSK_WITH_AES_128_CBC_SHA256 CipherSuiteID = 0x00ae //nolint:golint,stylecheck
 )
 
 var _ = allCipherSuites() // Necessary until this function isn't only used by Go 1.14
@@ -50,6 +51,8 @@ func (c CipherSuiteID) String() string {
 		return "TLS_PSK_WITH_AES_128_CCM_8"
 	case TLS_PSK_WITH_AES_128_GCM_SHA256:
 		return "TLS_PSK_WITH_AES_128_GCM_SHA256"
+	case TLS_PSK_WITH_AES_128_CBC_SHA256:
+		return "TLS_PSK_WITH_AES_128_CBC_SHA256"
 	default:
 		return fmt.Sprintf("unknown(%v)", uint16(c))
 	}
@@ -106,6 +109,8 @@ func cipherSuiteForID(id CipherSuiteID) cipherSuite {
 		return newCipherSuiteTLSPskWithAes128Ccm8()
 	case TLS_PSK_WITH_AES_128_GCM_SHA256:
 		return &cipherSuiteTLSPskWithAes128GcmSha256{}
+	case TLS_PSK_WITH_AES_128_CBC_SHA256:
+		return &cipherSuiteTLSPskWithAes128CbcSha256{}
 	}
 	return nil
 }

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -1,7 +1,7 @@
 package dtls
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
 	"fmt"
 	"hash"

--- a/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/cipher_suite_tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -1,6 +1,7 @@
 package dtls
 
 import (
+	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
 	"hash"
@@ -52,11 +53,13 @@ func (c *cipherSuiteTLSEcdheEcdsaWithAes256CbcSha) init(masterSecret, clientRand
 		cbc, err = newCryptoCBC(
 			keys.clientWriteKey, keys.clientWriteIV, keys.clientMACKey,
 			keys.serverWriteKey, keys.serverWriteIV, keys.serverMACKey,
+			sha1.New,
 		)
 	} else {
 		cbc, err = newCryptoCBC(
 			keys.serverWriteKey, keys.serverWriteIV, keys.serverMACKey,
 			keys.clientWriteKey, keys.clientWriteIV, keys.clientMACKey,
+			sha1.New,
 		)
 	}
 	c.cbc.Store(cbc)

--- a/cipher_suite_tls_psk_with_aes_128_cbc_sha256.go
+++ b/cipher_suite_tls_psk_with_aes_128_cbc_sha256.go
@@ -1,0 +1,85 @@
+package dtls
+
+import (
+	"crypto/sha256"
+	"errors"
+	"hash"
+	"sync/atomic"
+)
+
+type cipherSuiteTLSPskWithAes128CbcSha256 struct {
+	cbc atomic.Value // *cryptoCBC
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) certificateType() clientCertificateType {
+	return clientCertificateType(0)
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) ID() CipherSuiteID {
+	return TLS_PSK_WITH_AES_128_CBC_SHA256
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) String() string {
+	return "TLS_PSK_WITH_AES_128_CBC_SHA256"
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) hashFunc() func() hash.Hash {
+	return sha256.New
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) isPSK() bool {
+	return true
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) isInitialized() bool {
+	return c.cbc.Load() != nil
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
+	const (
+		prfMacLen = 32
+		prfKeyLen = 16
+		prfIvLen  = 16
+	)
+
+	keys, err := prfEncryptionKeys(masterSecret, clientRandom, serverRandom, prfMacLen, prfKeyLen, prfIvLen, c.hashFunc())
+	if err != nil {
+		return err
+	}
+
+	var cbc *cryptoCBC
+	if isClient {
+		cbc, err = newCryptoCBC(
+			keys.clientWriteKey, keys.clientWriteIV, keys.clientMACKey,
+			keys.serverWriteKey, keys.serverWriteIV, keys.serverMACKey,
+			c.hashFunc(),
+		)
+	} else {
+		cbc, err = newCryptoCBC(
+			keys.serverWriteKey, keys.serverWriteIV, keys.serverMACKey,
+			keys.clientWriteKey, keys.clientWriteIV, keys.clientMACKey,
+			c.hashFunc(),
+		)
+	}
+	c.cbc.Store(cbc)
+
+	return err
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) encrypt(pkt *recordLayer, raw []byte) ([]byte, error) {
+	cbc := c.cbc.Load()
+	if cbc == nil { // !c.isInitialized()
+		return nil, errors.New("CipherSuite has not been initialized, unable to encrypt")
+	}
+
+	return cbc.(*cryptoCBC).encrypt(pkt, raw)
+}
+
+func (c *cipherSuiteTLSPskWithAes128CbcSha256) decrypt(raw []byte) ([]byte, error) {
+	cbc := c.cbc.Load()
+	if cbc == nil { // !c.isInitialized()
+		return nil, errors.New("CipherSuite has not been initialized, unable to decrypt ")
+	}
+
+	return cbc.(*cryptoCBC).decrypt(raw)
+}

--- a/cipher_suite_tls_psk_with_aes_128_cbc_sha256.go
+++ b/cipher_suite_tls_psk_with_aes_128_cbc_sha256.go
@@ -2,7 +2,7 @@ package dtls
 
 import (
 	"crypto/sha256"
-	"errors"
+	"fmt"
 	"hash"
 	"sync/atomic"
 )
@@ -69,7 +69,7 @@ func (c *cipherSuiteTLSPskWithAes128CbcSha256) init(masterSecret, clientRandom, 
 func (c *cipherSuiteTLSPskWithAes128CbcSha256) encrypt(pkt *recordLayer, raw []byte) ([]byte, error) {
 	cbc := c.cbc.Load()
 	if cbc == nil { // !c.isInitialized()
-		return nil, errors.New("CipherSuite has not been initialized, unable to encrypt")
+		return nil, fmt.Errorf("%w, unable to encrypt", errCipherSuiteNotInit)
 	}
 
 	return cbc.(*cryptoCBC).encrypt(pkt, raw)
@@ -78,7 +78,7 @@ func (c *cipherSuiteTLSPskWithAes128CbcSha256) encrypt(pkt *recordLayer, raw []b
 func (c *cipherSuiteTLSPskWithAes128CbcSha256) decrypt(raw []byte) ([]byte, error) {
 	cbc := c.cbc.Load()
 	if cbc == nil { // !c.isInitialized()
-		return nil, errors.New("CipherSuite has not been initialized, unable to decrypt ")
+		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
 	return cbc.(*cryptoCBC).decrypt(raw)

--- a/config.go
+++ b/config.go
@@ -107,6 +107,11 @@ type Config struct {
 	// Packet with sequence number older than this value compared to the latest
 	// accepted packet will be discarded. (default is 64)
 	ReplayProtectionWindow int
+
+	// ClientHelloBypassReplay causes the server to reset a session, bypassing
+	// the replay window protection if a ClientHello message is received after the
+	// session has started.  (default is false)
+	ClientHelloBypassReplay bool
 }
 
 func defaultConnectContextMaker() (context.Context, func()) {

--- a/conn.go
+++ b/conn.go
@@ -670,14 +670,13 @@ func (c *Conn) handleIncomingPacket(buf []byte, enqueue bool) (bool, *alert, err
 			buf[recordLayerHeaderSize] == byte(handshakeTypeClientHello) {
 			// special exception to anti-replay to allow clients to re-establish a handshake with a new clientHello
 			c.log.Debugf("session reset via new clientHello")
-			c.close(true)
-			return false, nil, nil
+			_ = c.close(true)
 		} else {
 			c.log.Debugf("discarded duplicated packet (epoch: %d, seq: %d)",
 				h.epoch, h.sequenceNumber,
 			)
-			return false, nil, nil
 		}
+		return false, nil, nil
 	}
 
 	// Decrypt

--- a/conn.go
+++ b/conn.go
@@ -73,7 +73,8 @@ type Conn struct {
 
 	fsm *handshakeFSM
 
-	replayProtectionWindow uint
+	replayProtectionWindow  uint
+	clientHelloBypassReplay bool
 }
 
 func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient bool, initialState *State) (*Conn, error) {
@@ -135,7 +136,8 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		closed:           closer.NewCloser(),
 		cancelHandshaker: func() {},
 
-		replayProtectionWindow: uint(replayProtectionWindow),
+		replayProtectionWindow:  uint(replayProtectionWindow),
+		clientHelloBypassReplay: config.ClientHelloBypassReplay,
 
 		state: State{
 			isClient: isClient,
@@ -661,10 +663,21 @@ func (c *Conn) handleIncomingPacket(buf []byte, enqueue bool) (bool, *alert, err
 	}
 	markPacketAsValid, ok := c.state.replayDetector[int(h.epoch)].Check(h.sequenceNumber)
 	if !ok {
-		c.log.Debugf("discarded duplicated packet (epoch: %d, seq: %d)",
-			h.epoch, h.sequenceNumber,
-		)
-		return false, nil, nil
+		if c.clientHelloBypassReplay && h.epoch == 0 &&
+			h.sequenceNumber == 0 &&
+			h.contentType == contentTypeHandshake &&
+			len(buf) >= recordLayerHeaderSize+1 &&
+			buf[recordLayerHeaderSize] == byte(handshakeTypeClientHello) {
+			// special exception to anti-replay to allow clients to re-establish a handshake with a new clientHello
+			c.log.Debugf("session reset via new clientHello")
+			c.close(true)
+			return false, nil, nil
+		} else {
+			c.log.Debugf("discarded duplicated packet (epoch: %d, seq: %d)",
+				h.epoch, h.sequenceNumber,
+			)
+			return false, nil, nil
+		}
 	}
 
 	// Decrypt

--- a/extension.go
+++ b/extension.go
@@ -24,6 +24,9 @@ type extension interface {
 }
 
 func decodeExtensions(buf []byte) ([]extension, error) {
+	if len(buf) == 0 {
+		return []extension{}, nil
+	}
 	if len(buf) < 2 {
 		return nil, errBufferTooSmall
 	}

--- a/prf.go
+++ b/prf.go
@@ -3,7 +3,6 @@ package dtls
 import ( //nolint:gci
 	"crypto/elliptic"
 	"crypto/hmac"
-	"crypto/sha1" //nolint:gosec
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -208,8 +207,8 @@ func prfVerifyDataServer(masterSecret, handshakeBodies []byte, h hashFunc) ([]by
 }
 
 // compute the MAC using HMAC-SHA1
-func prfMac(epoch uint16, sequenceNumber uint64, contentType contentType, protocolVersion protocolVersion, payload []byte, key []byte) ([]byte, error) {
-	h := hmac.New(sha1.New, key)
+func prfMac(epoch uint16, sequenceNumber uint64, contentType contentType, protocolVersion protocolVersion, payload []byte, key []byte, hf hashFunc) ([]byte, error) {
+	h := hmac.New(hf, key)
 
 	msg := make([]byte, 13)
 


### PR DESCRIPTION
#### Description
1. Added support for clients that do not publish any extensions
2. Added optional configuration to bypass the replay detection window on new ClientHello packets.  (this fixes a problem with clients that use fixed IP and ports).
3. Added support for TLS_PSK_AES_128_CBC_SHA256 cipher suite.
