### PR TITLE
Implement Renegotiation Indication Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Frank Olbricht](https://github.com/folbricht)
 * [ZHENK](https://github.com/scorpionknifes)
 * [Carson Hoffman](https://github.com/CarsonHoffman)
+* [Vadim Filimonov](https://github.com/fffilimonov)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/extension.go
+++ b/extension.go
@@ -14,6 +14,7 @@ const (
 	extensionSupportedSignatureAlgorithmsValue extensionValue = 13
 	extensionUseSRTPValue                      extensionValue = 14
 	extensionUseExtendedMasterSecretValue      extensionValue = 23
+	extensionRenegotiationInfoValue            extensionValue = 65281
 )
 
 type extension interface {
@@ -56,6 +57,8 @@ func decodeExtensions(buf []byte) ([]extension, error) {
 			err = unmarshalAndAppend(buf[offset:], &extensionUseSRTP{})
 		case extensionUseExtendedMasterSecretValue:
 			err = unmarshalAndAppend(buf[offset:], &extensionUseExtendedMasterSecret{})
+		case extensionRenegotiationInfoValue:
+			err = unmarshalAndAppend(buf[offset:], &extensionRenegotiationInfo{})
 		default:
 		}
 		if err != nil {

--- a/extension_renegotiation_info.go
+++ b/extension_renegotiation_info.go
@@ -1,0 +1,37 @@
+package dtls
+
+import "encoding/binary"
+
+const (
+	extensionRenegotiationInfoHeaderSize = 5
+)
+
+// https://tools.ietf.org/html/rfc5746
+type extensionRenegotiationInfo struct {
+	renegotiatedConnection uint8
+}
+
+func (e extensionRenegotiationInfo) extensionValue() extensionValue {
+	return extensionRenegotiationInfoValue
+}
+
+func (e *extensionRenegotiationInfo) Marshal() ([]byte, error) {
+	out := make([]byte, extensionRenegotiationInfoHeaderSize)
+
+	binary.BigEndian.PutUint16(out, uint16(e.extensionValue()))
+	binary.BigEndian.PutUint16(out[2:], uint16(1)) // length
+	out[4] = e.renegotiatedConnection
+	return out, nil
+}
+
+func (e *extensionRenegotiationInfo) Unmarshal(data []byte) error {
+	if len(data) < extensionRenegotiationInfoHeaderSize {
+		return errBufferTooSmall
+	} else if extensionValue(binary.BigEndian.Uint16(data)) != e.extensionValue() {
+		return errInvalidExtensionType
+	}
+
+	e.renegotiatedConnection = data[4]
+
+	return nil
+}

--- a/extension_renegotiation_info_test.go
+++ b/extension_renegotiation_info_test.go
@@ -1,0 +1,22 @@
+package dtls
+
+import "testing"
+
+func TestRenegotiationInfo(t *testing.T) {
+	extension := extensionRenegotiationInfo{renegotiatedConnection: 0}
+
+	raw, err := extension.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newExtension := extensionRenegotiationInfo{}
+	err = newExtension.Unmarshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if newExtension.renegotiatedConnection != extension.renegotiatedConnection {
+		t.Errorf("extensionRenegotiationInfo marshal: got %s expected %s", newExtension.renegotiatedConnection, extension.renegotiatedConnection)
+	}
+}

--- a/extension_renegotiation_info_test.go
+++ b/extension_renegotiation_info_test.go
@@ -17,6 +17,6 @@ func TestRenegotiationInfo(t *testing.T) {
 	}
 
 	if newExtension.renegotiatedConnection != extension.renegotiatedConnection {
-		t.Errorf("extensionRenegotiationInfo marshal: got %s expected %s", newExtension.renegotiatedConnection, extension.renegotiatedConnection)
+		t.Errorf("extensionRenegotiationInfo marshal: got %d expected %d", newExtension.renegotiatedConnection, extension.renegotiatedConnection)
 	}
 }

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -51,6 +51,9 @@ func flight1Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		&extensionSupportedSignatureAlgorithms{
 			signatureHashAlgorithms: cfg.localSignatureSchemes,
 		},
+		&extensionRenegotiationInfo{
+			renegotiatedConnection: 0,
+		},
 	}
 	if cfg.localPSKCallback == nil {
 		extensions = append(extensions, []extension{

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -123,6 +123,9 @@ func flight3Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		&extensionSupportedSignatureAlgorithms{
 			signatureHashAlgorithms: cfg.localSignatureSchemes,
 		},
+		&extensionRenegotiationInfo{
+			renegotiatedConnection: 0,
+		},
 	}
 	if cfg.localPSKCallback == nil {
 		extensions = append(extensions, []extension{


### PR DESCRIPTION
Implement Renegotiation Indication Extension

Add minimal renegotiation_info support

#### Description
As described in #274 it's not possible to connect to server which using Bouncy Castle DTLS library (e.g. Jitsi) as a client using Pion.
According to [rfc5746](https://tools.ietf.org/html/rfc5746) the client MUST include either an empty "renegotiation_info" extension, or the TLS_EMPTY_RENEGOTIATION_INFO_SCSV signaling cipher suite value in the ClientHello. Pion doesn't support renegotiations so it doesn't require anything except sending empty renegotiation_info. But it will increase interoperability.


#### Reference issue
Fixes #274 
