### PR TITLE
Add PSK Client Hint to conn state

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Carson Hoffman](https://github.com/CarsonHoffman)
 * [Vadim Filimonov](https://github.com/fffilimonov)
 * [Jim Wert](https://github.com/bocajim)
+* [Alvaro Viebrantz](https://github.com/alvarowolfx)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/conn_test.go
+++ b/conn_test.go
@@ -485,6 +485,12 @@ func TestPSK(t *testing.T) {
 			if err != nil {
 				t.Fatalf("TestPSK: Server failed(%v)", err)
 			}
+
+			actualPSKIdentityHint := server.ConnectionState().IdentityHint
+			if !bytes.Equal(actualPSKIdentityHint, clientIdentity) {
+				t.Errorf("TestPSK: Server ClientPSKIdentity Mismatch '%s': expected(%v) actual(%v)", test.Name, clientIdentity, actualPSKIdentityHint)
+			}
+
 			defer func() {
 				_ = server.Close()
 			}()

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -103,7 +103,7 @@ func handleServerKeyExchange(_ flightConn, state *State, cfg *handshakeConfig, h
 		if psk, err = cfg.localPSKCallback(h.identityHint); err != nil {
 			return &alert{alertLevelFatal, alertInternalError}, err
 		}
-
+		state.IdentityHint = h.identityHint
 		state.preMasterSecret = prfPSKPreMasterSecret(psk)
 	} else {
 		if state.localKeypair, err = generateKeypair(h.namedCurve); err != nil {

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -85,7 +85,7 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			if psk, err = cfg.localPSKCallback(clientKeyExchange.identityHint); err != nil {
 				return 0, &alert{alertLevelFatal, alertInternalError}, err
 			}
-
+			state.IdentityHint = clientKeyExchange.identityHint
 			preMasterSecret = prfPSKPreMasterSecret(psk)
 		} else {
 			preMasterSecret, err = prfPreMasterSecret(clientKeyExchange.publicKey, state.localKeypair.privateKey, state.localKeypair.curve)

--- a/state.go
+++ b/state.go
@@ -18,6 +18,7 @@ type State struct {
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
 	PeerCertificates      [][]byte
+	IdentityHint          []byte
 
 	isClient bool
 
@@ -49,6 +50,7 @@ type serializedState struct {
 	SequenceNumber        uint64
 	SRTPProtectionProfile uint16
 	PeerCertificates      [][]byte
+	IdentityHint          []byte
 	IsClient              bool
 }
 
@@ -76,6 +78,7 @@ func (s *State) serialize() *serializedState {
 		RemoteRandom:          remoteRnd,
 		SRTPProtectionProfile: uint16(s.srtpProtectionProfile),
 		PeerCertificates:      s.PeerCertificates,
+		IdentityHint:          s.IdentityHint,
 		IsClient:              s.isClient,
 	}
 }
@@ -112,6 +115,7 @@ func (s *State) deserialize(serialized serializedState) {
 
 	// Set remote certificate
 	s.PeerCertificates = serialized.PeerCertificates
+	s.IdentityHint = serialized.IdentityHint
 }
 
 func (s *State) initCipherSuite() error {


### PR DESCRIPTION
#### Description
My issue started when using the `go-coap` project where we had the need o access the PSK Client Hint after the DTLS +PSK handshake, more specifically, inside a path handler or middleware. Today that is already possible for the DTLS + PKI secure method, where we can have access to the Client Certificate after the handshake.

This PR basically adds the field `IdentityHint` to the connection State struct following the same idea of the `PeerCertificates` field on the same struct.

Here is the issue with more details: https://github.com/plgd-dev/go-coap/issues/196

#### Reference issue
Fixes https://github.com/plgd-dev/go-coap/issues/196
