### PR TITLE
Add missing *rsa.PrivateKey into validating config certs private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jim Wert](https://github.com/bocajim)
 * [Alvaro Viebrantz](https://github.com/alvarowolfx)
 * [Kegan Dougal](https://github.com/Kegsay)
+* [Michael Zabka](https://github.com/misak113)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"io"
@@ -182,6 +183,7 @@ func validateConfig(config *Config) error {
 			switch cert.PrivateKey.(type) {
 			case ed25519.PrivateKey:
 			case *ecdsa.PrivateKey:
+			case *rsa.PrivateKey:
 			default:
 				return errInvalidPrivateKey
 			}


### PR DESCRIPTION
#### Description

validates private keys of certs to be one of RSA, ECDSA or ED25519
everywhere else the RSA is correctly supported but the config validation

#### Reference issue
No issues
