### PR TITLE
Enable supported EC point formats and supported algorithm extensions

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -15,6 +15,7 @@ Carson Hoffman <c@rsonhoffman.com>
 Cecylia Bocovich <cohosh@torproject.org>
 Chris Hiszpanski <thinkski@users.noreply.github.com>
 cnderrauber <zengjie9004@gmail.com>
+Daniel Mangum <georgedanielmangum@gmail.com>
 Daniele Sluijters <daenney@users.noreply.github.com>
 folbrich <frank.olbricht@gmail.com>
 Hayden James <hayden.james@gmail.com>

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -64,6 +64,8 @@ func Unmarshal(buf []byte) ([]Extension, error) {
 			err = unmarshalAndAppend(buf[offset:], &ServerName{})
 		case SupportedEllipticCurvesTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &SupportedEllipticCurves{})
+		case SupportedPointFormatsTypeValue:
+			err = unmarshalAndAppend(buf[offset:], &SupportedPointFormats{})
 		case UseSRTPTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &UseSRTP{})
 		case ALPNTypeValue:

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -66,6 +66,8 @@ func Unmarshal(buf []byte) ([]Extension, error) {
 			err = unmarshalAndAppend(buf[offset:], &SupportedEllipticCurves{})
 		case SupportedPointFormatsTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &SupportedPointFormats{})
+		case SupportedSignatureAlgorithmsTypeValue:
+			err = unmarshalAndAppend(buf[offset:], &SupportedSignatureAlgorithms{})
 		case UseSRTPTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &UseSRTP{})
 		case ALPNTypeValue:

--- a/pkg/protocol/extension/supported_elliptic_curves_test.go
+++ b/pkg/protocol/extension/supported_elliptic_curves_test.go
@@ -22,4 +22,11 @@ func TestExtensionSupportedGroups(t *testing.T) {
 	} else if !reflect.DeepEqual(raw, rawSupportedGroups) {
 		t.Errorf("extensionSupportedGroups marshal: got %#v, want %#v", raw, rawSupportedGroups)
 	}
+
+	roundtrip := &SupportedEllipticCurves{}
+	if err := roundtrip.Unmarshal(raw); err != nil {
+		t.Error(err)
+	} else if !reflect.DeepEqual(roundtrip, parsedSupportedGroups) {
+		t.Errorf("extensionSupportedGroups unmarshal: got %#v, want %#v", roundtrip, parsedSupportedGroups)
+	}
 }

--- a/pkg/protocol/extension/supported_point_formats.go
+++ b/pkg/protocol/extension/supported_point_formats.go
@@ -44,12 +44,14 @@ func (s *SupportedPointFormats) Marshal() ([]byte, error) {
 func (s *SupportedPointFormats) Unmarshal(data []byte) error {
 	if len(data) <= supportedPointFormatsSize {
 		return errBufferTooSmall
-	} else if TypeValue(binary.BigEndian.Uint16(data)) != s.TypeValue() {
+	}
+
+	if TypeValue(binary.BigEndian.Uint16(data)) != s.TypeValue() {
 		return errInvalidExtensionType
 	}
 
-	pointFormatCount := int(binary.BigEndian.Uint16(data[4:]))
-	if supportedGroupsHeaderSize+(pointFormatCount) > len(data) {
+	pointFormatCount := int(data[4])
+	if supportedPointFormatsSize+pointFormatCount > len(data) {
 		return errLengthMismatch
 	}
 

--- a/pkg/protocol/extension/supported_point_formats_test.go
+++ b/pkg/protocol/extension/supported_point_formats_test.go
@@ -22,4 +22,11 @@ func TestExtensionSupportedPointFormats(t *testing.T) {
 	} else if !reflect.DeepEqual(raw, rawExtensionSupportedPointFormats) {
 		t.Errorf("extensionSupportedPointFormats marshal: got %#v, want %#v", raw, rawExtensionSupportedPointFormats)
 	}
+
+	roundtrip := &SupportedPointFormats{}
+	if err := roundtrip.Unmarshal(raw); err != nil {
+		t.Error(err)
+	} else if !reflect.DeepEqual(roundtrip, parsedExtensionSupportedPointFormats) {
+		t.Errorf("extensionSupportedPointFormats unmarshal: got %#v, want %#v", roundtrip, parsedExtensionSupportedPointFormats)
+	}
 }

--- a/pkg/protocol/extension/supported_signature_algorithms_test.go
+++ b/pkg/protocol/extension/supported_signature_algorithms_test.go
@@ -35,4 +35,11 @@ func TestExtensionSupportedSignatureAlgorithms(t *testing.T) {
 	} else if !reflect.DeepEqual(raw, rawExtensionSupportedSignatureAlgorithms) {
 		t.Errorf("extensionSupportedSignatureAlgorithms marshal: got %#v, want %#v", raw, rawExtensionSupportedSignatureAlgorithms)
 	}
+
+	roundtrip := &SupportedSignatureAlgorithms{}
+	if err := roundtrip.Unmarshal(raw); err != nil {
+		t.Error(err)
+	} else if !reflect.DeepEqual(roundtrip, parsedExtensionSupportedSignatureAlgorithms) {
+		t.Errorf("extensionSupportedSignatureAlgorithms unmarshal: got %#v, want %#v", roundtrip, parsedExtensionSupportedSignatureAlgorithms)
+	}
 }


### PR DESCRIPTION
Enables parsing the elliptic curve supported points format extension.

https://www.rfc-editor.org/rfc/rfc8422.html#section-5.1.2

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Enables parsing the supported signature algorithms extension.

https://datatracker.ietf.org/doc/html/rfc5246#autoid-39

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

> Note: I noticed these while tracing and capturing packets in wireshark. They were present in the relevant `ClientHello` / `ServerHello`, but were not be extracted by their counterpart.