### PR TITLE
Ignore lint error on Subjects() deprecation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -29,6 +29,7 @@ Jozef Kralik <jojo.lwin@gmail.com>
 Julien Salleyron <julien.salleyron@gmail.com>
 Juliusz Chroboczek <jch@irif.fr>
 Kegan Dougal <kegan@matrix.org>
+Kevin Wang <kevmo314@gmail.com>
 Lander Noterman <lander.noterman@basalte.be>
 Len <len@hpcnt.com>
 Lukas Lihotzki <lukas@lihotzki.de>

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -339,6 +339,7 @@ func flight4Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 			// an appropriate certificate to give to us.
 			var certificateAuthorities [][]byte
 			if cfg.clientCAs != nil {
+				// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool and it's ok if certificate authorities is empty.
 				certificateAuthorities = cfg.clientCAs.Subjects()
 			}
 			pkts = append(pkts, &packet{


### PR DESCRIPTION
The API is expected to be called with a new cert pool.

The deprecation has no suggested alternative.