### PR TITLE
Include RenegotiationInfo in ServerHello

### DIFF
--- a/flight0handler.go
+++ b/flight0handler.go
@@ -64,6 +64,8 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			}
 		case *extension.ServerName:
 			state.serverName = e.ServerName // remote server name
+		case *extension.RenegotiationInfo:
+			state.remoteSupportsRenegotiation = true
 		}
 	}
 

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -185,6 +185,11 @@ func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 			ProtectionProfiles: []SRTPProtectionProfile{state.srtpProtectionProfile},
 		})
 	}
+	if state.remoteSupportsRenegotiation {
+		extensions = append(extensions, &extension.RenegotiationInfo{
+			RenegotiatedConnection: 0,
+		})
+	}
 	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate {
 		extensions = append(extensions, []extension.Extension{
 			&extension.SupportedEllipticCurves{

--- a/state.go
+++ b/state.go
@@ -13,11 +13,12 @@ import (
 
 // State holds the dtls connection state and implements both encoding.BinaryMarshaler and encoding.BinaryUnmarshaler
 type State struct {
-	localEpoch, remoteEpoch   atomic.Value
-	localSequenceNumber       []uint64 // uint48
-	localRandom, remoteRandom handshake.Random
-	masterSecret              []byte
-	cipherSuite               CipherSuite // nil if a cipherSuite hasn't been chosen
+	localEpoch, remoteEpoch     atomic.Value
+	localSequenceNumber         []uint64 // uint48
+	localRandom, remoteRandom   handshake.Random
+	masterSecret                []byte
+	cipherSuite                 CipherSuite // nil if a cipherSuite hasn't been chosen
+	remoteSupportsRenegotiation bool        // did ClientHello contain a RenegotiationInfo
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
 	PeerCertificates      [][]byte


### PR DESCRIPTION
Before if clients sent a ClientHello with RenegotiationInfo we would
just ignore. Now we properly respond that we don't support.

Relates to #314
