### PR TITLE
Do not include IP addresses as SNI values

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -10,6 +10,7 @@ backkem <mail@backkem.me>
 bjdgyc <bjdgyc@163.com>
 Bragadeesh <bragboy@gmail.com>
 Carson Hoffman <c@rsonhoffman.com>
+Cecylia Bocovich <cohosh@torproject.org>
 Chris Hiszpanski <thinkski@users.noreply.github.com>
 Daniele Sluijters <daenney@users.noreply.github.com>
 folbrich <frank.olbricht@gmail.com>

--- a/conn.go
+++ b/conn.go
@@ -147,16 +147,10 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 	c.setLocalEpoch(0)
 
 	serverName := config.ServerName
-	// Use host from conn address when serverName is not provided
-	if isClient && serverName == "" && nextConn.RemoteAddr() != nil {
-		remoteAddr := nextConn.RemoteAddr().String()
-		var host string
-		host, _, err = net.SplitHostPort(remoteAddr)
-		if err != nil {
-			serverName = remoteAddr
-		} else {
-			serverName = host
-		}
+	// Do not allow the use of an IP address literal as an SNI value.
+	// See RFC 6066, Section 3.
+	if net.ParseIP(serverName) != nil {
+		serverName = ""
 	}
 
 	hsCfg := &handshakeConfig{


### PR DESCRIPTION
According to RFC 6066, IP address literals are not permitted as valid
SNI values in the server name extension.
See https://datatracker.ietf.org/doc/html/rfc6066#section-3

#### Description

I used the same method that crypto/tls uses to check to see if the `serverName` is an IP address: https://cs.opensource.google/go/go/+/master:src/crypto/tls/handshake_client.go;l=1004

I kept the port parsing logic for the case that `net.ParseIP` would also fail if the `remoteAddr` was an IP:Port pair.

I didn't see existing testing logic to check SNI values but can add tests if necessary.

#### Reference issue
Fixes #406 
