### PR TITLE
Fixes for 2 potential runtime panics

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -39,8 +39,10 @@ Michiel De Backker <mail@backkem.me>
 Rachel Chen <rachel@chens.email>
 Robert Eperjesi <eperjesi@uber.com>
 Ryan Gordon <ryan.gordon@getcruise.com>
+Sam Lancia <sam.lancia@motorolasolutions.com>
 Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@siobud.com>
+Shelikhoo <xiaokangwang@outlook.com>
 Stefan Tatschner <stefan@rumpelsepp.org>
 Steffen Vogel <post@steffenvogel.de>
 Vadim <fffilimonov@yandex.ru>

--- a/pkg/protocol/handshake/fuzz_test.go
+++ b/pkg/protocol/handshake/fuzz_test.go
@@ -1,0 +1,21 @@
+package handshake
+
+import (
+	"testing"
+)
+
+func FuzzDtlsHandshake(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		h := &Handshake{}
+		if err := h.Unmarshal(data); err != nil {
+			return
+		}
+		buf, err := h.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(buf) == 0 {
+			t.Fatal("Zero buff")
+		}
+	})
+}

--- a/pkg/protocol/handshake/message_hello_verify_request.go
+++ b/pkg/protocol/handshake/message_hello_verify_request.go
@@ -51,8 +51,8 @@ func (m *MessageHelloVerifyRequest) Unmarshal(data []byte) error {
 	}
 	m.Version.Major = data[0]
 	m.Version.Minor = data[1]
-	cookieLength := data[2]
-	if len(data) < (int(cookieLength) + 3) {
+	cookieLength := int(data[2])
+	if len(data) < cookieLength+3 {
 		return errBufferTooSmall
 	}
 	m.Cookie = make([]byte, cookieLength)

--- a/pkg/protocol/handshake/message_server_hello.go
+++ b/pkg/protocol/handshake/message_server_hello.go
@@ -88,11 +88,14 @@ func (m *MessageServerHello) Unmarshal(data []byte) error {
 	m.SessionID = append([]byte{}, data[currOffset:currOffset+n]...)
 	currOffset += len(m.SessionID)
 
+	if len(data) < currOffset+2 {
+		return errBufferTooSmall
+	}
 	m.CipherSuiteID = new(uint16)
 	*m.CipherSuiteID = binary.BigEndian.Uint16(data[currOffset:])
 	currOffset += 2
 
-	if len(data) < currOffset {
+	if len(data) <= currOffset {
 		return errBufferTooSmall
 	}
 	if compressionMethod, ok := protocol.CompressionMethods()[protocol.CompressionMethodID(data[currOffset])]; ok {


### PR DESCRIPTION
The first 2 patches fix 2 issues where we could panic at runtime. The third patch adds a fuzz check for the DTLS handshake.

This fixes the following (pending) security advisories:
* Fixes: GHSA-4xgv-j62q-h3rj
* Fixes: GHSA-hxp2-xqf3-v83h

Both issues were disclosed privately by @nerd2 from Motorola Solutions, Inc. to the Pion security team.

## For maintainers

I've got 2 security advisories ready that I'll publish once this gets merged.
