### PR TITLE
config: adding support for GetCertificate(*tls.ClientHello)

### DIFF
--- a/certificate_test.go
+++ b/certificate_test.go
@@ -2,6 +2,7 @@ package dtls
 
 import (
 	"crypto/tls"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -69,6 +70,84 @@ func TestGetCertificate(t *testing.T) {
 			cert, err := cfg.getCertificate(test.serverName)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(cert.Leaf, test.expectedCertificate.Leaf) {
+				t.Fatalf("Certificate does not match: expected(%v) actual(%v)", test.expectedCertificate.Leaf, cert.Leaf)
+			}
+		})
+	}
+}
+
+func TestGetCertificateEmpty(t *testing.T) {
+	cfg := &handshakeConfig{}
+	_, err := cfg.getCertificate("test")
+	if err != errNoCertificates {
+		t.Fatalf("getCertificate should return errNoCertificates")
+	}
+}
+
+func TestGetCertificateFunc(t *testing.T) {
+	certMap := map[string]*tls.Certificate{
+		"pop.test.test": nil,
+		"test.test":     nil,
+	}
+	for k := range certMap {
+		cert, err := selfsign.GenerateSelfSignedWithDNS(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certMap[k] = &cert
+	}
+	getCertFunc := func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cert, ok := certMap[chi.ServerName]
+		if !ok {
+			return nil, errors.New("no cert found")
+		}
+		return cert, nil
+	}
+
+	cfg := &handshakeConfig{
+		getCertificateFunc: getCertFunc,
+	}
+
+	testCases := []struct {
+		desc                string
+		serverName          string
+		expectedCertificate *tls.Certificate
+	}{
+		{
+			desc:                "Simple match in CN",
+			serverName:          "test.test",
+			expectedCertificate: certMap["test.test"],
+		},
+		{
+			desc:                "Simple match in SANs",
+			serverName:          "pop.test.test",
+			expectedCertificate: certMap["pop.test.test"],
+		},
+		{
+			desc:                "No match return error",
+			serverName:          "foo.bar",
+			expectedCertificate: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cert, err := cfg.getCertificate(test.serverName)
+			if test.expectedCertificate != nil && err != nil {
+				t.Fatal(err)
+			}
+			if test.expectedCertificate == nil {
+				if err == nil {
+					t.Fatalf("Expected error on nil expectedCertificate")
+				}
+				return
 			}
 
 			if !reflect.DeepEqual(cert.Leaf, test.expectedCertificate.Leaf) {

--- a/config.go
+++ b/config.go
@@ -23,6 +23,14 @@ type Config struct {
 	// client SHOULD sets this so CertificateRequests can be handled if PSK is non-nil
 	Certificates []tls.Certificate
 
+	// GetCertificate returns a Certificate based on the given ClientHelloInfo.
+	// It will only be called if Certificates is empty. Note that this behavior is different than
+	// *tls.Config's GetCertificate as ServerName will always be populated
+	//
+	// Because of the way dtls implements certificate lookup, only ServerName is populated
+	// in ClientHelloInfo.
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
 	// CipherSuites is a list of supported cipher suites.
 	// If CipherSuites is nil, a default list is used
 	CipherSuites []CipherSuiteID
@@ -190,6 +198,6 @@ func validateConfig(config *Config) error {
 		}
 	}
 
-	_, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
+	_, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0 || config.GetCertificate != nil, config.PSK != nil)
 	return err
 }

--- a/conn.go
+++ b/conn.go
@@ -87,7 +87,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		return nil, errNilNextConn
 	}
 
-	cipherSuites, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0, config.PSK != nil)
+	cipherSuites, err := parseCipherSuites(config.CipherSuites, config.CustomCipherSuites, config.PSK == nil || len(config.Certificates) > 0 || config.GetCertificate != nil, config.PSK != nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,6 +168,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		localSRTPProtectionProfiles: config.SRTPProtectionProfiles,
 		serverName:                  serverName,
 		clientAuth:                  config.ClientAuth,
+		getCertificateFunc:          config.GetCertificate,
 		localCertificates:           config.Certificates,
 		insecureSkipVerify:          config.InsecureSkipVerify,
 		verifyPeerCertificate:       config.VerifyPeerCertificate,

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -54,7 +54,7 @@ func flight5Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) { //nolint:gocognit
 	var certBytes [][]byte
 	var privateKey crypto.PrivateKey
-	if len(cfg.localCertificates) > 0 {
+	if len(cfg.localCertificates) > 0 || cfg.getCertificateFunc != nil {
 		certificate, err := cfg.getCertificate(cfg.serverName)
 		if err != nil {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, err
@@ -151,7 +151,7 @@ func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 	// If the client has sent a certificate with signing ability, a digitally-signed
 	// CertificateVerify message is sent to explicitly verify possession of the
 	// private key in the certificate.
-	if state.remoteRequestedCertificate && len(cfg.localCertificates) > 0 {
+	if state.remoteRequestedCertificate && (len(cfg.localCertificates) > 0 || cfg.getCertificateFunc != nil) {
 		plainText := append(cache.pullAndMerge(
 			handshakeCachePullRule{handshake.TypeClientHello, cfg.initialEpoch, true, false},
 			handshakeCachePullRule{handshake.TypeServerHello, cfg.initialEpoch, false, false},

--- a/handshaker.go
+++ b/handshaker.go
@@ -96,6 +96,7 @@ type handshakeConfig struct {
 	localSRTPProtectionProfiles []SRTPProtectionProfile   // Available SRTPProtectionProfiles, if empty no SRTP support
 	serverName                  string
 	clientAuth                  ClientAuthType // If we are a client should we request a client certificate
+	getCertificateFunc          func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 	localCertificates           []tls.Certificate
 	nameToCertificate           map[string]*tls.Certificate
 	insecureSkipVerify          bool


### PR DESCRIPTION
#### Description

Add support for `GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)`. The goal is to close the feature parity gap with stdlib's `tls` package.

Questions to reviewers: What other tests should I be adding? I'm certain that I've missed some code paths.

#### Reference issue
Fixes #386 
