### PR TITLE
Shuffle Elliptic Curves in ClientHello to circumvent Russian censorship

### DIFF
--- a/flight1handler.go
+++ b/flight1handler.go
@@ -74,7 +74,7 @@ func flight1Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 	if setEllipticCurveCryptographyClientHelloExtensions {
 		extensions = append(extensions, []extension.Extension{
 			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
+				EllipticCurves: []elliptic.Curve{elliptic.P256, elliptic.P384, elliptic.X25519},
 			},
 			&extension.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -236,7 +236,7 @@ func flight3Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 	if state.namedCurve != 0 {
 		extensions = append(extensions, []extension.Extension{
 			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
+				EllipticCurves: []elliptic.Curve{elliptic.P256, elliptic.P384, elliptic.X25519},
 			},
 			&extension.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},


### PR DESCRIPTION
Since the December 2021, Russia is blocking Tor, including Snowflake
circumvention method which internally uses pion dtls for WebRTC.

Russian state DPI system fingerprints pion handshake features, namely
Elliptic Curves in ClientHello/ServerHello. The issue has been fixed
for ServerHello in 2f8ef4e48879f1129b3432c9ac04d2f4aad8049e
(by removing supported_groups extension from ServerHello), but
apparently ClientHello is also getting filtered.

Shuffle the order of Elliptic Curves in order to break the fingerprint
for ClientHello.

The fingerprint is performed by comparing the `00 1D 00 17 00 18` bytes at 0x6e offset of the packet, as well as at 0x59 offset.

More information:
https://gitlab.torproject.org/tpo/anti-censorship/censorship-analysis/-/issues/40030#note_2804998
