### PR TITLE
Fix ED25519 client certificate

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -108,6 +108,13 @@ func verifyKeySignature(message, remoteKeySignature []byte, hashAlgorithm hash.A
 // the private key in the certificate.
 // https://tools.ietf.org/html/rfc5246#section-7.3
 func generateCertificateVerify(handshakeBodies []byte, privateKey crypto.PrivateKey, hashAlgorithm hash.Algorithm) ([]byte, error) {
+	if p, ok := privateKey.(ed25519.PrivateKey); ok {
+		// https://pkg.go.dev/crypto/ed25519#PrivateKey.Sign
+		// Sign signs the given message with priv. Ed25519 performs two passes over
+		// messages to be signed and therefore cannot handle pre-hashed messages.
+		return p.Sign(rand.Reader, handshakeBodies, crypto.Hash(0))
+	}
+
 	h := sha256.New()
 	if _, err := h.Write(handshakeBodies); err != nil {
 		return nil, err
@@ -115,9 +122,6 @@ func generateCertificateVerify(handshakeBodies []byte, privateKey crypto.Private
 	hashed := h.Sum(nil)
 
 	switch p := privateKey.(type) {
-	case ed25519.PrivateKey:
-		// https://crypto.stackexchange.com/a/55483
-		return p.Sign(rand.Reader, hashed, crypto.Hash(0))
 	case *ecdsa.PrivateKey:
 		return p.Sign(rand.Reader, hashed, hashAlgorithm.CryptoHash())
 	case *rsa.PrivateKey:

--- a/pkg/crypto/selfsign/selfsign.go
+++ b/pkg/crypto/selfsign/selfsign.go
@@ -72,6 +72,11 @@ func WithDNS(key crypto.PrivateKey, cn string, sans ...string) (tls.Certificate,
 	names := []string{cn}
 	names = append(names, sans...)
 
+	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign
+	if _, isRSA := key.(*rsa.PrivateKey); isRSA {
+		keyUsage |= x509.KeyUsageKeyEncipherment
+	}
+
 	template := x509.Certificate{
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,
@@ -79,7 +84,7 @@ func WithDNS(key crypto.PrivateKey, cn string, sans ...string) (tls.Certificate,
 		},
 		BasicConstraintsValid: true,
 		NotBefore:             time.Now(),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		KeyUsage:              keyUsage,
 		NotAfter:              time.Now().AddDate(0, 1, 0),
 		SerialNumber:          serialNumber,
 		Version:               2,


### PR DESCRIPTION
#### Description

We were incorrectly hashing the handshakeBodies and passing that into Sign. However, for ed25519 you're not supposed to do that, it's part of the signature scheme (aside from the fact that it also uses SHA-512, not SHA-256).

This should now result in ED25519 client certificates working correctly.

#### Reference issue
Fixes #469 
