### PR TITLE
Add support for KeyLogWriter

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,10 +6,13 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"time"
 
 	"github.com/pion/logging"
 )
+
+const keyLogLabelTLS12 = "CLIENT_RANDOM"
 
 // Config is used to configure a DTLS client or server.
 // After a Config is passed to a DTLS function it must not be modified.
@@ -112,6 +115,14 @@ type Config struct {
 	// Packet with sequence number older than this value compared to the latest
 	// accepted packet will be discarded. (default is 64)
 	ReplayProtectionWindow int
+
+	// KeyLogWriter optionally specifies a destination for TLS master secrets
+	// in NSS key log format that can be used to allow external programs
+	// such as Wireshark to decrypt TLS connections.
+	// See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
+	// Use of KeyLogWriter compromises security and should only be
+	// used for debugging.
+	KeyLogWriter io.Writer
 }
 
 func defaultConnectContextMaker() (context.Context, func()) {

--- a/conn.go
+++ b/conn.go
@@ -177,6 +177,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		retransmitInterval:          workerInterval,
 		log:                         logger,
 		initialEpoch:                0,
+		keyLogWriter:                config.KeyLogWriter,
 	}
 
 	var initialFlight flightVal

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -125,6 +125,7 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		if err := state.cipherSuite.Init(state.masterSecret, clientRandom[:], serverRandom[:], false); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
+		cfg.writeKeyLog(keyLogLabelTLS12, clientRandom[:], state.masterSecret)
 	}
 
 	// Now, encrypted packets can be handled

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -316,5 +316,8 @@ func initalizeCipherSuite(state *State, cache *handshakeCache, cfg *handshakeCon
 	if err = state.cipherSuite.Init(state.masterSecret, clientRandom[:], serverRandom[:], true); err != nil {
 		return &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
+
+	cfg.writeKeyLog(keyLogLabelTLS12, clientRandom[:], state.masterSecret)
+
 	return nil, nil
 }

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -1,6 +1,7 @@
 package dtls
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"sync"
@@ -17,6 +18,27 @@ import (
 )
 
 const nonZeroRetransmitInterval = 100 * time.Millisecond
+
+// Test that writes to the key log are in the correct format and only applies
+// when a key log writer is given.
+func TestWriteKeyLog(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := handshakeConfig{
+		keyLogWriter: &buf,
+	}
+	cfg.writeKeyLog("LABEL", []byte{0xAA, 0xBB, 0xCC}, []byte{0xDD, 0xEE, 0xFF})
+
+	// Secrets follow the format <Label> <space> <ClientRandom> <space> <Secret>
+	// https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format
+	want := "LABEL aabbcc ddeeff\n"
+	if buf.String() != want {
+		t.Fatalf("Got %s want %s", buf.String(), want)
+	}
+
+	// no key log writer = no writes
+	cfg = handshakeConfig{}
+	cfg.writeKeyLog("LABEL", []byte{0xAA, 0xBB, 0xCC}, []byte{0xDD, 0xEE, 0xFF})
+}
 
 func TestHandshaker(t *testing.T) {
 	// Check for leaking routines


### PR DESCRIPTION
Fixes #343 - style is done in the same way as `tls.Config`.

Manually tested both as a client and as a server, then reading the resulting logs in Wireshark and confirming that data can be decrypted.
