### PR TITLE
Only use algorithms specified in CertificateRequest msg

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -27,8 +27,10 @@ Jozef Kralik <jojo.lwin@gmail.com>
 Julien Salleyron <julien.salleyron@gmail.com>
 Kegan Dougal <kegan@matrix.org>
 Lander Noterman <lander.noterman@basalte.be>
+Len <len@hpcnt.com>
 Michael Zabka <zabka.michael@gmail.com>
 Michiel De Backker <mail@backkem.me>
+mschexnaydre <michael.schexnaydre@viasat.com>
 Robert Eperjesi <eperjesi@uber.com>
 Ryan Gordon <ryan.gordon@getcruise.com>
 Sean DuBois <seaduboi@amazon.com>

--- a/crypto.go
+++ b/crypto.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
@@ -108,11 +107,7 @@ func verifyKeySignature(message, remoteKeySignature []byte, hashAlgorithm hash.A
 // the private key in the certificate.
 // https://tools.ietf.org/html/rfc5246#section-7.3
 func generateCertificateVerify(handshakeBodies []byte, privateKey crypto.PrivateKey, hashAlgorithm hash.Algorithm) ([]byte, error) {
-	h := sha256.New()
-	if _, err := h.Write(handshakeBodies); err != nil {
-		return nil, err
-	}
-	hashed := h.Sum(nil)
+	hashed := hashAlgorithm.Digest(handshakeBodies)
 
 	switch p := privateKey.(type) {
 	case ed25519.PrivateKey:

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -132,7 +132,8 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		}
 	}
 
-	if _, ok := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
+	if creq, ok := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
+		state.remoteCertRequestAlgs = creq.SignatureHashAlgorithms
 		state.remoteRequestedCertificate = true
 	}
 

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"fmt"
 
 	"github.com/pion/dtls/v2/pkg/crypto/prf"
 	"github.com/pion/dtls/v2/pkg/crypto/signaturehash"
@@ -175,8 +176,10 @@ func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		), merged...)
 
 		// Find compatible signature scheme
-		signatureHashAlgo, err := signaturehash.SelectSignatureScheme(cfg.localSignatureSchemes, privateKey)
+
+		signatureHashAlgo, err := signaturehash.SelectSignatureScheme(state.remoteCertRequestAlgs, privateKey)
 		if err != nil {
+			fmt.Printf("Could not find a compatible signature algorithm: %v\n", err)
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, err
 		}
 

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
-	"fmt"
 
 	"github.com/pion/dtls/v2/pkg/crypto/prf"
 	"github.com/pion/dtls/v2/pkg/crypto/signaturehash"
@@ -179,7 +178,6 @@ func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 
 		signatureHashAlgo, err := signaturehash.SelectSignatureScheme(state.remoteCertRequestAlgs, privateKey)
 		if err != nil {
-			fmt.Printf("Could not find a compatible signature algorithm: %v\n", err)
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, err
 		}
 

--- a/state.go
+++ b/state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v2/pkg/crypto/prf"
+	"github.com/pion/dtls/v2/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 	"github.com/pion/transport/replaydetector"
 )
@@ -35,6 +36,7 @@ type State struct {
 	handshakeSendSequence      int
 	handshakeRecvSequence      int
 	serverName                 string
+	remoteCertRequestAlgs      []signaturehash.Algorithm
 	remoteRequestedCertificate bool   // Did we get a CertificateRequest
 	localCertificatesVerify    []byte // cache CertificateVerify
 	localVerifyData            []byte // cached VerifyData


### PR DESCRIPTION
#### Description
We should only be using one of the signature algorithms specified in the CertificateRequest message when generating the CertificateVerify message.  Prior to this fix SHA-256 was always being used.

This change stores the HASH algorithm from the CertificateRequest message in the State object so that we can reference these later when generating the CertificateVerify message.

Removed hard-coded usage of SHA-256 in generateCertificateVerify, now uses the Digest method of the passed in algorithm.

#### Reference issue
Fixes #418 
