### PR TITLE
Implement VerifyConnection as is in tls.Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,6 +83,16 @@ type Config struct {
 	// be considered but the verifiedChains will always be nil.
 	VerifyPeerCertificate func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
 
+	// VerifyConnection, if not nil, is called after normal certificate
+	// verification/PSK and after VerifyPeerCertificate by either a TLS client
+	// or server. If it returns a non-nil error, the handshake is aborted
+	// and that error results.
+	//
+	// If normal verification fails then the handshake will abort before
+	// considering this callback. This callback will run for all connections
+	// regardless of InsecureSkipVerify or ClientAuth settings.
+	VerifyConnection func(*State) error
+
 	// RootCAs defines the set of root certificate authorities
 	// that one peer uses when verifying the other peer's certificates.
 	// If RootCAs is nil, TLS uses the host's root CA set.

--- a/conn.go
+++ b/conn.go
@@ -172,6 +172,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		localCertificates:           config.Certificates,
 		insecureSkipVerify:          config.InsecureSkipVerify,
 		verifyPeerCertificate:       config.VerifyPeerCertificate,
+		verifyConnection:            config.VerifyConnection,
 		rootCAs:                     config.RootCAs,
 		clientCAs:                   config.ClientCAs,
 		customCipherSuites:          config.CustomCipherSuites,

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:bullseye
+FROM docker.io/library/golang:1.18-bullseye
 
 COPY . /go/src/github.com/pion/dtls
 WORKDIR /go/src/github.com/pion/dtls/e2e

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -328,6 +328,11 @@ func initalizeCipherSuite(state *State, cache *handshakeCache, cfg *handshakeCon
 			}
 		}
 	}
+	if cfg.verifyConnection != nil {
+		if err = cfg.verifyConnection(state.clone()); err != nil {
+			return &alert.Alert{Level: alert.Fatal, Description: alert.BadCertificate}, err
+		}
+	}
 
 	if err = state.cipherSuite.Init(state.masterSecret, clientRandom[:], serverRandom[:], true); err != nil {
 		return &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err

--- a/handshaker.go
+++ b/handshaker.go
@@ -102,6 +102,7 @@ type handshakeConfig struct {
 	nameToCertificate           map[string]*tls.Certificate
 	insecureSkipVerify          bool
 	verifyPeerCertificate       func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+	verifyConnection            func(*State) error
 	sessionStore                SessionStore
 	rootCAs                     *x509.CertPool
 	clientCAs                   *x509.CertPool


### PR DESCRIPTION
#### Description

VerifyConnection, if not nil, is called after normal certificate
verification/PSK and after VerifyPeerCertificate by either a TLS client
or server. If it returns a non-nil error, the handshake is aborted
and that error results.

If normal verification fails then the handshake will abort before
considering this callback. This callback will run for all connections
regardless of InsecureSkipVerify or ClientAuth settings.


#### Reference issue
Fixes #486
