### PR TITLE
Add handshake callback/monitor

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	PSK             PSKCallback
 	PSKIdentityHint []byte
 
+	// Callback to monitor handshake state
+	OnHandshakeState HandshakeCallback
+
 	// InsecureSkipVerify controls whether a client verifies the
 	// server's certificate chain and host name.
 	// If InsecureSkipVerify is true, TLS accepts any certificate
@@ -148,6 +151,9 @@ const defaultMTU = 1200 // bytes
 // PSKCallback is called once we have the remote's PSKIdentityHint.
 // If the remote provided none it will be nil
 type PSKCallback func([]byte) ([]byte, error)
+
+// HandshakeCallback is called multiple times as handshake progresses.
+type HandshakeCallback func(conn *Conn, f FlightVal, s HandshakeState, err error)
 
 // ClientAuthType declares the policy the server will follow for
 // TLS Client Authentication.

--- a/flight.go
+++ b/flight.go
@@ -53,49 +53,49 @@ package dtls
                           <--------             Finished    /
 */
 
-type flightVal uint8
+type FlightVal uint8
 
 const (
-	flight0 flightVal = iota + 1
-	flight1
-	flight2
-	flight3
-	flight4
-	flight4b
-	flight5
-	flight5b
-	flight6
+	Flight0 FlightVal = iota + 1
+	Flight1
+	Flight2
+	Flight3
+	Flight4
+	Flight4b
+	Flight5
+	Flight5b
+	Flight6
 )
 
-func (f flightVal) String() string {
+func (f FlightVal) String() string {
 	switch f {
-	case flight0:
+	case Flight0:
 		return "Flight 0"
-	case flight1:
+	case Flight1:
 		return "Flight 1"
-	case flight2:
+	case Flight2:
 		return "Flight 2"
-	case flight3:
+	case Flight3:
 		return "Flight 3"
-	case flight4:
+	case Flight4:
 		return "Flight 4"
-	case flight4b:
+	case Flight4b:
 		return "Flight 4b"
-	case flight5:
+	case Flight5:
 		return "Flight 5"
-	case flight5b:
+	case Flight5b:
 		return "Flight 5b"
-	case flight6:
+	case Flight6:
 		return "Flight 6"
 	default:
 		return "Invalid Flight"
 	}
 }
 
-func (f flightVal) isLastSendFlight() bool {
-	return f == flight6 || f == flight5b
+func (f FlightVal) isLastSendFlight() bool {
+	return f == Flight6 || f == Flight5b
 }
 
-func (f flightVal) isLastRecvFlight() bool {
-	return f == flight5 || f == flight4b
+func (f FlightVal) isLastRecvFlight() bool {
+	return f == Flight5 || f == Flight4b
 }

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 )
 
-func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	seq, msgs, ok := cache.fullPullMap(0, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeClientHello, cfg.initialEpoch, true, false},
 	)
@@ -81,10 +81,10 @@ func flight0Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		}
 	}
 
-	return handleHelloResume(clientHello.SessionID, state, cfg, flight2)
+	return handleHelloResume(clientHello.SessionID, state, cfg, Flight2)
 }
 
-func handleHelloResume(sessionID []byte, state *State, cfg *handshakeConfig, next flightVal) (flightVal, *alert.Alert, error) {
+func handleHelloResume(sessionID []byte, state *State, cfg *handshakeConfig, next FlightVal) (FlightVal, *alert.Alert, error) {
 	if len(sessionID) > 0 && cfg.sessionStore != nil {
 		if s, err := cfg.sessionStore.Get(sessionID); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
@@ -101,7 +101,7 @@ func handleHelloResume(sessionID []byte, state *State, cfg *handshakeConfig, nex
 			clientRandom := state.localRandom.MarshalFixed()
 			cfg.writeKeyLog(keyLogLabelTLS12, clientRandom[:], state.masterSecret)
 
-			return flight4b, nil, nil
+			return Flight4b, nil, nil
 		}
 	}
 	return next, nil, nil

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight1Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight1Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	// HelloVerifyRequest can be skipped by the server,
 	// so allow ServerHello during flight1 also
 	seq, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence, state.cipherSuite,
@@ -37,7 +37,7 @@ func flight1Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		}
 		state.cookie = append([]byte{}, h.Cookie...)
 		state.handshakeRecvSequence = seq
-		return flight3, nil, nil
+		return Flight3, nil, nil
 	}
 
 	return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil

--- a/flight2handler.go
+++ b/flight2handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight2Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight2Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	seq, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeClientHello, cfg.initialEpoch, true, false},
 	)
@@ -38,7 +38,7 @@ func flight2Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	if !bytes.Equal(state.cookie, clientHello.Cookie) {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, errCookieMismatch
 	}
-	return flight4, nil, nil
+	return Flight4, nil, nil
 }
 
 func flight2Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) {

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) { //nolint:gocognit
+func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) { //nolint:gocognit
 	// Clients may receive multiple HelloVerifyRequest messages with different cookies.
 	// Clients SHOULD handle this by sending a new ClientHello with a cookie in response
 	// to the new HelloVerifyRequest. RFC 6347 Section 4.2.1
@@ -30,7 +30,7 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			}
 			state.cookie = append([]byte{}, h.Cookie...)
 			state.handshakeRecvSequence = seq
-			return flight3, nil, nil
+			return Flight3, nil, nil
 		}
 	}
 
@@ -142,10 +142,10 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		state.remoteRequestedCertificate = true
 	}
 
-	return flight5, nil, nil
+	return Flight5, nil, nil
 }
 
-func handleResumption(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func handleResumption(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	if err := state.initCipherSuite(); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
@@ -183,7 +183,7 @@ func handleResumption(ctx context.Context, c flightConn, state *State, cache *ha
 	clientRandom := state.localRandom.MarshalFixed()
 	cfg.writeKeyLog(keyLogLabelTLS12, clientRandom[:], state.masterSecret)
 
-	return flight5b, nil, nil
+	return Flight5b, nil, nil
 }
 
 func handleServerKeyExchange(_ flightConn, state *State, cfg *handshakeConfig, h *handshake.MessageServerKeyExchange) (*alert.Alert, error) {

--- a/flight4bhandler.go
+++ b/flight4bhandler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight4bParse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight4bParse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	_, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeFinished, cfg.initialEpoch + 1, true, false},
 	)
@@ -41,7 +41,7 @@ func flight4bParse(ctx context.Context, c flightConn, state *State, cache *hands
 	}
 
 	// Other party may re-transmit the last flight. Keep state to be flight4b.
-	return flight4b, nil, nil
+	return Flight4b, nil, nil
 }
 
 func flight4bGenerate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) {

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) { //nolint:gocognit
+func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) { //nolint:gocognit
 	seq, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeCertificate, cfg.initialEpoch, true, true},
 		handshakeCachePullRule{handshake.TypeClientKeyExchange, cfg.initialEpoch, true, false},
@@ -174,7 +174,7 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	}
 
 	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeAnonymous {
-		return flight6, nil, nil
+		return Flight6, nil, nil
 	}
 
 	switch cfg.clientAuth {
@@ -194,10 +194,10 @@ func flight4Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.BadCertificate}, errClientCertificateNotVerified
 		}
 	case NoClientCert, RequestClientCert:
-		return flight6, nil, nil
+		return Flight6, nil, nil
 	}
 
-	return flight6, nil, nil
+	return Flight6, nil, nil
 }
 
 func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) {

--- a/flight5bhandler.go
+++ b/flight5bhandler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight5bParse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight5bParse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	_, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence-1, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeFinished, cfg.initialEpoch + 1, false, false},
 	)
@@ -24,7 +24,7 @@ func flight5bParse(ctx context.Context, c flightConn, state *State, cache *hands
 	}
 
 	// Other party may re-transmit the last flight. Keep state to be flight5b.
-	return flight5b, nil, nil
+	return Flight5b, nil, nil
 }
 
 func flight5bGenerate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) { //nolint:gocognit

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight5Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight5Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	_, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeFinished, cfg.initialEpoch + 1, false, false},
 	)
@@ -59,7 +59,7 @@ func flight5Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		}
 	}
 
-	return flight5, nil, nil
+	return Flight5, nil, nil
 }
 
 func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) { //nolint:gocognit

--- a/flight6handler.go
+++ b/flight6handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 )
 
-func flight6Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (flightVal, *alert.Alert, error) {
+func flight6Parse(ctx context.Context, c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) (FlightVal, *alert.Alert, error) {
 	_, msgs, ok := cache.fullPullMap(state.handshakeRecvSequence-1, state.cipherSuite,
 		handshakeCachePullRule{handshake.TypeFinished, cfg.initialEpoch + 1, true, false},
 	)
@@ -24,7 +24,7 @@ func flight6Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 	}
 
 	// Other party may re-transmit the last flight. Keep state to be flight6.
-	return flight6, nil, nil
+	return Flight6, nil, nil
 }
 
 func flight6Generate(c flightConn, state *State, cache *handshakeCache, cfg *handshakeConfig) ([]*packet, *alert.Alert, error) {

--- a/flighthandler.go
+++ b/flighthandler.go
@@ -6,58 +6,58 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/alert"
 )
 
-// Parse received handshakes and return next flightVal
-type flightParser func(context.Context, flightConn, *State, *handshakeCache, *handshakeConfig) (flightVal, *alert.Alert, error)
+// Parse received handshakes and return next FlightVal
+type flightParser func(context.Context, flightConn, *State, *handshakeCache, *handshakeConfig) (FlightVal, *alert.Alert, error)
 
 // Generate flights
 type flightGenerator func(flightConn, *State, *handshakeCache, *handshakeConfig) ([]*packet, *alert.Alert, error)
 
-func (f flightVal) getFlightParser() (flightParser, error) {
+func (f FlightVal) getFlightParser() (flightParser, error) {
 	switch f {
-	case flight0:
+	case Flight0:
 		return flight0Parse, nil
-	case flight1:
+	case Flight1:
 		return flight1Parse, nil
-	case flight2:
+	case Flight2:
 		return flight2Parse, nil
-	case flight3:
+	case Flight3:
 		return flight3Parse, nil
-	case flight4:
+	case Flight4:
 		return flight4Parse, nil
-	case flight4b:
+	case Flight4b:
 		return flight4bParse, nil
-	case flight5:
+	case Flight5:
 		return flight5Parse, nil
-	case flight5b:
+	case Flight5b:
 		return flight5bParse, nil
-	case flight6:
+	case Flight6:
 		return flight6Parse, nil
 	default:
 		return nil, errInvalidFlight
 	}
 }
 
-func (f flightVal) getFlightGenerator() (gen flightGenerator, retransmit bool, err error) {
+func (f FlightVal) getFlightGenerator() (gen flightGenerator, retransmit bool, err error) {
 	switch f {
-	case flight0:
+	case Flight0:
 		return flight0Generate, true, nil
-	case flight1:
+	case Flight1:
 		return flight1Generate, true, nil
-	case flight2:
+	case Flight2:
 		// https://tools.ietf.org/html/rfc6347#section-3.2.1
 		// HelloVerifyRequests must not be retransmitted.
 		return flight2Generate, false, nil
-	case flight3:
+	case Flight3:
 		return flight3Generate, true, nil
-	case flight4:
+	case Flight4:
 		return flight4Generate, true, nil
-	case flight4b:
+	case Flight4b:
 		return flight4bGenerate, true, nil
-	case flight5:
+	case Flight5:
 		return flight5Generate, true, nil
-	case flight5b:
+	case Flight5b:
 		return flight5bGenerate, true, nil
-	case flight6:
+	case Flight6:
 		return flight6Generate, true, nil
 	default:
 		return nil, false, errInvalidFlight

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -267,8 +267,8 @@ func TestHandshaker(t *testing.T) {
 					localSignatureSchemes: signaturehash.Algorithms(),
 					insecureSkipVerify:    true,
 					log:                   logger,
-					onFlightState: func(f flightVal, s handshakeState) {
-						if s == handshakeFinished {
+					onFlightState: func(f FlightVal, s HandshakeState) {
+						if s == HandshakeFinished {
 							if clientEndpoint.OnFinished != nil {
 								clientEndpoint.OnFinished()
 							}
@@ -280,8 +280,8 @@ func TestHandshaker(t *testing.T) {
 					retransmitInterval: nonZeroRetransmitInterval,
 				}
 
-				fsm := newHandshakeFSM(&ca.state, ca.handshakeCache, cfg, flight1)
-				err := fsm.Run(ctx, ca, handshakePreparing)
+				fsm := newHandshakeFSM(&ca.state, ca.handshakeCache, cfg, Flight1)
+				err := fsm.Run(ctx, ca, HandshakePreparing)
 				switch {
 				case errors.Is(err, context.Canceled):
 				case errors.Is(err, context.DeadlineExceeded):
@@ -299,8 +299,8 @@ func TestHandshaker(t *testing.T) {
 					localSignatureSchemes: signaturehash.Algorithms(),
 					insecureSkipVerify:    true,
 					log:                   logger,
-					onFlightState: func(f flightVal, s handshakeState) {
-						if s == handshakeFinished {
+					onFlightState: func(f FlightVal, s HandshakeState) {
+						if s == HandshakeFinished {
 							if serverEndpoint.OnFinished != nil {
 								serverEndpoint.OnFinished()
 							}
@@ -312,8 +312,8 @@ func TestHandshaker(t *testing.T) {
 					retransmitInterval: nonZeroRetransmitInterval,
 				}
 
-				fsm := newHandshakeFSM(&cb.state, cb.handshakeCache, cfg, flight0)
-				err := fsm.Run(ctx, cb, handshakePreparing)
+				fsm := newHandshakeFSM(&cb.state, cb.handshakeCache, cfg, Flight0)
+				err := fsm.Run(ctx, cb, HandshakePreparing)
 				switch {
 				case errors.Is(err, context.Canceled):
 				case errors.Is(err, context.DeadlineExceeded):


### PR DESCRIPTION
#### Description

This issue is a draft and I wanted to discuss a need that we had here in our project. We use the DTLS library in the IoT context, for IoT devices to authenticate to our system. One issue that we started seeing is that the auth/handshake can fail in some cases, and we want to keep track of when that happens. We have 3 major scenarios:
* Devices on a constrained network and might take too long to finish the handshake ( basically times out ) 
* The device informed the wrong set of credentials ( for now just PSK ID and PSK, but later we want to use certificates )
   *  Right now we can identify when the PSK ID is wrong, but when the PSK is not, even though I see crypto errors internally in the library, I could not capture that and It still falls under the previous "timeout" category. 

With this PR, I added a way to keep track of the Handshake as it progress, tracking the current Flight, Handshake State, and the connection itself ( so we can trace back to which client/device is using)

```go
OnHandshakeState: func(conn *dtls.Conn, f dtls.FlightVal, s dtls.HandshakeState, err error) {
			fmt.Printf("Handshake state %d: %s\n", f, s)
			if err != nil {
				pskID := conn.ConnectionState().IdentityHint
				fmt.Printf("Handshake error for device `%s`: %s\n", pskID, err)
			}
		},
```		

In our use case here, we save those error states as audit logs in our system so users can know when they have authentication errors on their system. 

I ended up having to make the types and constants related `FlightVal` and `HandshakeState` public to be shared on this function, so this generated many changes to the codebase. 

Again, I'm open to suggestions on better ways to track handshake errors and wanted to open this draft preview to see if this makes sense and can be merged or if we can do this differently. 

#### Reference issue
No related issue
