### PR TITLE
Add InsecureSkipVerifyHello Option

### DIFF
--- a/config.go
+++ b/config.go
@@ -168,6 +168,11 @@ type Config struct {
 	// the server. If this is unacceptable to the server then it may abort
 	// the handshake.
 	GetClientCertificate func(*CertificateRequestInfo) (*tls.Certificate, error)
+
+	// InsecureSkipVerifyHello, if true and when acting as server, allow client to
+	// skip hello verify phase and receive ServerHello after initial ClientHello.
+	// This have implication on DoS attack resistance.
+	InsecureSkipVerifyHello bool
 }
 
 func defaultConnectContextMaker() (context.Context, func()) {

--- a/conn.go
+++ b/conn.go
@@ -184,6 +184,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		ellipticCurves:              curves,
 		localGetCertificate:         config.GetCertificate,
 		localGetClientCertificate:   config.GetClientCertificate,
+		insecureSkipHelloVerify:     config.InsecureSkipVerifyHello,
 	}
 
 	// rfc5246#section-7.4.3

--- a/handshaker.go
+++ b/handshaker.go
@@ -109,6 +109,7 @@ type handshakeConfig struct {
 	retransmitInterval          time.Duration
 	customCipherSuites          func() []CipherSuite
 	ellipticCurves              []elliptic.Curve
+	insecureSkipHelloVerify     bool
 
 	onFlightState func(flightVal, handshakeState)
 	log           logging.LeveledLogger


### PR DESCRIPTION
#### Description
This is a pull request that add SkipHelloVerify option to DTLS library. This is a common behavior for WebRTC Peer on browser stack where DoS resistance on DTLS level is redundant as this is built into ICE.

It have been observed that snowflake, a crowdsourced censorship resistant proxy has been blocked in some part of Russia by identifying the transmission of HelloVerify packet. This pull request is a series of pull request to remove this distinguisher.
#### Reference issue

