### PR TITLE
Avoid a copy in compactRawPackets

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -430,6 +430,11 @@ func (c *Conn) writePackets(ctx context.Context, pkts []*packet) error {
 }
 
 func (c *Conn) compactRawPackets(rawPackets [][]byte) [][]byte {
+	// avoid a useless copy in the common case
+	if len(rawPackets) == 1 {
+		return rawPackets
+	}
+
 	combinedRawPackets := make([][]byte, 0)
 	currentCombinedRawPacket := make([]byte, 0)
 


### PR DESCRIPTION
The method compactRawPackets accumulates packets into MTU-sized
chunks.  Unfortunately, it systematically copies the list of
packets.

Fortunately, it's usually called with a list of just one packet,
in which case there's nothing to do.  Rather than rewriting the
code to avoid allocation altogether, we just optimise away the
trivial case.

This reduces the amount of garbage generated during bulk transfers
by some 10%.
