### PR TITLE
Remove spurious key/cert loading code

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -27,6 +27,7 @@ Jim Wert <jimwert@gmail.com>
 jinleileiking <jinleileiking@gmail.com>
 Jozef Kralik <jojo.lwin@gmail.com>
 Julien Salleyron <julien.salleyron@gmail.com>
+Juliusz Chroboczek <jch@irif.fr>
 Kegan Dougal <kegan@matrix.org>
 Lander Noterman <lander.noterman@basalte.be>
 Len <len@hpcnt.com>

--- a/examples/dial/verify/main.go
+++ b/examples/dial/verify/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
-		Certificates:         []tls.Certificate{*certificate},
+		Certificates:         []tls.Certificate{certificate},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		RootCAs:              certPool,
 	}

--- a/examples/listen/verify/main.go
+++ b/examples/listen/verify/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// Prepare the configuration of the DTLS connection
 	config := &dtls.Config{
-		Certificates:         []tls.Certificate{*certificate},
+		Certificates:         []tls.Certificate{certificate},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		ClientAuth:           dtls.RequireAndVerifyClientCert,
 		ClientCAs:            certPool,

--- a/examples/util/util.go
+++ b/examples/util/util.go
@@ -3,11 +3,7 @@ package util
 
 import (
 	"bufio"
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -22,9 +18,6 @@ import (
 const bufSize = 8192
 
 var (
-	errBlockIsNotPrivateKey  = errors.New("block is not a private key, unable to load key")
-	errUnknownKeyTime        = errors.New("unknown key time in PKCS#8 wrapping, unable to load key")
-	errNoPrivateKeyFound     = errors.New("no private key found, unable to load key")
 	errBlockIsNotCertificate = errors.New("block is not a certificate, unable to load certificates")
 	errNoCertificateFound    = errors.New("no certificate found, unable to load certificates")
 )
@@ -75,52 +68,8 @@ func Check(err error) {
 }
 
 // LoadKeyAndCertificate reads certificates or key from file
-func LoadKeyAndCertificate(keyPath string, certificatePath string) (*tls.Certificate, error) {
-	privateKey, err := LoadKey(keyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	certificate, err := LoadCertificate(certificatePath)
-	if err != nil {
-		return nil, err
-	}
-
-	certificate.PrivateKey = privateKey
-
-	return certificate, nil
-}
-
-// LoadKey Load/read key from file
-func LoadKey(path string) (crypto.PrivateKey, error) {
-	rawData, err := ioutil.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(rawData)
-	if block == nil || !strings.HasSuffix(block.Type, "PRIVATE KEY") {
-		return nil, errBlockIsNotPrivateKey
-	}
-
-	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
-		return key, nil
-	}
-
-	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
-		switch key := key.(type) {
-		case *rsa.PrivateKey, *ecdsa.PrivateKey:
-			return key, nil
-		default:
-			return nil, errUnknownKeyTime
-		}
-	}
-
-	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
-		return key, nil
-	}
-
-	return nil, errNoPrivateKeyFound
+func LoadKeyAndCertificate(keyPath string, certificatePath string) (tls.Certificate, error) {
+	return tls.LoadX509KeyPair(certificatePath, keyPath)
 }
 
 // LoadCertificate Load/read certificate(s) from file


### PR DESCRIPTION
We can use tls.LoadX509KeyPair from stdlib instead of our custom LoadKeyAndCertificate. This means we can also get rid of LoadKey, since we only need LoadCert for the client.
