### PR TITLE
Expose CipherSuite

### DIFF
--- a/cipher_suite_go114.go
+++ b/cipher_suite_go114.go
@@ -11,7 +11,7 @@ import (
 const VersionDTLS12 = 0xfefd
 
 // Convert from our cipherSuite interface to a tls.CipherSuite struct
-func toTLSCipherSuite(c cipherSuite) *tls.CipherSuite {
+func toTLSCipherSuite(c CipherSuite) *tls.CipherSuite {
 	return &tls.CipherSuite{
 		ID:                uint16(c.ID()),
 		Name:              c.String(),

--- a/cipher_suite_test.go
+++ b/cipher_suite_test.go
@@ -1,7 +1,13 @@
 package dtls
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/pion/dtls/v2/internal/ciphersuite"
+	"github.com/pion/dtls/v2/internal/net/dpipe"
+	"github.com/pion/transport/test"
 )
 
 func TestCipherSuiteName(t *testing.T) {
@@ -26,4 +32,58 @@ func TestAllCipherSuites(t *testing.T) {
 	if actual == 0 {
 		t.Fatal()
 	}
+}
+
+// CustomCipher that is just used to test CustomerCiphers and Anonymous Authentication
+type testCustomCipherSuite struct {
+	ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256
+}
+
+func (t *testCustomCipherSuite) ID() CipherSuiteID {
+	return 0xFFFF
+}
+
+// Assert that two connections that pass in a CipherSuite with a CustomID works
+func TestCustomCipherSuite(t *testing.T) {
+	type result struct {
+		c   *Conn
+		err error
+	}
+
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	t.Run("Custom ID", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ca, cb := dpipe.Pipe()
+		c := make(chan result)
+
+		go func() {
+			client, err := testClient(ctx, ca, &Config{
+				CipherSuites:       []CipherSuiteID{},
+				CustomCipherSuites: func() []CipherSuite { return []CipherSuite{&testCustomCipherSuite{}} },
+			}, true)
+			c <- result{client, err}
+		}()
+
+		server, err := testServer(ctx, cb, &Config{
+			CipherSuites:       []CipherSuiteID{},
+			CustomCipherSuites: func() []CipherSuite { return []CipherSuite{&testCustomCipherSuite{}} },
+		}, true)
+
+		if err != nil {
+			t.Error(err)
+		} else {
+			_ = server.Close()
+		}
+
+		if res := <-c; res.err != nil {
+			t.Error(res.err)
+		} else {
+			_ = res.c.Close()
+		}
+	})
 }

--- a/config.go
+++ b/config.go
@@ -23,6 +23,11 @@ type Config struct {
 	// If CipherSuites is nil, a default list is used
 	CipherSuites []CipherSuiteID
 
+	// CustomCipherSuites is a list of CipherSuites that can be
+	// provided by the user. This allow users to user Ciphers that are reserved
+	// for private usage.
+	CustomCipherSuites func() []CipherSuite
+
 	// SignatureSchemes contains the signature and hash schemes that the peer requests to verify.
 	SignatureSchemes []tls.SignatureScheme
 
@@ -172,6 +177,6 @@ func validateConfig(config *Config) error {
 		}
 	}
 
-	_, err := parseCipherSuites(config.CipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
+	_, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
 	return err
 }

--- a/conn.go
+++ b/conn.go
@@ -87,7 +87,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		return nil, errNilNextConn
 	}
 
-	cipherSuites, err := parseCipherSuites(config.CipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
+	cipherSuites, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +173,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		verifyPeerCertificate:       config.VerifyPeerCertificate,
 		rootCAs:                     config.RootCAs,
 		clientCAs:                   config.ClientCAs,
+		customCipherSuites:          config.CustomCipherSuites,
 		retransmitInterval:          workerInterval,
 		log:                         logger,
 		initialEpoch:                0,

--- a/conn_test.go
+++ b/conn_test.go
@@ -1428,7 +1428,7 @@ func TestServerTimeout(t *testing.T) {
 	var rand [28]byte
 	random := handshake.Random{GMTUnixTime: time.Unix(500, 0), RandomBytes: rand}
 
-	cipherSuites := []cipherSuite{
+	cipherSuites := []CipherSuite{
 		&ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256{},
 		&ciphersuite.TLSEcdheRsaWithAes128GcmSha256{},
 	}

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -36,7 +36,7 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 
 	cipherSuites := []CipherSuite{}
 	for _, id := range clientHello.CipherSuiteIDs {
-		if c := cipherSuiteForID(CipherSuiteID(id)); c != nil {
+		if c := cipherSuiteForID(CipherSuiteID(id), cfg.customCipherSuites); c != nil {
 			cipherSuites = append(cipherSuites, c)
 		}
 	}

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -34,7 +34,7 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 
 	state.remoteRandom = clientHello.Random
 
-	cipherSuites := []cipherSuite{}
+	cipherSuites := []CipherSuite{}
 	for _, id := range clientHello.CipherSuiteIDs {
 		if c := cipherSuiteForID(CipherSuiteID(id)); c != nil {
 			cipherSuites = append(cipherSuites, c)

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -78,7 +78,7 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errRequestedButNoSRTPExtension
 		}
 
-		remoteCipherSuite := cipherSuiteForID(CipherSuiteID(*h.CipherSuiteID))
+		remoteCipherSuite := cipherSuiteForID(CipherSuiteID(*h.CipherSuiteID), cfg.customCipherSuites)
 		if remoteCipherSuite == nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
 		}

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -83,7 +83,7 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
 		}
 
-		selectedCipherSuite, ok := findMatchingCipherSuite([]cipherSuite{remoteCipherSuite}, cfg.localCipherSuites)
+		selectedCipherSuite, ok := findMatchingCipherSuite([]CipherSuite{remoteCipherSuite}, cfg.localCipherSuites)
 		if !ok {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errInvalidCipherSuite
 		}

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -90,7 +90,7 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 
 		var err error
 		var preMasterSecret []byte
-		if state.cipherSuite.IsPSK() {
+		if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypePreSharedKey {
 			var psk []byte
 			if psk, err = cfg.localPSKCallback(clientKeyExchange.IdentityHint); err != nil {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
@@ -181,7 +181,7 @@ func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 			ProtectionProfiles: []SRTPProtectionProfile{state.srtpProtectionProfile},
 		})
 	}
-	if !state.cipherSuite.IsPSK() {
+	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate {
 		extensions = append(extensions, []extension.Extension{
 			&extension.SupportedEllipticCurves{
 				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
@@ -212,7 +212,7 @@ func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		},
 	})
 
-	if !state.cipherSuite.IsPSK() {
+	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate {
 		certificate, err := cfg.getCertificate(cfg.serverName)
 		if err != nil {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, err

--- a/handshaker.go
+++ b/handshaker.go
@@ -101,6 +101,7 @@ type handshakeConfig struct {
 	rootCAs                     *x509.CertPool
 	clientCAs                   *x509.CertPool
 	retransmitInterval          time.Duration
+	customCipherSuites          func() []CipherSuite
 
 	onFlightState func(flightVal, handshakeState)
 	log           logging.LeveledLogger

--- a/handshaker.go
+++ b/handshaker.go
@@ -88,7 +88,7 @@ type handshakeFSM struct {
 type handshakeConfig struct {
 	localPSKCallback            PSKCallback
 	localPSKIdentityHint        []byte
-	localCipherSuites           []cipherSuite             // Available CipherSuites
+	localCipherSuites           []CipherSuite             // Available CipherSuites
 	localSignatureSchemes       []signaturehash.Algorithm // Available signature schemes
 	extendedMasterSecret        ExtendedMasterSecretType  // Policy for the Extended Master Support extension
 	localSRTPProtectionProfiles []SRTPProtectionProfile   // Available SRTPProtectionProfiles, if empty no SRTP support

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -26,7 +26,7 @@ func TestHandshaker(t *testing.T) {
 	loggerFactory := logging.NewDefaultLoggerFactory()
 	logger := loggerFactory.NewLogger("dtls")
 
-	cipherSuites, err := parseCipherSuites(nil, true, false)
+	cipherSuites, err := parseCipherSuites(nil, nil, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ciphersuite/aes_128_ccm.go
+++ b/internal/ciphersuite/aes_128_ccm.go
@@ -49,9 +49,12 @@ func (c *Aes128Ccm) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// IsPSK returns if the CipherSuite requires a pre-shared key
-func (c *Aes128Ccm) IsPSK() bool {
-	return c.psk
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *Aes128Ccm) AuthenticationType() AuthenticationType {
+	if c.psk {
+		return AuthenticationTypePreSharedKey
+	}
+	return AuthenticationTypeCertificate
 }
 
 // IsInitialized returns if the CipherSuite has keying material and can

--- a/internal/ciphersuite/ciphersuite.go
+++ b/internal/ciphersuite/ciphersuite.go
@@ -59,3 +59,13 @@ const (
 	TLS_PSK_WITH_AES_128_GCM_SHA256 ID = 0x00a8 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CBC_SHA256 ID = 0x00ae //nolint:golint,stylecheck
 )
+
+// AuthenticationType controls what authentication method is using during the handshake
+type AuthenticationType int
+
+// AuthenticationType Enums
+const (
+	AuthenticationTypeCertificate AuthenticationType = iota + 1
+	AuthenticationTypePreSharedKey
+	AuthenticationTypeAnonymous
+)

--- a/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
@@ -36,9 +36,9 @@ func (c *TLSEcdheEcdsaWithAes128GcmSha256) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// IsPSK returns if the CipherSuite requires a pre-shared key
-func (c *TLSEcdheEcdsaWithAes128GcmSha256) IsPSK() bool {
-	return false
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *TLSEcdheEcdsaWithAes128GcmSha256) AuthenticationType() AuthenticationType {
+	return AuthenticationTypeCertificate
 }
 
 // IsInitialized returns if the CipherSuite has keying material and can

--- a/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -37,9 +37,9 @@ func (c *TLSEcdheEcdsaWithAes256CbcSha) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// IsPSK returns if the CipherSuite requires a pre-shared key
-func (c *TLSEcdheEcdsaWithAes256CbcSha) IsPSK() bool {
-	return false
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *TLSEcdheEcdsaWithAes256CbcSha) AuthenticationType() AuthenticationType {
+	return AuthenticationTypeCertificate
 }
 
 // IsInitialized returns if the CipherSuite has keying material and can

--- a/internal/ciphersuite/tls_psk_with_aes_128_cbc_sha256.go
+++ b/internal/ciphersuite/tls_psk_with_aes_128_cbc_sha256.go
@@ -36,9 +36,9 @@ func (c *TLSPskWithAes128CbcSha256) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// IsPSK returns if the CipherSuite requires a pre-shared key
-func (c *TLSPskWithAes128CbcSha256) IsPSK() bool {
-	return true
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *TLSPskWithAes128CbcSha256) AuthenticationType() AuthenticationType {
+	return AuthenticationTypePreSharedKey
 }
 
 // IsInitialized returns if the CipherSuite has keying material and can

--- a/internal/ciphersuite/tls_psk_with_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_psk_with_aes_128_gcm_sha256.go
@@ -21,7 +21,7 @@ func (c *TLSPskWithAes128GcmSha256) String() string {
 	return "TLS_PSK_WITH_AES_128_GCM_SHA256"
 }
 
-// IsPSK returns if the CipherSuite requires a pre-shared key
-func (c *TLSPskWithAes128GcmSha256) IsPSK() bool {
-	return true
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *TLSPskWithAes128GcmSha256) AuthenticationType() AuthenticationType {
+	return AuthenticationTypePreSharedKey
 }

--- a/state.go
+++ b/state.go
@@ -111,7 +111,7 @@ func (s *State) deserialize(serialized serializedState) {
 	s.masterSecret = serialized.MasterSecret
 
 	// Set cipher suite
-	s.cipherSuite = cipherSuiteForID(CipherSuiteID(serialized.CipherSuiteID))
+	s.cipherSuite = cipherSuiteForID(CipherSuiteID(serialized.CipherSuiteID), nil)
 
 	atomic.StoreUint64(&s.localSequenceNumber[epoch], serialized.SequenceNumber)
 	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)

--- a/state.go
+++ b/state.go
@@ -17,7 +17,7 @@ type State struct {
 	localSequenceNumber       []uint64 // uint48
 	localRandom, remoteRandom handshake.Random
 	masterSecret              []byte
-	cipherSuite               cipherSuite // nil if a cipherSuite hasn't been chosen
+	cipherSuite               CipherSuite // nil if a cipherSuite hasn't been chosen
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
 	PeerCertificates      [][]byte

--- a/util.go
+++ b/util.go
@@ -11,7 +11,7 @@ func findMatchingSRTPProfile(a, b []SRTPProtectionProfile) (SRTPProtectionProfil
 	return 0, false
 }
 
-func findMatchingCipherSuite(a, b []cipherSuite) (cipherSuite, bool) { //nolint
+func findMatchingCipherSuite(a, b []CipherSuite) (CipherSuite, bool) { //nolint
 	for _, aSuite := range a {
 		for _, bSuite := range b {
 			if aSuite.ID() == bSuite.ID() {


### PR DESCRIPTION
Also change `IsPSK` to `AuthenticationType` to allow users to choose
between PSK, Certificate and Anonymous authentication. In a follow up
commit users will be able to pass their own ciphers.

Relates to #337

----

Expose CustomCipherSuites

Allow a user to implement their own CipherSuite if they implement the
interface.

Relates to #337
