### PR TITLE
Make the Elliptic curves and order configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/logging"
 )
 
@@ -130,6 +131,12 @@ type Config struct {
 
 	// List of application protocols the peer supports, for ALPN
 	SupportedProtocols []string
+
+	// List of Elliptic Curves to use
+	//
+	// If an ECC ciphersuite is configured and EllipticCurves is empty
+	// it will default to X25519, P-256, P-384 in this specific order.
+	EllipticCurves []elliptic.Curve
 }
 
 func defaultConnectContextMaker() (context.Context, func()) {
@@ -144,6 +151,8 @@ func (c *Config) connectContextMaker() (context.Context, func()) {
 }
 
 const defaultMTU = 1200 // bytes
+
+var defaultCurves = []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384} //nolint:gochecknoglobals
 
 // PSKCallback is called once we have the remote's PSKIdentityHint.
 // If the remote provided none it will be nil

--- a/conn.go
+++ b/conn.go
@@ -154,6 +154,11 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		serverName = ""
 	}
 
+	curves := config.EllipticCurves
+	if len(curves) == 0 {
+		curves = defaultCurves
+	}
+
 	hsCfg := &handshakeConfig{
 		localPSKCallback:            config.PSK,
 		localPSKIdentityHint:        config.PSKIdentityHint,
@@ -175,6 +180,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		initialEpoch:                0,
 		keyLogWriter:                config.KeyLogWriter,
 		sessionStore:                config.SessionStore,
+		ellipticCurves:              curves,
 	}
 
 	// rfc5246#section-7.4.3

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -74,7 +74,7 @@ func flight1Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 	if setEllipticCurveCryptographyClientHelloExtensions {
 		extensions = append(extensions, []extension.Extension{
 			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
+				EllipticCurves: cfg.ellipticCurves,
 			},
 			&extension.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},

--- a/handshaker.go
+++ b/handshaker.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v2/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v2/pkg/protocol/alert"
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
@@ -106,6 +107,7 @@ type handshakeConfig struct {
 	clientCAs                   *x509.CertPool
 	retransmitInterval          time.Duration
 	customCipherSuites          func() []CipherSuite
+	ellipticCurves              []elliptic.Curve
 
 	onFlightState func(flightVal, handshakeState)
 	log           logging.LeveledLogger

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package dtls
 
 import (
@@ -264,6 +265,7 @@ func TestHandshaker(t *testing.T) {
 				cfg := &handshakeConfig{
 					localCipherSuites:     cipherSuites,
 					localCertificates:     []tls.Certificate{clientCert},
+					ellipticCurves:        defaultCurves,
 					localSignatureSchemes: signaturehash.Algorithms(),
 					insecureSkipVerify:    true,
 					log:                   logger,
@@ -296,6 +298,7 @@ func TestHandshaker(t *testing.T) {
 				cfg := &handshakeConfig{
 					localCipherSuites:     cipherSuites,
 					localCertificates:     []tls.Certificate{clientCert},
+					ellipticCurves:        defaultCurves,
 					localSignatureSchemes: signaturehash.Algorithms(),
 					insecureSkipVerify:    true,
 					log:                   logger,

--- a/pkg/crypto/elliptic/elliptic.go
+++ b/pkg/crypto/elliptic/elliptic.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"fmt"
 
 	"golang.org/x/crypto/curve25519"
 )
@@ -56,6 +57,18 @@ const (
 	P384   Curve = 0x0018
 	X25519 Curve = 0x001d
 )
+
+func (c Curve) String() string {
+	switch c {
+	case P256:
+		return "P-256"
+	case P384:
+		return "P-384"
+	case X25519:
+		return "X25519"
+	}
+	return fmt.Sprintf("%#x", uint16(c))
+}
 
 // Curves returns all curves we implement
 func Curves() map[Curve]bool {

--- a/pkg/crypto/elliptic/elliptic_test.go
+++ b/pkg/crypto/elliptic/elliptic_test.go
@@ -1,0 +1,24 @@
+package elliptic
+
+import "testing"
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		in  Curve
+		out string
+	}{
+		{X25519, "X25519"},
+		{P256, "P-256"},
+		{P384, "P-384"},
+		{0, "0x0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.out, func(t *testing.T) {
+			if tt.in.String() != tt.out {
+				t.Fatalf("Expected: %s, got: %s", tt.out, tt.in.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows the client/server to chose which elliptic curves they wish to advertise, and in which order.

Fixes #474