### PR TITLE
Only include supported_groups extension in ClientHello

### DIFF
--- a/flight4handler.go
+++ b/flight4handler.go
@@ -189,14 +189,9 @@ func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		})
 	}
 	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate {
-		extensions = append(extensions, []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
-			},
-			&extension.SupportedPointFormats{
-				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
-			},
-		}...)
+		extensions = append(extensions, &extension.SupportedPointFormats{
+			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
+		})
 	}
 
 	var pkts []*packet


### PR DESCRIPTION
#### Description

This removes the logic that adds the supported_groups extension from the ServerHello message in flight4handler.go.

There is also a new test in conn_test.go to check this functionality. To write this test, I refactored the `sendClientHello` func defined in another test to be a standalone function.

#### Reference issue
Fixes #409 
