### PR TITLE
Fix return of nil alertErrors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -605,17 +605,16 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 				}
 			}
 		}
-		if hs {
-			hasHandshake = true
-		}
 
 		var e *alertError
-		if errors.As(err, &e) {
-			if e.IsFatalOrCloseNotify() {
-				return e
-			}
-		} else if err != nil {
+		if errors.As(err, &e) && e.IsFatalOrCloseNotify() {
+			return e
+		}
+		if err != nil {
 			return err
+		}
+		if hs {
+			hasHandshake = true
 		}
 	}
 	if hasHandshake {
@@ -645,11 +644,10 @@ func (c *Conn) handleQueuedPackets(ctx context.Context) error {
 			}
 		}
 		var e *alertError
-		if errors.As(err, &e) {
-			if e.IsFatalOrCloseNotify() {
-				return e
-			}
-		} else if err != nil {
+		if errors.As(err, &e) && e.IsFatalOrCloseNotify() {
+			return e
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -615,7 +615,7 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 				return e
 			}
 		} else if err != nil {
-			return e
+			return err
 		}
 	}
 	if hasHandshake {
@@ -650,7 +650,7 @@ func (c *Conn) handleQueuedPackets(ctx context.Context) error {
 				return e
 			}
 		} else if err != nil {
-			return e
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
#### Description

Fixes two cases where nil alert errors were being returned rather than
the underlying error. Calling methods on these nil alert errors can lead
to panics.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>
