### PR TITLE
Add cipher suite TLS_PSK_WITH_AES_256_CCM_8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We would love contributions that fall under the 'Planned Features' and any bug f
 ##### PSK
 * TLS_PSK_WITH_AES_128_CCM ([RFC 6655][rfc6655])
 * TLS_PSK_WITH_AES_128_CCM_8 ([RFC 6655][rfc6655])
+* TLS_PSK_WITH_AES_256_CCM_8 ([RFC 6655][rfc6655])
 * TLS_PSK_WITH_AES_128_GCM_SHA256 ([RFC 5487][rfc5487])
 * TLS_PSK_WITH_AES_128_CBC_SHA256 ([RFC 5487][rfc5487])
 

--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -35,6 +35,7 @@ const (
 
 	TLS_PSK_WITH_AES_128_CCM        CipherSuiteID = ciphersuite.TLS_PSK_WITH_AES_128_CCM        //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CCM_8      CipherSuiteID = ciphersuite.TLS_PSK_WITH_AES_128_CCM_8      //nolint:golint,stylecheck
+	TLS_PSK_WITH_AES_256_CCM_8      CipherSuiteID = ciphersuite.TLS_PSK_WITH_AES_256_CCM_8      //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_GCM_SHA256 CipherSuiteID = ciphersuite.TLS_PSK_WITH_AES_128_GCM_SHA256 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CBC_SHA256 CipherSuiteID = ciphersuite.TLS_PSK_WITH_AES_128_CBC_SHA256 //nolint:golint,stylecheck
 )
@@ -109,6 +110,8 @@ func cipherSuiteForID(id CipherSuiteID, customCiphers func() []CipherSuite) Ciph
 		return ciphersuite.NewTLSPskWithAes128Ccm()
 	case TLS_PSK_WITH_AES_128_CCM_8:
 		return ciphersuite.NewTLSPskWithAes128Ccm8()
+	case TLS_PSK_WITH_AES_256_CCM_8:
+		return ciphersuite.NewTLSPskWithAes256Ccm8()
 	case TLS_PSK_WITH_AES_128_GCM_SHA256:
 		return &ciphersuite.TLSPskWithAes128GcmSha256{}
 	case TLS_PSK_WITH_AES_128_CBC_SHA256:
@@ -152,6 +155,7 @@ func allCipherSuites() []CipherSuite {
 		&ciphersuite.TLSEcdheRsaWithAes256CbcSha{},
 		ciphersuite.NewTLSPskWithAes128Ccm(),
 		ciphersuite.NewTLSPskWithAes128Ccm8(),
+		ciphersuite.NewTLSPskWithAes256Ccm8(),
 		&ciphersuite.TLSPskWithAes128GcmSha256{},
 		&ciphersuite.TLSEcdheEcdsaWithAes256GcmSha384{},
 		&ciphersuite.TLSEcdheRsaWithAes256GcmSha384{},

--- a/e2e/e2e_openssl_test.go
+++ b/e2e/e2e_openssl_test.go
@@ -179,6 +179,7 @@ func ciphersOpenSSL(cfg *dtls.Config) string {
 
 		dtls.TLS_PSK_WITH_AES_128_CCM:        "PSK-AES128-CCM",
 		dtls.TLS_PSK_WITH_AES_128_CCM_8:      "PSK-AES128-CCM8",
+		dtls.TLS_PSK_WITH_AES_256_CCM_8:      "PSK-AES256-CCM8",
 		dtls.TLS_PSK_WITH_AES_128_GCM_SHA256: "PSK-AES128-GCM-SHA256",
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -262,6 +262,7 @@ func testPionE2ESimplePSK(t *testing.T, server, client func(*comm)) {
 	for _, cipherSuite := range []dtls.CipherSuiteID{
 		dtls.TLS_PSK_WITH_AES_128_CCM,
 		dtls.TLS_PSK_WITH_AES_128_CCM_8,
+		dtls.TLS_PSK_WITH_AES_256_CCM_8,
 		dtls.TLS_PSK_WITH_AES_128_GCM_SHA256,
 	} {
 		cipherSuite := cipherSuite

--- a/internal/ciphersuite/aes_256_ccm.go
+++ b/internal/ciphersuite/aes_256_ccm.go
@@ -5,13 +5,13 @@ import (
 	"github.com/pion/dtls/v2/pkg/crypto/clientcertificate"
 )
 
-// Aes128Ccm is a base class used by multiple AES-CCM Ciphers
-type Aes128Ccm struct {
+// Aes256Ccm is a base class used by multiple AES-CCM Ciphers
+type Aes256Ccm struct {
 	AesCcm
 }
 
-func newAes128Ccm(clientCertificateType clientcertificate.Type, id ID, psk bool, cryptoCCMTagLen ciphersuite.CCMTagLen) *Aes128Ccm {
-	return &Aes128Ccm{
+func newAes256Ccm(clientCertificateType clientcertificate.Type, id ID, psk bool, cryptoCCMTagLen ciphersuite.CCMTagLen) *Aes256Ccm {
+	return &Aes256Ccm{
 		AesCcm: AesCcm{
 			clientCertificateType: clientCertificateType,
 			id:                    id,
@@ -22,7 +22,7 @@ func newAes128Ccm(clientCertificateType clientcertificate.Type, id ID, psk bool,
 }
 
 // Init initializes the internal Cipher with keying material
-func (c *Aes128Ccm) Init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
-	const prfKeyLen = 16
+func (c *Aes256Ccm) Init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error {
+	const prfKeyLen = 32
 	return c.AesCcm.Init(masterSecret, clientRandom, serverRandom, isClient, prfKeyLen)
 }

--- a/internal/ciphersuite/aes_ccm.go
+++ b/internal/ciphersuite/aes_ccm.go
@@ -1,0 +1,98 @@
+package ciphersuite
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"sync/atomic"
+
+	"github.com/pion/dtls/v2/pkg/crypto/ciphersuite"
+	"github.com/pion/dtls/v2/pkg/crypto/clientcertificate"
+	"github.com/pion/dtls/v2/pkg/crypto/prf"
+	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+)
+
+// AesCcm is a base class used by multiple AES-CCM Ciphers
+type AesCcm struct {
+	ccm                   atomic.Value // *cryptoCCM
+	clientCertificateType clientcertificate.Type
+	id                    ID
+	psk                   bool
+	cryptoCCMTagLen       ciphersuite.CCMTagLen
+}
+
+// CertificateType returns what type of certificate this CipherSuite exchanges
+func (c *AesCcm) CertificateType() clientcertificate.Type {
+	return c.clientCertificateType
+}
+
+// ID returns the ID of the CipherSuite
+func (c *AesCcm) ID() ID {
+	return c.id
+}
+
+func (c *AesCcm) String() string {
+	return c.id.String()
+}
+
+// HashFunc returns the hashing func for this CipherSuite
+func (c *AesCcm) HashFunc() func() hash.Hash {
+	return sha256.New
+}
+
+// AuthenticationType controls what authentication method is using during the handshake
+func (c *AesCcm) AuthenticationType() AuthenticationType {
+	if c.psk {
+		return AuthenticationTypePreSharedKey
+	}
+	return AuthenticationTypeCertificate
+}
+
+// IsInitialized returns if the CipherSuite has keying material and can
+// encrypt/decrypt packets
+func (c *AesCcm) IsInitialized() bool {
+	return c.ccm.Load() != nil
+}
+
+// Init initializes the internal Cipher with keying material
+func (c *AesCcm) Init(masterSecret, clientRandom, serverRandom []byte, isClient bool, prfKeyLen int) error {
+	const (
+		prfMacLen = 0
+		prfIvLen  = 4
+	)
+
+	keys, err := prf.GenerateEncryptionKeys(masterSecret, clientRandom, serverRandom, prfMacLen, prfKeyLen, prfIvLen, c.HashFunc())
+	if err != nil {
+		return err
+	}
+
+	var ccm *ciphersuite.CCM
+	if isClient {
+		ccm, err = ciphersuite.NewCCM(c.cryptoCCMTagLen, keys.ClientWriteKey, keys.ClientWriteIV, keys.ServerWriteKey, keys.ServerWriteIV)
+	} else {
+		ccm, err = ciphersuite.NewCCM(c.cryptoCCMTagLen, keys.ServerWriteKey, keys.ServerWriteIV, keys.ClientWriteKey, keys.ClientWriteIV)
+	}
+	c.ccm.Store(ccm)
+
+	return err
+}
+
+// Encrypt encrypts a single TLS RecordLayer
+func (c *AesCcm) Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, error) {
+	ccm := c.ccm.Load()
+	if ccm == nil {
+		return nil, fmt.Errorf("%w, unable to encrypt", errCipherSuiteNotInit)
+	}
+
+	return ccm.(*ciphersuite.CCM).Encrypt(pkt, raw)
+}
+
+// Decrypt decrypts a single TLS RecordLayer
+func (c *AesCcm) Decrypt(raw []byte) ([]byte, error) {
+	ccm := c.ccm.Load()
+	if ccm == nil {
+		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
+	}
+
+	return ccm.(*ciphersuite.CCM).Decrypt(raw)
+}

--- a/internal/ciphersuite/ciphersuite.go
+++ b/internal/ciphersuite/ciphersuite.go
@@ -31,6 +31,8 @@ func (i ID) String() string {
 		return "TLS_PSK_WITH_AES_128_CCM"
 	case TLS_PSK_WITH_AES_128_CCM_8:
 		return "TLS_PSK_WITH_AES_128_CCM_8"
+	case TLS_PSK_WITH_AES_256_CCM_8:
+		return "TLS_PSK_WITH_AES_256_CCM_8"
 	case TLS_PSK_WITH_AES_128_GCM_SHA256:
 		return "TLS_PSK_WITH_AES_128_GCM_SHA256"
 	case TLS_PSK_WITH_AES_128_CBC_SHA256:
@@ -62,6 +64,7 @@ const (
 
 	TLS_PSK_WITH_AES_128_CCM        ID = 0xc0a4 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CCM_8      ID = 0xc0a8 //nolint:golint,stylecheck
+	TLS_PSK_WITH_AES_256_CCM_8      ID = 0xc0a9 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_GCM_SHA256 ID = 0x00a8 //nolint:golint,stylecheck
 	TLS_PSK_WITH_AES_128_CBC_SHA256 ID = 0x00ae //nolint:golint,stylecheck
 )

--- a/internal/ciphersuite/tls_psk_with_aes_256_ccm8.go
+++ b/internal/ciphersuite/tls_psk_with_aes_256_ccm8.go
@@ -1,0 +1,11 @@
+package ciphersuite
+
+import (
+	"github.com/pion/dtls/v2/pkg/crypto/ciphersuite"
+	"github.com/pion/dtls/v2/pkg/crypto/clientcertificate"
+)
+
+// NewTLSPskWithAes256Ccm8 returns the TLS_PSK_WITH_AES_256_CCM_8 CipherSuite
+func NewTLSPskWithAes256Ccm8() *Aes256Ccm {
+	return newAes256Ccm(clientcertificate.Type(0), TLS_PSK_WITH_AES_256_CCM_8, true, ciphersuite.CCMTagLength8)
+}


### PR DESCRIPTION
#### Description
Refactoring to a more general AesCcm base class for old Aes128Ccm base class and new Aes256Ccm base class to allow easy creation of TLS_PSK_WITH_AES_256_CCM_8. Finally added this new ciphersuite.

#### Reference issue
Fixes #427
