### PR TITLE
Implement DTLS 1.2 Connection IDs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	"github.com/pion/logging"
 	"github.com/pion/transport/v2/dpipe"
@@ -30,7 +31,7 @@ func TestSimpleReadWrite(t *testing.T) {
 	gotHello := make(chan struct{})
 
 	go func() {
-		server, sErr := testServer(ctx, cb, &Config{
+		server, sErr := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{
 			Certificates:  []tls.Certificate{certificate},
 			LoggerFactory: logging.NewDefaultLoggerFactory(),
 		}, false)
@@ -48,7 +49,7 @@ func TestSimpleReadWrite(t *testing.T) {
 		}
 	}()
 
-	client, err := testClient(ctx, ca, &Config{
+	client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{
 		LoggerFactory:      logging.NewDefaultLoggerFactory(),
 		InsecureSkipVerify: true,
 	}, false)
@@ -78,7 +79,7 @@ func benchmarkConn(b *testing.B, n int64) {
 		certificate, err := selfsign.GenerateSelfSigned()
 		server := make(chan *Conn)
 		go func() {
-			s, sErr := testServer(ctx, cb, &Config{
+			s, sErr := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{
 				Certificates: []tls.Certificate{certificate},
 			}, false)
 			if err != nil {
@@ -94,7 +95,7 @@ func benchmarkConn(b *testing.B, n int64) {
 		b.ReportAllocs()
 		b.SetBytes(int64(len(hw)))
 		go func() {
-			client, cErr := testClient(ctx, ca, &Config{InsecureSkipVerify: true}, false)
+			client, cErr := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{InsecureSkipVerify: true}, false)
 			if cErr != nil {
 				b.Error(err)
 			}

--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -95,7 +95,7 @@ type CipherSuite interface {
 	Init(masterSecret, clientRandom, serverRandom []byte, isClient bool) error
 	IsInitialized() bool
 	Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, error)
-	Decrypt(in []byte) ([]byte, error)
+	Decrypt(h recordlayer.Header, in []byte) ([]byte, error)
 }
 
 // CipherSuiteName provides the same functionality as tls.CipherSuiteName

--- a/cipher_suite_test.go
+++ b/cipher_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v2/internal/ciphersuite"
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/transport/v2/dpipe"
 	"github.com/pion/transport/v2/test"
 )
@@ -70,14 +71,14 @@ func TestCustomCipherSuite(t *testing.T) {
 		c := make(chan result)
 
 		go func() {
-			client, err := testClient(ctx, ca, &Config{
+			client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{
 				CipherSuites:       []CipherSuiteID{},
 				CustomCipherSuites: cipherFactory,
 			}, true)
 			c <- result{client, err}
 		}()
 
-		server, err := testServer(ctx, cb, &Config{
+		server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{
 			CipherSuites:       []CipherSuiteID{},
 			CustomCipherSuites: cipherFactory,
 		}, true)

--- a/config.go
+++ b/config.go
@@ -176,6 +176,26 @@ type Config struct {
 	// skip hello verify phase and receive ServerHello after initial ClientHello.
 	// This have implication on DoS attack resistance.
 	InsecureSkipVerifyHello bool
+
+	// ConnectionIDGenerator generates connection identifiers that should be
+	// sent by the remote party if it supports the DTLS Connection Identifier
+	// extension, as determined during the handshake. Generated connection
+	// identifiers must always have the same length. Returning a zero-length
+	// connection identifier indicates that the local party supports sending
+	// connection identifiers but does not require the remote party to send
+	// them. A nil ConnectionIDGenerator indicates that connection identifiers
+	// are not supported.
+	// https://datatracker.ietf.org/doc/html/rfc9146
+	ConnectionIDGenerator func() []byte
+
+	// PaddingLengthGenerator generates the number of padding bytes used to
+	// inflate ciphertext size in order to obscure content size from observers.
+	// The length of the content is passed to the generator such that both
+	// deterministic and random padding schemes can be applied while not
+	// exceeding maximum record size.
+	// If no PaddingLengthGenerator is specified, padding will not be applied.
+	// https://datatracker.ietf.org/doc/html/rfc9146#section-4
+	PaddingLengthGenerator func(uint) uint
 }
 
 func defaultConnectContextMaker() (context.Context, func()) {

--- a/conn.go
+++ b/conn.go
@@ -4,6 +4,7 @@
 package dtls
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -21,8 +22,8 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
-	"github.com/pion/transport/v2/connctx"
 	"github.com/pion/transport/v2/deadline"
+	"github.com/pion/transport/v2/netctx"
 	"github.com/pion/transport/v2/replaydetector"
 )
 
@@ -45,21 +46,27 @@ func invalidKeyingLabels() map[string]bool {
 	}
 }
 
+type addrPkt struct {
+	rAddr net.Addr
+	data  []byte
+}
+
 // Conn represents a DTLS connection
 type Conn struct {
-	lock           sync.RWMutex     // Internal lock (must not be public)
-	nextConn       connctx.ConnCtx  // Embedded Conn, typically a udpconn we read/write from
-	fragmentBuffer *fragmentBuffer  // out-of-order and missing fragment handling
-	handshakeCache *handshakeCache  // caching of handshake messages for verifyData generation
-	decrypted      chan interface{} // Decrypted Application Data or error, pull by calling `Read`
-
-	state State // Internal state
+	lock           sync.RWMutex      // Internal lock (must not be public)
+	nextConn       netctx.PacketConn // Embedded Conn, typically a udpconn we read/write from
+	fragmentBuffer *fragmentBuffer   // out-of-order and missing fragment handling
+	handshakeCache *handshakeCache   // caching of handshake messages for verifyData generation
+	decrypted      chan interface{}  // Decrypted Application Data or error, pull by calling `Read`
+	rAddr          net.Addr
+	state          State // Internal state
 
 	maximumTransmissionUnit int
+	paddingLengthGenerator  func(uint) uint
 
 	handshakeCompletedSuccessfully atomic.Value
 
-	encryptedPackets [][]byte
+	encryptedPackets []addrPkt
 
 	connectionClosedByUser bool
 	closeLock              sync.Mutex
@@ -81,9 +88,8 @@ type Conn struct {
 	replayProtectionWindow uint
 }
 
-func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient bool, initialState *State) (*Conn, error) {
-	err := validateConfig(config)
-	if err != nil {
+func createConn(ctx context.Context, nextConn net.PacketConn, rAddr net.Addr, config *Config, isClient bool, initialState *State) (*Conn, error) {
+	if err := validateConfig(config); err != nil {
 		return nil, err
 	}
 
@@ -123,11 +129,18 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		replayProtectionWindow = defaultReplayProtectionWindow
 	}
 
+	paddingLengthGenerator := config.PaddingLengthGenerator
+	if paddingLengthGenerator == nil {
+		paddingLengthGenerator = func(uint) uint { return 0 }
+	}
+
 	c := &Conn{
-		nextConn:                connctx.New(nextConn),
+		rAddr:                   rAddr,
+		nextConn:                netctx.NewPacketConn(nextConn),
 		fragmentBuffer:          newFragmentBuffer(),
 		handshakeCache:          newHandshakeCache(),
 		maximumTransmissionUnit: mtu,
+		paddingLengthGenerator:  paddingLengthGenerator,
 
 		decrypted: make(chan interface{}, 1),
 		log:       logger,
@@ -188,6 +201,7 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 		localGetCertificate:         config.GetCertificate,
 		localGetClientCertificate:   config.GetClientCertificate,
 		insecureSkipHelloVerify:     config.InsecureSkipVerifyHello,
+		connectionIDGenerator:       config.ConnectionIDGenerator,
 	}
 
 	// rfc5246#section-7.4.3
@@ -234,44 +248,49 @@ func createConn(ctx context.Context, nextConn net.Conn, config *Config, isClient
 // Dial connects to the given network address and establishes a DTLS connection on top.
 // Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use DialWithContext() instead.
-func Dial(network string, raddr *net.UDPAddr, config *Config) (*Conn, error) {
+func Dial(network string, rAddr *net.UDPAddr, config *Config) (*Conn, error) {
 	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
-	return DialWithContext(ctx, network, raddr, config)
+	return DialWithContext(ctx, network, rAddr, config)
 }
 
 // Client establishes a DTLS connection over an existing connection.
 // Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use ClientWithContext() instead.
-func Client(conn net.Conn, config *Config) (*Conn, error) {
+func Client(conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
-	return ClientWithContext(ctx, conn, config)
+	return ClientWithContext(ctx, conn, rAddr, config)
 }
 
 // Server listens for incoming DTLS connections.
 // Connection handshake will timeout using ConnectContextMaker in the Config.
 // If you want to specify the timeout duration, use ServerWithContext() instead.
-func Server(conn net.Conn, config *Config) (*Conn, error) {
+func Server(conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	ctx, cancel := config.connectContextMaker()
 	defer cancel()
 
-	return ServerWithContext(ctx, conn, config)
+	return ServerWithContext(ctx, conn, rAddr, config)
 }
 
-// DialWithContext connects to the given network address and establishes a DTLS connection on top.
-func DialWithContext(ctx context.Context, network string, raddr *net.UDPAddr, config *Config) (*Conn, error) {
-	pConn, err := net.DialUDP(network, nil, raddr)
+// DialWithContext connects to the given network address and establishes a DTLS
+// connection on top.
+func DialWithContext(ctx context.Context, network string, rAddr *net.UDPAddr, config *Config) (*Conn, error) {
+	// net.ListenUDP is used rather than net.DialUDP as the latter prevents the
+	// use of net.PacketConn.WriteTo.
+	// https://github.com/golang/go/blob/ce5e37ec21442c6eb13a43e68ca20129102ebac0/src/net/udpsock_posix.go#L115
+	pConn, err := net.ListenUDP(network, nil)
 	if err != nil {
 		return nil, err
 	}
-	return ClientWithContext(ctx, pConn, config)
+
+	return ClientWithContext(ctx, pConn, rAddr, config)
 }
 
 // ClientWithContext establishes a DTLS connection over an existing connection.
-func ClientWithContext(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
+func ClientWithContext(ctx context.Context, conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	switch {
 	case config == nil:
 		return nil, errNoConfigProvided
@@ -279,16 +298,16 @@ func ClientWithContext(ctx context.Context, conn net.Conn, config *Config) (*Con
 		return nil, errPSKAndIdentityMustBeSetForClient
 	}
 
-	return createConn(ctx, conn, config, true, nil)
+	return createConn(ctx, conn, rAddr, config, true, nil)
 }
 
 // ServerWithContext listens for incoming DTLS connections.
-func ServerWithContext(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
+func ServerWithContext(ctx context.Context, conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	if config == nil {
 		return nil, errNoConfigProvided
 	}
 
-	return createConn(ctx, conn, config, false, nil)
+	return createConn(ctx, conn, rAddr, config, false, nil)
 }
 
 // Read reads data from the connection.
@@ -352,6 +371,7 @@ func (c *Conn) Write(p []byte) (int, error) {
 					Data: p,
 				},
 			},
+			shouldWrapCID: len(c.state.remoteConnectionID) > 0,
 			shouldEncrypt: true,
 		},
 	})
@@ -400,7 +420,8 @@ func (c *Conn) writePackets(ctx context.Context, pkts []*packet) error {
 			c.log.Tracef("[handshake:%v] -> %s (epoch: %d, seq: %d)",
 				srvCliStr(c.state.isClient), h.Header.Type.String(),
 				p.record.Header.Epoch, h.Header.MessageSequence)
-			c.handshakeCache.push(handshakeRaw[recordlayer.HeaderSize:], p.record.Header.Epoch, h.Header.MessageSequence, h.Header.Type, c.state.isClient)
+
+			c.handshakeCache.push(handshakeRaw[recordlayer.FixedHeaderSize:], p.record.Header.Epoch, h.Header.MessageSequence, h.Header.Type, c.state.isClient)
 
 			rawHandshakePackets, err := c.processHandshakePacket(p, h)
 			if err != nil {
@@ -421,7 +442,7 @@ func (c *Conn) writePackets(ctx context.Context, pkts []*packet) error {
 	compactedRawPackets := c.compactRawPackets(rawPackets)
 
 	for _, compactedRawPackets := range compactedRawPackets {
-		if _, err := c.nextConn.WriteContext(ctx, compactedRawPackets); err != nil {
+		if _, err := c.nextConn.WriteToContext(ctx, compactedRawPackets, c.rAddr); err != nil {
 			return netError(err)
 		}
 	}
@@ -465,9 +486,44 @@ func (c *Conn) processPacket(p *packet) ([]byte, error) {
 	}
 	p.record.Header.SequenceNumber = seq
 
-	rawPacket, err := p.record.Marshal()
-	if err != nil {
-		return nil, err
+	var rawPacket []byte
+	if p.shouldWrapCID {
+		// Record must be marshaled to populate fields used in inner plaintext.
+		if _, err := p.record.Marshal(); err != nil {
+			return nil, err
+		}
+		content, err := p.record.Content.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		inner := &recordlayer.InnerPlaintext{
+			Content:  content,
+			RealType: p.record.Header.ContentType,
+		}
+		rawInner, err := inner.Marshal() //nolint:govet
+		if err != nil {
+			return nil, err
+		}
+		cidHeader := &recordlayer.Header{
+			Version:        p.record.Header.Version,
+			ContentType:    protocol.ContentTypeConnectionID,
+			Epoch:          p.record.Header.Epoch,
+			ContentLen:     uint16(len(rawInner)),
+			ConnectionID:   c.state.remoteConnectionID,
+			SequenceNumber: p.record.Header.SequenceNumber,
+		}
+		rawPacket, err = cidHeader.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		p.record.Header = *cidHeader
+		rawPacket = append(rawPacket, rawInner...)
+	} else {
+		var err error
+		rawPacket, err = p.record.Marshal()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if p.shouldEncrypt {
@@ -499,22 +555,49 @@ func (c *Conn) processHandshakePacket(p *packet, h *handshake.Handshake) ([][]by
 			return nil, errSequenceNumberOverflow
 		}
 
-		recordlayerHeader := &recordlayer.Header{
-			Version:        p.record.Header.Version,
-			ContentType:    p.record.Header.ContentType,
-			ContentLen:     uint16(len(handshakeFragment)),
-			Epoch:          p.record.Header.Epoch,
-			SequenceNumber: seq,
+		var rawPacket []byte
+		if p.shouldWrapCID {
+			inner := &recordlayer.InnerPlaintext{
+				Content:  handshakeFragment,
+				RealType: protocol.ContentTypeHandshake,
+				Zeros:    c.paddingLengthGenerator(uint(len(handshakeFragment))),
+			}
+			rawInner, err := inner.Marshal() //nolint:govet
+			if err != nil {
+				return nil, err
+			}
+			cidHeader := &recordlayer.Header{
+				Version:        p.record.Header.Version,
+				ContentType:    protocol.ContentTypeConnectionID,
+				Epoch:          p.record.Header.Epoch,
+				ContentLen:     uint16(len(rawInner)),
+				ConnectionID:   c.state.remoteConnectionID,
+				SequenceNumber: p.record.Header.SequenceNumber,
+			}
+			rawPacket, err = cidHeader.Marshal()
+			if err != nil {
+				return nil, err
+			}
+			p.record.Header = *cidHeader
+			rawPacket = append(rawPacket, rawInner...)
+		} else {
+			recordlayerHeader := &recordlayer.Header{
+				Version:        p.record.Header.Version,
+				ContentType:    p.record.Header.ContentType,
+				ContentLen:     uint16(len(handshakeFragment)),
+				Epoch:          p.record.Header.Epoch,
+				SequenceNumber: seq,
+			}
+
+			rawPacket, err = recordlayerHeader.Marshal()
+			if err != nil {
+				return nil, err
+			}
+
+			p.record.Header = *recordlayerHeader
+			rawPacket = append(rawPacket, handshakeFragment...)
 		}
 
-		rawPacket, err := recordlayerHeader.Marshal()
-		if err != nil {
-			return nil, err
-		}
-
-		p.record.Header = *recordlayerHeader
-
-		rawPacket = append(rawPacket, handshakeFragment...)
 		if p.shouldEncrypt {
 			var err error
 			rawPacket, err = c.state.cipherSuite.Encrypt(p.record, rawPacket)
@@ -585,19 +668,19 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 	defer poolReadBuffer.Put(bufptr)
 
 	b := *bufptr
-	i, err := c.nextConn.ReadContext(ctx, b)
+	i, rAddr, err := c.nextConn.ReadFromContext(ctx, b)
 	if err != nil {
 		return netError(err)
 	}
 
-	pkts, err := recordlayer.UnpackDatagram(b[:i])
+	pkts, err := recordlayer.ContentAwareUnpackDatagram(b[:i], len(c.state.localConnectionID))
 	if err != nil {
 		return err
 	}
 
 	var hasHandshake bool
 	for _, p := range pkts {
-		hs, alert, err := c.handleIncomingPacket(ctx, p, true)
+		hs, alert, err := c.handleIncomingPacket(ctx, p, rAddr, true)
 		if alert != nil {
 			if alertErr := c.notify(ctx, alert.Level, alert.Description); alertErr != nil {
 				if err == nil {
@@ -635,7 +718,7 @@ func (c *Conn) handleQueuedPackets(ctx context.Context) error {
 	c.encryptedPackets = nil
 
 	for _, p := range pkts {
-		_, alert, err := c.handleIncomingPacket(ctx, p, false) // don't re-enqueue
+		_, alert, err := c.handleIncomingPacket(ctx, p.data, p.rAddr, false) // don't re-enqueue
 		if alert != nil {
 			if alertErr := c.notify(ctx, alert.Level, alert.Description); alertErr != nil {
 				if err == nil {
@@ -654,8 +737,13 @@ func (c *Conn) handleQueuedPackets(ctx context.Context) error {
 	return nil
 }
 
-func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue bool) (bool, *alert.Alert, error) { //nolint:gocognit
+func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, rAddr net.Addr, enqueue bool) (bool, *alert.Alert, error) { //nolint:gocognit
 	h := &recordlayer.Header{}
+	// Set connection ID size so that records of content type tls12_cid will
+	// be parsed correctly.
+	if len(c.state.localConnectionID) > 0 {
+		h.ConnectionID = make([]byte, len(c.state.localConnectionID))
+	}
 	if err := h.Unmarshal(buf); err != nil {
 		// Decode error must be silently discarded
 		// [RFC6347 Section-4.1.2.7]
@@ -674,7 +762,7 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 		}
 		if enqueue {
 			c.log.Debug("received packet of next epoch, queuing packet")
-			c.encryptedPackets = append(c.encryptedPackets, buf)
+			c.encryptedPackets = append(c.encryptedPackets, addrPkt{rAddr, buf})
 		}
 		return false, nil, nil
 	}
@@ -693,20 +781,64 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 		return false, nil, nil
 	}
 
+	// originalCID indicates whether the original record had content type
+	// Connection ID.
+	originalCID := false
+
 	// Decrypt
 	if h.Epoch != 0 {
 		if c.state.cipherSuite == nil || !c.state.cipherSuite.IsInitialized() {
 			if enqueue {
-				c.encryptedPackets = append(c.encryptedPackets, buf)
+				c.encryptedPackets = append(c.encryptedPackets, addrPkt{rAddr, buf})
 				c.log.Debug("handshake not finished, queuing packet")
 			}
 			return false, nil, nil
 		}
 
+		// If a connection identifier had been negotiated and encryption is
+		// enabled, the connection identifier MUST be sent.
+		if len(c.state.localConnectionID) > 0 && h.ContentType != protocol.ContentTypeConnectionID {
+			c.log.Debug("discarded packet missing connection ID after value negotiated")
+			return false, nil, nil
+		}
+
 		var err error
-		buf, err = c.state.cipherSuite.Decrypt(buf)
+		var hdr recordlayer.Header
+		if h.ContentType == protocol.ContentTypeConnectionID {
+			hdr.ConnectionID = make([]byte, len(c.state.localConnectionID))
+		}
+		buf, err = c.state.cipherSuite.Decrypt(hdr, buf)
 		if err != nil {
 			c.log.Debugf("%s: decrypt failed: %s", srvCliStr(c.state.isClient), err)
+			return false, nil, nil
+		}
+		// If this is a connection ID record, make it look like a normal record for
+		// further processing.
+		if h.ContentType == protocol.ContentTypeConnectionID {
+			originalCID = true
+			ip := &recordlayer.InnerPlaintext{}
+			if err := ip.Unmarshal(buf[h.Size():]); err != nil { //nolint:govet
+				c.log.Debugf("unpacking inner plaintext failed: %s", err)
+				return false, nil, nil
+			}
+			unpacked := &recordlayer.Header{
+				ContentType:    ip.RealType,
+				ContentLen:     uint16(len(ip.Content)),
+				Version:        h.Version,
+				Epoch:          h.Epoch,
+				SequenceNumber: h.SequenceNumber,
+			}
+			buf, err = unpacked.Marshal()
+			if err != nil {
+				c.log.Debugf("converting CID record to inner plaintext failed: %s", err)
+				return false, nil, nil
+			}
+			buf = append(buf, ip.Content...)
+		}
+
+		// If connection ID does not match discard the packet.
+		if !bytes.Equal(c.state.localConnectionID, h.ConnectionID) {
+			c.log.Debug("unexpected connection ID")
 			return false, nil, nil
 		}
 	}
@@ -736,6 +868,7 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 		return false, &alert.Alert{Level: alert.Fatal, Description: alert.DecodeError}, err
 	}
 
+	isLatestSeqNum := false
 	switch content := r.Content.(type) {
 	case *alert.Alert:
 		c.log.Tracef("%s: <- %s", srvCliStr(c.state.isClient), content.String())
@@ -744,12 +877,12 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 			// Respond with a close_notify [RFC5246 Section 7.2.1]
 			a = &alert.Alert{Level: alert.Warning, Description: alert.CloseNotify}
 		}
-		markPacketAsValid()
+		_ = markPacketAsValid()
 		return false, a, &alertError{content}
 	case *protocol.ChangeCipherSpec:
 		if c.state.cipherSuite == nil || !c.state.cipherSuite.IsInitialized() {
 			if enqueue {
-				c.encryptedPackets = append(c.encryptedPackets, buf)
+				c.encryptedPackets = append(c.encryptedPackets, addrPkt{rAddr, buf})
 				c.log.Debugf("CipherSuite not initialized, queuing packet")
 			}
 			return false, nil, nil
@@ -760,14 +893,14 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 
 		if c.state.getRemoteEpoch()+1 == newRemoteEpoch {
 			c.setRemoteEpoch(newRemoteEpoch)
-			markPacketAsValid()
+			isLatestSeqNum = markPacketAsValid()
 		}
 	case *protocol.ApplicationData:
 		if h.Epoch == 0 {
 			return false, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, errApplicationDataEpochZero
 		}
 
-		markPacketAsValid()
+		isLatestSeqNum = markPacketAsValid()
 
 		select {
 		case c.decrypted <- content.Data:
@@ -778,6 +911,18 @@ func (c *Conn) handleIncomingPacket(ctx context.Context, buf []byte, enqueue boo
 	default:
 		return false, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, fmt.Errorf("%w: %d", errUnhandledContextType, content.ContentType())
 	}
+
+	// Any valid connection ID record is a candidate for updating the remote
+	// address if it is the latest record received.
+	// https://datatracker.ietf.org/doc/html/rfc9146#peer-address-update
+	if originalCID && isLatestSeqNum {
+		if rAddr != c.RemoteAddr() {
+			c.lock.Lock()
+			c.rAddr = rAddr
+			c.lock.Unlock()
+		}
+	}
+
 	return false, nil, nil
 }
 
@@ -881,7 +1026,7 @@ func (c *Conn) handshake(ctx context.Context, cfg *handshakeConfig, initialFligh
 					}
 				} else {
 					switch {
-					case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled), errors.Is(err, io.EOF):
+					case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled), errors.Is(err, io.EOF), errors.Is(err, net.ErrClosed):
 					default:
 						if c.isHandshakeCompletedSuccessfully() {
 							// Keep read loop and pass the read error to Read()
@@ -995,7 +1140,9 @@ func (c *Conn) LocalAddr() net.Addr {
 
 // RemoteAddr implements net.Conn.RemoteAddr
 func (c *Conn) RemoteAddr() net.Addr {
-	return c.nextConn.RemoteAddr()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.rAddr
 }
 
 func (c *Conn) sessionKey() []byte {
@@ -1003,7 +1150,7 @@ func (c *Conn) sessionKey() []byte {
 		// As ServerName can be like 0.example.com, it's better to add
 		// delimiter character which is not allowed to be in
 		// neither address or domain name.
-		return []byte(c.nextConn.RemoteAddr().String() + "_" + c.fsm.cfg.serverName)
+		return []byte(c.rAddr.String() + "_" + c.fsm.cfg.serverName)
 	}
 	return c.state.SessionID
 }

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	"github.com/pion/transport/v2/dpipe"
 	"github.com/pion/transport/v2/test"
@@ -85,7 +86,7 @@ func TestContextConfig(t *testing.T) {
 			f: func() (func() (net.Conn, error), func()) {
 				ca, _ := dpipe.Pipe()
 				return func() (net.Conn, error) {
-						return Client(ca, config)
+						return Client(util.FromConn(ca), ca.RemoteAddr(), config)
 					}, func() {
 						_ = ca.Close()
 					}
@@ -97,7 +98,7 @@ func TestContextConfig(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 				ca, _ := dpipe.Pipe()
 				return func() (net.Conn, error) {
-						return ClientWithContext(ctx, ca, config)
+						return ClientWithContext(ctx, util.FromConn(ca), ca.RemoteAddr(), config)
 					}, func() {
 						cancel()
 						_ = ca.Close()
@@ -109,7 +110,7 @@ func TestContextConfig(t *testing.T) {
 			f: func() (func() (net.Conn, error), func()) {
 				ca, _ := dpipe.Pipe()
 				return func() (net.Conn, error) {
-						return Server(ca, config)
+						return Server(util.FromConn(ca), ca.RemoteAddr(), config)
 					}, func() {
 						_ = ca.Close()
 					}
@@ -121,7 +122,7 @@ func TestContextConfig(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 				ca, _ := dpipe.Pipe()
 				return func() (net.Conn, error) {
-						return ServerWithContext(ctx, ca, config)
+						return ServerWithContext(ctx, util.FromConn(ca), ca.RemoteAddr(), config)
 					}, func() {
 						cancel()
 						_ = ca.Close()

--- a/conn_test.go
+++ b/conn_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v2/internal/ciphersuite"
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v2/pkg/crypto/hash"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
@@ -265,12 +266,12 @@ func pipeConn(ca, cb net.Conn) (*Conn, *Conn, error) {
 
 	// Setup client
 	go func() {
-		client, err := testClient(ctx, ca, &Config{SRTPProtectionProfiles: []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80}}, true)
+		client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{SRTPProtectionProfiles: []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80}}, true)
 		c <- result{client, err}
 	}()
 
 	// Setup server
-	server, err := testServer(ctx, cb, &Config{SRTPProtectionProfiles: []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80}}, true)
+	server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{SRTPProtectionProfiles: []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80}}, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -285,7 +286,7 @@ func pipeConn(ca, cb net.Conn) (*Conn, *Conn, error) {
 	return res.c, server, nil
 }
 
-func testClient(ctx context.Context, c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error) {
+func testClient(ctx context.Context, c net.PacketConn, rAddr net.Addr, cfg *Config, generateCertificate bool) (*Conn, error) {
 	if generateCertificate {
 		clientCert, err := selfsign.GenerateSelfSigned()
 		if err != nil {
@@ -294,10 +295,10 @@ func testClient(ctx context.Context, c net.Conn, cfg *Config, generateCertificat
 		cfg.Certificates = []tls.Certificate{clientCert}
 	}
 	cfg.InsecureSkipVerify = true
-	return ClientWithContext(ctx, c, cfg)
+	return ClientWithContext(ctx, c, rAddr, cfg)
 }
 
-func testServer(ctx context.Context, c net.Conn, cfg *Config, generateCertificate bool) (*Conn, error) {
+func testServer(ctx context.Context, c net.PacketConn, rAddr net.Addr, cfg *Config, generateCertificate bool) (*Conn, error) {
 	if generateCertificate {
 		serverCert, err := selfsign.GenerateSelfSigned()
 		if err != nil {
@@ -305,7 +306,7 @@ func testServer(ctx context.Context, c net.Conn, cfg *Config, generateCertificat
 		}
 		cfg.Certificates = []tls.Certificate{serverCert}
 	}
-	return ServerWithContext(ctx, c, cfg)
+	return ServerWithContext(ctx, c, rAddr, cfg)
 }
 
 func sendClientHello(cookie []byte, ca net.Conn, sequenceNumber uint64, extensions []extension.Extension) error {
@@ -384,11 +385,11 @@ func TestHandshakeWithAlert(t *testing.T) {
 
 			ca, cb := dpipe.Pipe()
 			go func() {
-				_, err := testClient(ctx, ca, testCase.configClient, true)
+				_, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), testCase.configClient, true)
 				clientErr <- err
 			}()
 
-			_, errServer := testServer(ctx, cb, testCase.configServer, true)
+			_, errServer := testServer(ctx, util.FromConn(cb), ca.RemoteAddr(), testCase.configServer, true)
 			if !errors.Is(errServer, testCase.errServer) {
 				t.Fatalf("Server error exp(%v) failed(%v)", testCase.errServer, errServer)
 			}
@@ -551,7 +552,7 @@ func TestPSK(t *testing.T) {
 					VerifyConnection: test.ClientVerifyConnection,
 				}
 
-				c, err := testClient(ctx, ca, conf, false)
+				c, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), conf, false)
 				clientRes <- result{c, err}
 			}()
 
@@ -567,7 +568,7 @@ func TestPSK(t *testing.T) {
 				VerifyConnection: test.ServerVerifyConnection,
 			}
 
-			server, err := testServer(ctx, cb, config, false)
+			server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, false)
 			if test.WantFail {
 				res := <-clientRes
 				if err == nil || !strings.Contains(err.Error(), test.ExpectedServerErr) {
@@ -626,7 +627,7 @@ func TestPSKHintFail(t *testing.T) {
 			CipherSuites:    []CipherSuiteID{TLS_PSK_WITH_AES_128_CCM_8},
 		}
 
-		_, err := testClient(ctx, ca, conf, false)
+		_, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), conf, false)
 		clientErr <- err
 	}()
 
@@ -638,7 +639,7 @@ func TestPSKHintFail(t *testing.T) {
 		CipherSuites:    []CipherSuiteID{TLS_PSK_WITH_AES_128_CCM_8},
 	}
 
-	if _, err := testServer(ctx, cb, config, false); !errors.Is(err, serverAlertError) {
+	if _, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, false); !errors.Is(err, serverAlertError) {
 		t.Fatalf("TestPSK: Server error exp(%v) failed(%v)", serverAlertError, err)
 	}
 
@@ -665,7 +666,7 @@ func TestClientTimeout(t *testing.T) {
 	go func() {
 		conf := &Config{}
 
-		c, err := testClient(ctx, ca, conf, true)
+		c, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), conf, true)
 		if err == nil {
 			_ = c.Close() //nolint:contextcheck
 		}
@@ -753,11 +754,11 @@ func TestSRTPConfiguration(t *testing.T) {
 		c := make(chan result)
 
 		go func() {
-			client, err := testClient(ctx, ca, &Config{SRTPProtectionProfiles: test.ClientSRTP}, true)
+			client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{SRTPProtectionProfiles: test.ClientSRTP}, true)
 			c <- result{client, err}
 		}()
 
-		server, err := testServer(ctx, cb, &Config{SRTPProtectionProfiles: test.ServerSRTP}, true)
+		server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{SRTPProtectionProfiles: test.ServerSRTP}, true)
 		if !errors.Is(err, test.WantServerError) {
 			t.Errorf("TestSRTPConfiguration: Server Error Mismatch '%s': expected(%v) actual(%v)", test.Name, test.WantServerError, err)
 		}
@@ -961,11 +962,11 @@ func TestClientCertificate(t *testing.T) {
 				c := make(chan result)
 
 				go func() {
-					client, err := Client(ca, tt.clientCfg)
+					client, err := Client(util.FromConn(ca), ca.RemoteAddr(), tt.clientCfg)
 					c <- result{client, err}
 				}()
 
-				server, err := Server(cb, tt.serverCfg)
+				server, err := Server(util.FromConn(cb), cb.RemoteAddr(), tt.serverCfg)
 				res := <-c
 				defer func() {
 					if err == nil {
@@ -1039,6 +1040,120 @@ func TestClientCertificate(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestConnectionID(t *testing.T) {
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	clientCID := []byte{5, 77, 33, 24, 93, 27, 45, 81}
+	serverCID := []byte{64, 24, 73, 2, 17, 96, 38, 59}
+	cidEcho := func(echo []byte) func() []byte {
+		return func() []byte {
+			return echo
+		}
+	}
+	tests := map[string]struct {
+		clientCfg          *Config
+		serverCfg          *Config
+		clientConnectionID []byte
+		serverConnectionID []byte
+	}{
+		"BidirectionalConnectionIDs": {
+			clientCfg: &Config{
+				ConnectionIDGenerator: cidEcho(clientCID),
+			},
+			serverCfg: &Config{
+				ConnectionIDGenerator: cidEcho(serverCID),
+			},
+			clientConnectionID: clientCID,
+			serverConnectionID: serverCID,
+		},
+		"BothSupportOnlyClientSends": {
+			clientCfg: &Config{
+				ConnectionIDGenerator: cidEcho(nil),
+			},
+			serverCfg: &Config{
+				ConnectionIDGenerator: cidEcho(serverCID),
+			},
+			serverConnectionID: serverCID,
+		},
+		"BothSupportOnlyServerSends": {
+			clientCfg: &Config{
+				ConnectionIDGenerator: cidEcho(clientCID),
+			},
+			serverCfg: &Config{
+				ConnectionIDGenerator: cidEcho(nil),
+			},
+			clientConnectionID: clientCID,
+		},
+		"ClientDoesNotSupport": {
+			clientCfg: &Config{},
+			serverCfg: &Config{
+				ConnectionIDGenerator: cidEcho(serverCID),
+			},
+		},
+		"ServerDoesNotSupport": {
+			clientCfg: &Config{
+				ConnectionIDGenerator: cidEcho(clientCID),
+			},
+			serverCfg: &Config{},
+		},
+		"NeitherSupport": {
+			clientCfg: &Config{},
+			serverCfg: &Config{},
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			ca, cb := dpipe.Pipe()
+			type result struct {
+				c   *Conn
+				err error
+			}
+			c := make(chan result)
+
+			go func() {
+				client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), tt.clientCfg, true)
+				c <- result{client, err}
+			}()
+
+			server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), tt.serverCfg, true)
+			if err != nil {
+				t.Fatalf("Unexpected server error: %v", err)
+			}
+			res := <-c
+			if res.err != nil {
+				t.Fatalf("Unexpected client error: %v", res.err)
+			}
+			defer func() {
+				if err == nil {
+					_ = server.Close()
+				}
+				if res.err == nil {
+					_ = res.c.Close()
+				}
+			}()
+
+			if !bytes.Equal(res.c.state.localConnectionID, tt.clientConnectionID) {
+				t.Errorf("Unexpected client local connection ID\nwant: %v\ngot:%v", tt.clientConnectionID, res.c.state.localConnectionID)
+			}
+			if !bytes.Equal(res.c.state.remoteConnectionID, tt.serverConnectionID) {
+				t.Errorf("Unexpected client remote connection ID\nwant: %v\ngot:%v", tt.serverConnectionID, res.c.state.remoteConnectionID)
+			}
+			if !bytes.Equal(server.state.localConnectionID, tt.serverConnectionID) {
+				t.Errorf("Unexpected server local connection ID\nwant: %v\ngot:%v", tt.serverConnectionID, server.state.localConnectionID)
+			}
+			if !bytes.Equal(server.state.remoteConnectionID, tt.clientConnectionID) {
+				t.Errorf("Unexpected server remote connection ID\nwant: %v\ngot:%v", tt.clientConnectionID, server.state.remoteConnectionID)
+			}
+		})
+	}
 }
 
 func TestExtendedMasterSecret(t *testing.T) {
@@ -1157,11 +1272,11 @@ func TestExtendedMasterSecret(t *testing.T) {
 			c := make(chan result)
 
 			go func() {
-				client, err := testClient(ctx, ca, tt.clientCfg, true)
+				client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), tt.clientCfg, true)
 				c <- result{client, err}
 			}()
 
-			server, err := testServer(ctx, cb, tt.serverCfg, true)
+			server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), tt.serverCfg, true)
 			res := <-c
 			defer func() {
 				if err == nil {
@@ -1267,11 +1382,11 @@ func TestServerCertificate(t *testing.T) {
 				}
 				srvCh := make(chan result)
 				go func() {
-					s, err := Server(cb, tt.serverCfg)
+					s, err := Server(util.FromConn(cb), cb.RemoteAddr(), tt.serverCfg)
 					srvCh <- result{s, err}
 				}()
 
-				cli, err := Client(ca, tt.clientCfg)
+				cli, err := Client(util.FromConn(ca), ca.RemoteAddr(), tt.clientCfg)
 				if err == nil {
 					_ = cli.Close()
 				}
@@ -1371,11 +1486,11 @@ func TestCipherSuiteConfiguration(t *testing.T) {
 			c := make(chan result)
 
 			go func() {
-				client, err := testClient(ctx, ca, &Config{CipherSuites: test.ClientCipherSuites}, true)
+				client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{CipherSuites: test.ClientCipherSuites}, true)
 				c <- result{client, err}
 			}()
 
-			server, err := testServer(ctx, cb, &Config{CipherSuites: test.ServerCipherSuites}, true)
+			server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{CipherSuites: test.ServerCipherSuites}, true)
 			if err == nil {
 				defer func() {
 					_ = server.Close()
@@ -1440,7 +1555,7 @@ func TestCertificateAndPSKServer(t *testing.T) {
 					config.CipherSuites = []CipherSuiteID{TLS_PSK_WITH_AES_128_GCM_SHA256}
 				}
 
-				client, err := testClient(ctx, ca, config, false)
+				client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), config, false)
 				c <- result{client, err}
 			}()
 
@@ -1451,7 +1566,7 @@ func TestCertificateAndPSKServer(t *testing.T) {
 				},
 			}
 
-			server, err := testServer(ctx, cb, config, true)
+			server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true)
 			if err == nil {
 				defer func() {
 					_ = server.Close()
@@ -1543,11 +1658,11 @@ func TestPSKConfiguration(t *testing.T) {
 		c := make(chan result)
 
 		go func() {
-			client, err := testClient(ctx, ca, &Config{PSK: test.ClientPSK, PSKIdentityHint: test.ClientPSKIdentity}, test.ClientHasCertificate)
+			client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{PSK: test.ClientPSK, PSKIdentityHint: test.ClientPSKIdentity}, test.ClientHasCertificate)
 			c <- result{client, err}
 		}()
 
-		_, err := testServer(ctx, cb, &Config{PSK: test.ServerPSK, PSKIdentityHint: test.ServerPSKIdentity}, test.ServerHasCertificate)
+		_, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{PSK: test.ServerPSK, PSKIdentityHint: test.ServerPSKIdentity}, test.ServerHasCertificate)
 		if err != nil || test.WantServerError != nil {
 			if !(err != nil && test.WantServerError != nil && err.Error() == test.WantServerError.Error()) {
 				t.Fatalf("TestPSKConfiguration: Server Error Mismatch '%s': expected(%v) actual(%v)", test.Name, test.WantServerError, err)
@@ -1677,7 +1792,7 @@ func TestServerTimeout(t *testing.T) {
 		FlightInterval: 100 * time.Millisecond,
 	}
 
-	_, serverErr := testServer(ctx, cb, config, true)
+	_, serverErr := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true)
 	var netErr net.Error
 	if !errors.As(serverErr, &netErr) || !netErr.Timeout() {
 		t.Fatalf("Client error exp(Temporary network error) failed(%v)", serverErr)
@@ -1792,7 +1907,7 @@ func TestProtocolVersionValidation(t *testing.T) {
 				defer wg.Wait()
 				go func() {
 					defer wg.Done()
-					if _, err := testServer(ctx, cb, config, true); !errors.Is(err, errUnsupportedProtocolVersion) {
+					if _, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true); !errors.Is(err, errUnsupportedProtocolVersion) {
 						t.Errorf("Client error exp(%v) failed(%v)", errUnsupportedProtocolVersion, err)
 					}
 				}()
@@ -1882,7 +1997,7 @@ func TestProtocolVersionValidation(t *testing.T) {
 				defer wg.Wait()
 				go func() {
 					defer wg.Done()
-					if _, err := testClient(ctx, cb, config, true); !errors.Is(err, errUnsupportedProtocolVersion) {
+					if _, err := testClient(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true); !errors.Is(err, errUnsupportedProtocolVersion) {
 						t.Errorf("Server error exp(%v) failed(%v)", errUnsupportedProtocolVersion, err)
 					}
 				}()
@@ -1980,7 +2095,7 @@ func TestMultipleHelloVerifyRequest(t *testing.T) {
 	defer wg.Wait()
 	go func() {
 		defer wg.Done()
-		_, _ = testClient(ctx, ca, &Config{}, false)
+		_, _ = testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{}, false)
 	}()
 
 	for i, cookie := range cookies {
@@ -2052,7 +2167,7 @@ func TestRenegotationInfo(t *testing.T) {
 			defer cancel()
 
 			go func() {
-				if _, err := testServer(ctx, cb, &Config{}, true); !errors.Is(err, context.Canceled) {
+				if _, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{}, true); !errors.Is(err, context.Canceled) {
 					t.Error(err)
 				}
 			}()
@@ -2164,7 +2279,7 @@ func TestServerNameIndicationExtension(t *testing.T) {
 					ServerName: test.ServerName,
 				}
 
-				_, _ = testClient(ctx, ca, conf, false)
+				_, _ = testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), conf, false)
 			}()
 
 			// Receive ClientHello
@@ -2282,7 +2397,7 @@ func TestALPNExtension(t *testing.T) {
 				conf := &Config{
 					SupportedProtocols: test.ClientProtocolNameList,
 				}
-				_, _ = testClient(ctx, ca, conf, false)
+				_, _ = testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), conf, false)
 			}()
 
 			// Receive ClientHello
@@ -2300,7 +2415,7 @@ func TestALPNExtension(t *testing.T) {
 				conf := &Config{
 					SupportedProtocols: test.ServerProtocolNameList,
 				}
-				if _, err2 := testServer(ctx2, cb2, conf, true); !errors.Is(err2, context.Canceled) {
+				if _, err2 := testServer(ctx2, util.FromConn(cb2), cb2.RemoteAddr(), conf, true); !errors.Is(err2, context.Canceled) {
 					if test.ExpectAlertFromServer { //nolint
 						// Assert the error type?
 					} else {
@@ -2447,7 +2562,7 @@ func TestSupportedGroupsExtension(t *testing.T) {
 
 		ca, cb := dpipe.Pipe()
 		go func() {
-			if _, err := testServer(ctx, cb, &Config{}, true); !errors.Is(err, context.Canceled) {
+			if _, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{}, true); !errors.Is(err, context.Canceled) {
 				t.Error(err)
 			}
 		}()
@@ -2556,7 +2671,7 @@ func TestSessionResume(t *testing.T) {
 				SessionStore: ss,
 				MTU:          100,
 			}
-			c, err := testClient(ctx, ca, config, false)
+			c, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), config, false)
 			clientRes <- result{c, err}
 		}()
 
@@ -2566,7 +2681,7 @@ func TestSessionResume(t *testing.T) {
 			SessionStore: ss,
 			MTU:          100,
 		}
-		server, err := testServer(ctx, cb, config, true)
+		server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true)
 		if err != nil {
 			t.Fatalf("TestSessionResume: Server failed(%v)", err)
 		}
@@ -2610,14 +2725,14 @@ func TestSessionResume(t *testing.T) {
 				ServerName:   "example.com",
 				SessionStore: s1,
 			}
-			c, err := testClient(ctx, ca, config, false)
+			c, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), config, false)
 			clientRes <- result{c, err}
 		}()
 
 		config := &Config{
 			SessionStore: s2,
 		}
-		server, err := testServer(ctx, cb, config, true)
+		server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), config, true)
 		if err != nil {
 			t.Fatalf("TestSessionResumetion: Server failed(%v)", err)
 		}
@@ -2715,7 +2830,7 @@ func TestCipherSuiteMatchesCertificateType(t *testing.T) {
 
 			ca, cb := dpipe.Pipe()
 			go func() {
-				c, err := testClient(context.TODO(), ca, &Config{CipherSuites: test.cipherList}, false)
+				c, err := testClient(context.TODO(), util.FromConn(ca), ca.RemoteAddr(), &Config{CipherSuites: test.cipherList}, false)
 				clientErr <- err
 				client <- c
 			}()
@@ -2740,7 +2855,7 @@ func TestCipherSuiteMatchesCertificateType(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if s, err := testServer(context.TODO(), cb, &Config{
+			if s, err := testServer(context.TODO(), util.FromConn(cb), cb.RemoteAddr(), &Config{
 				CipherSuites: test.cipherList,
 				Certificates: []tls.Certificate{serverCert},
 			}, false); err != nil {
@@ -2805,7 +2920,7 @@ func TestMultipleServerCertificates(t *testing.T) {
 
 			ca, cb := dpipe.Pipe()
 			go func() {
-				c, err := testClient(context.TODO(), ca, &Config{
+				c, err := testClient(context.TODO(), util.FromConn(ca), ca.RemoteAddr(), &Config{
 					RootCAs:    caPool,
 					ServerName: test.RequestServerName,
 					VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -2825,7 +2940,7 @@ func TestMultipleServerCertificates(t *testing.T) {
 				client <- c
 			}()
 
-			if s, err := testServer(context.TODO(), cb, &Config{Certificates: []tls.Certificate{fooCert, barCert}}, false); err != nil {
+			if s, err := testServer(context.TODO(), util.FromConn(cb), cb.RemoteAddr(), &Config{Certificates: []tls.Certificate{fooCert, barCert}}, false); err != nil {
 				t.Fatal(err)
 			} else if err = s.Close(); err != nil {
 				t.Fatal(err)
@@ -2877,11 +2992,11 @@ func TestEllipticCurveConfiguration(t *testing.T) {
 		c := make(chan result)
 
 		go func() {
-			client, err := testClient(ctx, ca, &Config{CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}, EllipticCurves: test.ConfigCurves}, true)
+			client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}, EllipticCurves: test.ConfigCurves}, true)
 			c <- result{client, err}
 		}()
 
-		server, err := testServer(ctx, cb, &Config{CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}, EllipticCurves: test.ConfigCurves}, true)
+		server, err := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{CipherSuites: []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}, EllipticCurves: test.ConfigCurves}, true)
 		if err != nil {
 			t.Fatalf("Server error: %v", err)
 		}
@@ -2933,7 +3048,7 @@ func TestSkipHelloVerify(t *testing.T) {
 	gotHello := make(chan struct{})
 
 	go func() {
-		server, sErr := testServer(ctx, cb, &Config{
+		server, sErr := testServer(ctx, util.FromConn(cb), cb.RemoteAddr(), &Config{
 			Certificates:            []tls.Certificate{certificate},
 			LoggerFactory:           logging.NewDefaultLoggerFactory(),
 			InsecureSkipVerifyHello: true,
@@ -2952,7 +3067,7 @@ func TestSkipHelloVerify(t *testing.T) {
 		}
 	}()
 
-	client, err := testClient(ctx, ca, &Config{
+	client, err := testClient(ctx, util.FromConn(ca), ca.RemoteAddr(), &Config{
 		LoggerFactory:      logging.NewDefaultLoggerFactory(),
 		InsecureSkipVerify: true,
 	}, false)

--- a/connection_id.go
+++ b/connection_id.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import "crypto/rand"
+
+// RandomCIDGenerator is a random Connection ID generator where CID is the
+// specified size. Specifying a size of 0 will indicate to peers that sending a
+// Connection ID is not necessary.
+func RandomCIDGenerator(size int) func() []byte {
+	return func() []byte {
+		cid := make([]byte, size)
+		if _, err := rand.Read(cid); err != nil {
+			panic(err) //nolint -- nonrecoverable
+		}
+		return cid
+	}
+}
+
+// OnlySendCIDGenerator enables sending Connection IDs negotiated with a peer,
+// but indicates to the peer that sending Connection IDs in return is not
+// necessary.
+func OnlySendCIDGenerator() func() []byte {
+	return func() []byte {
+		return nil
+	}
+}

--- a/connection_id_test.go
+++ b/connection_id_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import "testing"
+
+func TestRandomConnectionIDGenerator(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		size   int
+	}{
+		"LengthMatch": {
+			reason: "Zero size should match length of generated CID.",
+			size:   0,
+		},
+		"LengthMatchSome": {
+			reason: "Non-zero size should match length of generated CID with non-zero.",
+			size:   8,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if cidLen := len(RandomCIDGenerator(tc.size)()); cidLen != tc.size {
+				t.Errorf("%s\nRandomCIDGenerator: expected CID length %d, but got %d.", tc.reason, tc.size, cidLen)
+			}
+		})
+	}
+}
+
+func TestOnlySendCIDGenerator(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+	}{
+		"LengthMatch": {
+			reason: "CID length should always be zero.",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if cidLen := len(OnlySendCIDGenerator()()); cidLen != 0 {
+				t.Errorf("%s\nOnlySendCIDGenerator: expected CID length %d, but got %d.", tc.reason, 0, cidLen)
+			}
+		})
+	}
+}

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	transportTest "github.com/pion/transport/v2/test"
 )
@@ -144,7 +145,7 @@ func TestPionE2ELossy(t *testing.T) {
 					cfg.Certificates = []tls.Certificate{clientCert}
 				}
 
-				client, startupErr := dtls.Client(br.GetConn0(), cfg)
+				client, startupErr := dtls.Client(util.FromConn(br.GetConn0()), br.GetConn0().RemoteAddr(), cfg)
 				clientDone <- runResult{client, startupErr}
 			}()
 
@@ -159,7 +160,7 @@ func TestPionE2ELossy(t *testing.T) {
 					cfg.ClientAuth = dtls.RequireAnyClientCert
 				}
 
-				server, startupErr := dtls.Server(br.GetConn1(), cfg)
+				server, startupErr := dtls.Server(util.FromConn(br.GetConn1()), br.GetConn1().RemoteAddr(), cfg)
 				serverDone <- runResult{server, startupErr}
 			}()
 

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -69,7 +69,19 @@ func flight0Parse(_ context.Context, _ flightConn, state *State, cache *handshak
 			state.serverName = e.ServerName // remote server name
 		case *extension.ALPN:
 			state.peerSupportedProtocols = e.ProtocolNameList
+		case *extension.ConnectionID:
+			// Only set connection ID to be sent if server supports connection
+			// IDs.
+			if cfg.connectionIDGenerator != nil {
+				state.remoteConnectionID = e.CID
+			}
 		}
+	}
+
+	// If the client doesn't support connection IDs, the server should not
+	// expect one to be sent.
+	if state.remoteConnectionID == nil {
+		state.localConnectionID = nil
 	}
 
 	if cfg.extendedMasterSecret == RequireExtendedMasterSecret && !state.extendedMasterSecret {

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -118,6 +118,14 @@ func flight1Generate(c flightConn, state *State, _ *handshakeCache, cfg *handsha
 		}
 	}
 
+	// If we have a connection ID generator, use it. The CID may be zero length,
+	// in which case we are just requesting that the server send us a CID to
+	// use.
+	if cfg.connectionIDGenerator != nil {
+		state.localConnectionID = cfg.connectionIDGenerator()
+		extensions = append(extensions, &extension.ConnectionID{CID: state.localConnectionID})
+	}
+
 	return []*packet{
 		{
 			record: &recordlayer.RecordLayer{

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -277,6 +277,7 @@ func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 					},
 				},
 			},
+			shouldWrapCID:            len(state.remoteConnectionID) > 0,
 			shouldEncrypt:            true,
 			resetLocalSequenceNumber: true,
 		})

--- a/flight6handler.go
+++ b/flight6handler.go
@@ -77,6 +77,7 @@ func flight6Generate(_ flightConn, state *State, cache *handshakeCache, cfg *han
 					},
 				},
 			},
+			shouldWrapCID:            len(state.remoteConnectionID) > 0,
 			shouldEncrypt:            true,
 			resetLocalSequenceNumber: true,
 		},

--- a/fragment_buffer.go
+++ b/fragment_buffer.go
@@ -58,7 +58,7 @@ func (f *fragmentBuffer) push(buf []byte) (bool, error) {
 		return false, nil
 	}
 
-	for buf = buf[recordlayer.HeaderSize:]; len(buf) != 0; frag = new(fragment) {
+	for buf = buf[recordlayer.FixedHeaderSize:]; len(buf) != 0; frag = new(fragment) {
 		if err := frag.handshakeHeader.Unmarshal(buf); err != nil {
 			return false, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/pion/dtls/v2
 
 require (
 	github.com/pion/logging v0.2.2
-	github.com/pion/transport/v2 v2.2.1
+	github.com/pion/transport/v2 v2.2.2-0.20230802201558-f2dffd80896b
 	golang.org/x/crypto v0.12.0
 	golang.org/x/net v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
-github.com/pion/transport/v2 v2.2.1 h1:7qYnCBlpgSJNYMbLCKuSY9KbQdBFoETvPNETv0y4N7c=
-github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1Aq29pGcU5g=
+github.com/pion/transport/v2 v2.2.2-0.20230802201558-f2dffd80896b h1:g/axuqY9eU5L6YeAQSq+yW4CU5fPqOb90EaWI+8xeiI=
+github.com/pion/transport/v2 v2.2.2-0.20230802201558-f2dffd80896b/go.mod h1:OJg3ojoBJopjEeECq2yJdXH9YVrUJ1uQ++NjXLOUorc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -12,8 +12,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -26,7 +26,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
 golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
@@ -39,14 +38,12 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
 golang.org/x/term v0.11.0/go.mod h1:zC9APTIj3jG3FdV/Ons+XE1riIZXG4aZ4GTHiPZJPIU=

--- a/handshaker.go
+++ b/handshaker.go
@@ -113,6 +113,7 @@ type handshakeConfig struct {
 	customCipherSuites          func() []CipherSuite
 	ellipticCurves              []elliptic.Curve
 	insecureSkipHelloVerify     bool
+	connectionIDGenerator       func() []byte
 
 	onFlightState func(flightVal, handshakeState)
 	log           logging.LeveledLogger

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -409,7 +409,7 @@ func (c *flightTestConn) writePackets(_ context.Context, pkts []*packet) error {
 				return err
 			}
 
-			c.handshakeCache.push(handshakeRaw[recordlayer.HeaderSize:], p.record.Header.Epoch, h.Header.MessageSequence, h.Header.Type, c.state.isClient)
+			c.handshakeCache.push(handshakeRaw[recordlayer.FixedHeaderSize:], p.record.Header.Epoch, h.Header.MessageSequence, h.Header.Type, c.state.isClient)
 
 			content, err := h.Message.Marshal()
 			if err != nil {

--- a/internal/ciphersuite/aes_ccm.go
+++ b/internal/ciphersuite/aes_ccm.go
@@ -103,11 +103,11 @@ func (c *AesCcm) Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, erro
 }
 
 // Decrypt decrypts a single TLS RecordLayer
-func (c *AesCcm) Decrypt(raw []byte) ([]byte, error) {
+func (c *AesCcm) Decrypt(h recordlayer.Header, raw []byte) ([]byte, error) {
 	cipherSuite, ok := c.ccm.Load().(*ciphersuite.CCM)
 	if !ok {
 		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
-	return cipherSuite.Decrypt(raw)
+	return cipherSuite.Decrypt(h, raw)
 }

--- a/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_128_gcm_sha256.go
@@ -98,11 +98,11 @@ func (c *TLSEcdheEcdsaWithAes128GcmSha256) Encrypt(pkt *recordlayer.RecordLayer,
 }
 
 // Decrypt decrypts a single TLS RecordLayer
-func (c *TLSEcdheEcdsaWithAes128GcmSha256) Decrypt(raw []byte) ([]byte, error) {
+func (c *TLSEcdheEcdsaWithAes128GcmSha256) Decrypt(h recordlayer.Header, raw []byte) ([]byte, error) {
 	cipherSuite, ok := c.gcm.Load().(*ciphersuite.GCM)
 	if !ok {
 		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
-	return cipherSuite.Decrypt(raw)
+	return cipherSuite.Decrypt(h, raw)
 }

--- a/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
+++ b/internal/ciphersuite/tls_ecdhe_ecdsa_with_aes_256_cbc_sha.go
@@ -104,11 +104,11 @@ func (c *TLSEcdheEcdsaWithAes256CbcSha) Encrypt(pkt *recordlayer.RecordLayer, ra
 }
 
 // Decrypt decrypts a single TLS RecordLayer
-func (c *TLSEcdheEcdsaWithAes256CbcSha) Decrypt(raw []byte) ([]byte, error) {
+func (c *TLSEcdheEcdsaWithAes256CbcSha) Decrypt(h recordlayer.Header, raw []byte) ([]byte, error) {
 	cipherSuite, ok := c.cbc.Load().(*ciphersuite.CBC)
 	if !ok {
 		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
-	return cipherSuite.Decrypt(raw)
+	return cipherSuite.Decrypt(h, raw)
 }

--- a/internal/ciphersuite/tls_ecdhe_psk_with_aes_128_cbc_sha256.go
+++ b/internal/ciphersuite/tls_ecdhe_psk_with_aes_128_cbc_sha256.go
@@ -108,11 +108,11 @@ func (c *TLSEcdhePskWithAes128CbcSha256) Encrypt(pkt *recordlayer.RecordLayer, r
 }
 
 // Decrypt decrypts a single TLS RecordLayer
-func (c *TLSEcdhePskWithAes128CbcSha256) Decrypt(raw []byte) ([]byte, error) {
+func (c *TLSEcdhePskWithAes128CbcSha256) Decrypt(h recordlayer.Header, raw []byte) ([]byte, error) {
 	cipherSuite, ok := c.cbc.Load().(*ciphersuite.CBC)
 	if !ok { // !c.isInitialized()
 		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
-	return cipherSuite.Decrypt(raw)
+	return cipherSuite.Decrypt(h, raw)
 }

--- a/internal/ciphersuite/tls_psk_with_aes_128_cbc_sha256.go
+++ b/internal/ciphersuite/tls_psk_with_aes_128_cbc_sha256.go
@@ -103,11 +103,11 @@ func (c *TLSPskWithAes128CbcSha256) Encrypt(pkt *recordlayer.RecordLayer, raw []
 }
 
 // Decrypt decrypts a single TLS RecordLayer
-func (c *TLSPskWithAes128CbcSha256) Decrypt(raw []byte) ([]byte, error) {
+func (c *TLSPskWithAes128CbcSha256) Decrypt(h recordlayer.Header, raw []byte) ([]byte, error) {
 	cipherSuite, ok := c.cbc.Load().(*ciphersuite.CBC)
 	if !ok {
 		return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteNotInit)
 	}
 
-	return cipherSuite.Decrypt(raw)
+	return cipherSuite.Decrypt(h, raw)
 }

--- a/internal/util/net.go
+++ b/internal/util/net.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package util contains small helpers used across the repo
+package util
+
+import (
+	"net"
+	"time"
+)
+
+// packetConn wraps a net.Conn with methods that satisfy net.PacketConn.
+type packetConn struct {
+	conn net.Conn
+}
+
+// FromConn converts a net.Conn into a net.PacketConn.
+func FromConn(conn net.Conn) net.PacketConn {
+	return &packetConn{conn}
+}
+
+// ReadFrom reads from the underlying net.Conn and returns its remote address.
+func (cp *packetConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, err := cp.conn.Read(b)
+	return n, cp.conn.RemoteAddr(), err
+}
+
+// WriteTo writes to the underlying net.Conn.
+func (cp *packetConn) WriteTo(b []byte, _ net.Addr) (int, error) {
+	n, err := cp.conn.Write(b)
+	return n, err
+}
+
+// Close closes the underlying net.Conn.
+func (cp *packetConn) Close() error {
+	return cp.conn.Close()
+}
+
+// LocalAddr returns the local address of the underlying net.Conn.
+func (cp *packetConn) LocalAddr() net.Addr {
+	return cp.conn.LocalAddr()
+}
+
+// SetDeadline sets the deadline on the underlying net.Conn.
+func (cp *packetConn) SetDeadline(t time.Time) error {
+	return cp.conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline on the underlying net.Conn.
+func (cp *packetConn) SetReadDeadline(t time.Time) error {
+	return cp.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline on the underlying net.Conn.
+func (cp *packetConn) SetWriteDeadline(t time.Time) error {
+	return cp.conn.SetWriteDeadline(t)
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -6,6 +6,8 @@ package util
 
 import (
 	"encoding/binary"
+
+	"golang.org/x/crypto/cryptobyte"
 )
 
 // BigEndianUint24 returns the value of a big endian uint24
@@ -39,4 +41,11 @@ func Max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// AddUint48 appends a big-endian, 48-bit value to the byte string.
+// Remove if / when https://github.com/golang/crypto/pull/265 is merged
+// upstream.
+func AddUint48(b *cryptobyte.Builder, v uint64) {
+	b.AddBytes([]byte{byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+func TestAddUint48(t *testing.T) {
+	cases := map[string]struct {
+		reason  string
+		builder *cryptobyte.Builder
+		postAdd func(*cryptobyte.Builder)
+		in      uint64
+		want    []byte
+	}{
+		"OnlyUint48": {
+			reason:  "Adding only a 48-bit unsigned integer should yield expected result.",
+			builder: &cryptobyte.Builder{},
+			in:      0xfefcff3cfdfc,
+			want:    []byte{254, 252, 255, 60, 253, 252},
+		},
+		"ExistingAddUint48": {
+			reason: "Adding a 48-bit unsigned integer to a builder with existing bytes should yield expected result.",
+			builder: func() *cryptobyte.Builder {
+				var b cryptobyte.Builder
+				b.AddUint64(0xffffffffffffffff)
+				return &b
+			}(),
+			in:   0xfefcff3cfdfc,
+			want: []byte{255, 255, 255, 255, 255, 255, 255, 255, 254, 252, 255, 60, 253, 252},
+		},
+		"ExistingAddUint48AndMore": {
+			reason: "Adding a 48-bit unsigned integer to a builder with existing bytes, then adding more bytes, should yield expected result.",
+			builder: func() *cryptobyte.Builder {
+				var b cryptobyte.Builder
+				b.AddUint64(0xffffffffffffffff)
+				return &b
+			}(),
+			postAdd: func(b *cryptobyte.Builder) {
+				b.AddUint32(0xffffffff)
+			},
+			in:   0xfefcff3cfdfc,
+			want: []byte{255, 255, 255, 255, 255, 255, 255, 255, 254, 252, 255, 60, 253, 252, 255, 255, 255, 255},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			AddUint48(tc.builder, tc.in)
+			if tc.postAdd != nil {
+				tc.postAdd(tc.builder)
+			}
+			got := tc.builder.BytesOrPanic()
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("Bytes() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/listener.go
+++ b/listener.go
@@ -6,6 +6,7 @@ package dtls
 import (
 	"net"
 
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/protocol"
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
 	"github.com/pion/transport/v2/udp"
@@ -67,7 +68,7 @@ func (l *listener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Server(c, l.config)
+	return Server(util.FromConn(c), c.RemoteAddr(), l.config)
 }
 
 // Close closes the listener.

--- a/packet.go
+++ b/packet.go
@@ -3,10 +3,13 @@
 
 package dtls
 
-import "github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+import (
+	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+)
 
 type packet struct {
 	record                   *recordlayer.RecordLayer
 	shouldEncrypt            bool
+	shouldWrapCID            bool
 	resetLocalSequenceNumber bool
 }

--- a/pkg/crypto/ciphersuite/cbc.go
+++ b/pkg/crypto/ciphersuite/cbc.go
@@ -15,6 +15,7 @@ import ( //nolint:gci
 	"github.com/pion/dtls/v2/pkg/crypto/prf"
 	"github.com/pion/dtls/v2/pkg/protocol"
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+	"golang.org/x/crypto/cryptobyte"
 )
 
 // block ciphers using cipher block chaining.
@@ -64,18 +65,24 @@ func NewCBC(localKey, localWriteIV, localMac, remoteKey, remoteWriteIV, remoteMa
 
 // Encrypt encrypt a DTLS RecordLayer message
 func (c *CBC) Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, error) {
-	payload := raw[recordlayer.HeaderSize:]
-	raw = raw[:recordlayer.HeaderSize]
+	payload := raw[pkt.Header.Size():]
+	raw = raw[:pkt.Header.Size()]
 	blockSize := c.writeCBC.BlockSize()
 
 	// Generate + Append MAC
 	h := pkt.Header
 
-	MAC, err := c.hmac(h.Epoch, h.SequenceNumber, h.ContentType, h.Version, payload, c.writeMac, c.h)
+	var err error
+	var mac []byte
+	if h.ContentType == protocol.ContentTypeConnectionID {
+		mac, err = c.hmacCID(h.Epoch, h.SequenceNumber, h.Version, payload, c.writeMac, c.h, h.ConnectionID)
+	} else {
+		mac, err = c.hmac(h.Epoch, h.SequenceNumber, h.ContentType, h.Version, payload, c.writeMac, c.h)
+	}
 	if err != nil {
 		return nil, err
 	}
-	payload = append(payload, MAC...)
+	payload = append(payload, mac...)
 
 	// Generate + Append padding
 	padding := make([]byte, blockSize-len(payload)%blockSize)
@@ -96,26 +103,26 @@ func (c *CBC) Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, error) 
 	c.writeCBC.CryptBlocks(payload, payload)
 	payload = append(iv, payload...)
 
-	// Prepend unencrypte header with encrypted payload
+	// Prepend unencrypted header with encrypted payload
 	raw = append(raw, payload...)
 
 	// Update recordLayer size to include IV+MAC+Padding
-	binary.BigEndian.PutUint16(raw[recordlayer.HeaderSize-2:], uint16(len(raw)-recordlayer.HeaderSize))
+	binary.BigEndian.PutUint16(raw[pkt.Header.Size()-2:], uint16(len(raw)-pkt.Header.Size()))
 
 	return raw, nil
 }
 
 // Decrypt decrypts a DTLS RecordLayer message
-func (c *CBC) Decrypt(in []byte) ([]byte, error) {
-	body := in[recordlayer.HeaderSize:]
+func (c *CBC) Decrypt(h recordlayer.Header, in []byte) ([]byte, error) {
 	blockSize := c.readCBC.BlockSize()
 	mac := c.h()
 
-	var h recordlayer.Header
-	err := h.Unmarshal(in)
-	switch {
-	case err != nil:
+	if err := h.Unmarshal(in); err != nil {
 		return nil, err
+	}
+	body := in[h.Size():]
+
+	switch {
 	case h.ContentType == protocol.ContentTypeChangeCipherSpec:
 		// Nothing to encrypt with ChangeCipherSpec
 		return in, nil
@@ -145,14 +152,19 @@ func (c *CBC) Decrypt(in []byte) ([]byte, error) {
 	dataEnd := len(body) - macSize - paddingLen
 
 	expectedMAC := body[dataEnd : dataEnd+macSize]
-	actualMAC, err := c.hmac(h.Epoch, h.SequenceNumber, h.ContentType, h.Version, body[:dataEnd], c.readMac, c.h)
-
+	var err error
+	var actualMAC []byte
+	if h.ContentType == protocol.ContentTypeConnectionID {
+		actualMAC, err = c.hmacCID(h.Epoch, h.SequenceNumber, h.Version, body[:dataEnd], c.readMac, c.h, h.ConnectionID)
+	} else {
+		actualMAC, err = c.hmac(h.Epoch, h.SequenceNumber, h.ContentType, h.Version, body[:dataEnd], c.readMac, c.h)
+	}
 	// Compute Local MAC and compare
 	if err != nil || !hmac.Equal(actualMAC, expectedMAC) {
 		return nil, errInvalidMAC
 	}
 
-	return append(in[:recordlayer.HeaderSize], body[:dataEnd]...), nil
+	return append(in[:h.Size()], body[:dataEnd]...), nil
 }
 
 func (c *CBC) hmac(epoch uint16, sequenceNumber uint64, contentType protocol.ContentType, protocolVersion protocol.Version, payload []byte, key []byte, hf func() hash.Hash) ([]byte, error) {
@@ -169,7 +181,45 @@ func (c *CBC) hmac(epoch uint16, sequenceNumber uint64, contentType protocol.Con
 
 	if _, err := h.Write(msg); err != nil {
 		return nil, err
-	} else if _, err := h.Write(payload); err != nil {
+	}
+	if _, err := h.Write(payload); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+// hmacCID calculates a MAC according to
+// https://datatracker.ietf.org/doc/html/rfc9146#section-5.1
+func (c *CBC) hmacCID(epoch uint16, sequenceNumber uint64, protocolVersion protocol.Version, payload []byte, key []byte, hf func() hash.Hash, cid []byte) ([]byte, error) {
+	// Must unmarshal inner plaintext in orde to perform MAC.
+	ip := &recordlayer.InnerPlaintext{}
+	if err := ip.Unmarshal(payload); err != nil {
+		return nil, err
+	}
+
+	h := hmac.New(hf, key)
+
+	var msg cryptobyte.Builder
+
+	msg.AddUint64(seqNumPlaceholder)
+	msg.AddUint8(uint8(protocol.ContentTypeConnectionID))
+	msg.AddUint8(uint8(len(cid)))
+	msg.AddUint8(uint8(protocol.ContentTypeConnectionID))
+	msg.AddUint8(protocolVersion.Major)
+	msg.AddUint8(protocolVersion.Minor)
+	msg.AddUint16(epoch)
+	util.AddUint48(&msg, sequenceNumber)
+	msg.AddBytes(cid)
+	msg.AddUint16(uint16(len(payload)))
+	msg.AddBytes(ip.Content)
+	msg.AddUint8(uint8(ip.RealType))
+	msg.AddBytes(make([]byte, ip.Zeros))
+
+	if _, err := h.Write(msg.BytesOrPanic()); err != nil {
+		return nil, err
+	}
+	if _, err := h.Write(payload); err != nil {
 		return nil, err
 	}
 

--- a/pkg/crypto/ciphersuite/ciphersuite.go
+++ b/pkg/crypto/ciphersuite/ciphersuite.go
@@ -8,8 +8,16 @@ import (
 	"encoding/binary"
 	"errors"
 
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/protocol"
 	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+	"golang.org/x/crypto/cryptobyte"
+)
+
+const (
+	// 8 bytes of 0xff.
+	// https://datatracker.ietf.org/doc/html/rfc9146#name-record-payload-protection
+	seqNumPlaceholder = 0xffffffffffffffff
 )
 
 var (
@@ -21,6 +29,7 @@ var (
 
 func generateAEADAdditionalData(h *recordlayer.Header, payloadLen int) []byte {
 	var additionalData [13]byte
+
 	// SequenceNumber MUST be set first
 	// we only want uint48, clobbering an extra 2 (using uint64, Golang doesn't have uint48)
 	binary.BigEndian.PutUint64(additionalData[:], h.SequenceNumber)
@@ -31,6 +40,25 @@ func generateAEADAdditionalData(h *recordlayer.Header, payloadLen int) []byte {
 	binary.BigEndian.PutUint16(additionalData[len(additionalData)-2:], uint16(payloadLen))
 
 	return additionalData[:]
+}
+
+// generateAEADAdditionalDataCID generates additional data for AEAD ciphers
+// according to https://datatracker.ietf.org/doc/html/rfc9146#name-aead-ciphers
+func generateAEADAdditionalDataCID(h *recordlayer.Header, payloadLen int) []byte {
+	var b cryptobyte.Builder
+
+	b.AddUint64(seqNumPlaceholder)
+	b.AddUint8(uint8(protocol.ContentTypeConnectionID))
+	b.AddUint8(uint8(len(h.ConnectionID)))
+	b.AddUint8(uint8(protocol.ContentTypeConnectionID))
+	b.AddUint8(h.Version.Major)
+	b.AddUint8(h.Version.Minor)
+	b.AddUint16(h.Epoch)
+	util.AddUint48(&b, h.SequenceNumber)
+	b.AddBytes(h.ConnectionID)
+	b.AddUint16(uint16(payloadLen))
+
+	return b.BytesOrPanic()
 }
 
 // examinePadding returns, in constant time, the length of the padding to remove

--- a/pkg/crypto/ciphersuite/ciphersuite_test.go
+++ b/pkg/crypto/ciphersuite/ciphersuite_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package ciphersuite provides the crypto operations needed for a DTLS CipherSuite
+package ciphersuite
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pion/dtls/v2/pkg/protocol"
+	"github.com/pion/dtls/v2/pkg/protocol/recordlayer"
+)
+
+func TestGenerateAEADAdditionalDataCID(t *testing.T) {
+	cases := map[string]struct {
+		reason     string
+		header     *recordlayer.Header
+		payloadLen int
+		expected   []byte
+	}{
+		"WithConnectionID": {
+			reason: "Should successfully generate additional data with valid header",
+			header: &recordlayer.Header{
+				ContentType:    protocol.ContentTypeConnectionID,
+				ConnectionID:   []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				Version:        protocol.Version1_2,
+				Epoch:          2,
+				SequenceNumber: 277,
+			},
+			payloadLen: 1784,
+			expected:   []byte{255, 255, 255, 255, 255, 255, 255, 255, 25, 8, 25, 254, 253, 0, 2, 0, 0, 0, 0, 1, 21, 1, 2, 3, 4, 5, 6, 7, 8, 6, 248},
+		},
+		"IgnoreContentType": {
+			reason: "Should use Connection ID content type regardless of header content type.",
+			header: &recordlayer.Header{
+				ContentType:    protocol.ContentTypeAlert,
+				ConnectionID:   []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				Version:        protocol.Version1_2,
+				Epoch:          2,
+				SequenceNumber: 277,
+			},
+			payloadLen: 1784,
+			expected:   []byte{255, 255, 255, 255, 255, 255, 255, 255, 25, 8, 25, 254, 253, 0, 2, 0, 0, 0, 0, 1, 21, 1, 2, 3, 4, 5, 6, 7, 8, 6, 248},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := generateAEADAdditionalDataCID(tc.header, tc.payloadLen)
+			if !bytes.Equal(data, tc.expected) {
+				t.Errorf("%s\nUnexpected additional data\nwant: %v\ngot: %v", tc.reason, tc.expected, data)
+			}
+		})
+	}
+}

--- a/pkg/protocol/content.go
+++ b/pkg/protocol/content.go
@@ -14,6 +14,7 @@ const (
 	ContentTypeAlert            ContentType = 21
 	ContentTypeHandshake        ContentType = 22
 	ContentTypeApplicationData  ContentType = 23
+	ContentTypeConnectionID     ContentType = 25
 )
 
 // Content is the top level distinguisher for a DTLS Datagram

--- a/pkg/protocol/extension/connection_id.go
+++ b/pkg/protocol/extension/connection_id.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// ConnectionID is a DTLS extension that provides an alternative to IP address
+// and port for session association.
+//
+// https://tools.ietf.org/html/rfc9146
+type ConnectionID struct {
+	// A zero-length connection ID indicates for a client or server that
+	// negotiated connection IDs from the peer will be sent but there is no need
+	// to respond with one
+	CID []byte // variable length
+}
+
+// TypeValue returns the extension TypeValue
+func (c ConnectionID) TypeValue() TypeValue {
+	return ConnectionIDTypeValue
+}
+
+// Marshal encodes the extension
+func (c *ConnectionID) Marshal() ([]byte, error) {
+	var b cryptobyte.Builder
+	b.AddUint16(uint16(c.TypeValue()))
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.CID)
+		})
+	})
+	return b.Bytes()
+}
+
+// Unmarshal populates the extension from encoded data
+func (c *ConnectionID) Unmarshal(data []byte) error {
+	val := cryptobyte.String(data)
+	var extension uint16
+	val.ReadUint16(&extension)
+	if TypeValue(extension) != c.TypeValue() {
+		return errInvalidExtensionType
+	}
+
+	var extData cryptobyte.String
+	val.ReadUint16LengthPrefixed(&extData)
+
+	var cid cryptobyte.String
+	if !extData.ReadUint8LengthPrefixed(&cid) {
+		return errInvalidCIDFormat
+	}
+	c.CID = make([]byte, len(cid))
+	if !cid.CopyBytes(c.CID) {
+		return errInvalidCIDFormat
+	}
+	return nil
+}

--- a/pkg/protocol/extension/connection_id_test.go
+++ b/pkg/protocol/extension/connection_id_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtensionConnectionID(t *testing.T) {
+	rawExtensionConnectionID := []byte{1, 6, 8, 3, 88, 12, 2, 47}
+	parsedExtensionConnectionID := &ConnectionID{
+		CID: rawExtensionConnectionID,
+	}
+
+	raw, err := parsedExtensionConnectionID.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roundtrip := &ConnectionID{}
+	if err := roundtrip.Unmarshal(raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(roundtrip, parsedExtensionConnectionID) {
+		t.Errorf("parsedExtensionConnectionID unmarshal: got %#v, want %#v", roundtrip, parsedExtensionConnectionID)
+	}
+}

--- a/pkg/protocol/extension/errors.go
+++ b/pkg/protocol/extension/errors.go
@@ -16,5 +16,6 @@ var (
 	errBufferTooSmall       = &protocol.TemporaryError{Err: errors.New("buffer is too small")}                         //nolint:goerr113
 	errInvalidExtensionType = &protocol.FatalError{Err: errors.New("invalid extension type")}                          //nolint:goerr113
 	errInvalidSNIFormat     = &protocol.FatalError{Err: errors.New("invalid server name format")}                      //nolint:goerr113
+	errInvalidCIDFormat     = &protocol.FatalError{Err: errors.New("invalid connection ID format")}                    //nolint:goerr113
 	errLengthMismatch       = &protocol.InternalError{Err: errors.New("data length and declared length do not match")} //nolint:goerr113
 )

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -20,6 +20,7 @@ const (
 	UseSRTPTypeValue                      TypeValue = 14
 	ALPNTypeValue                         TypeValue = 16
 	UseExtendedMasterSecretTypeValue      TypeValue = 23
+	ConnectionIDTypeValue                 TypeValue = 54
 	RenegotiationInfoTypeValue            TypeValue = 65281
 )
 
@@ -76,6 +77,8 @@ func Unmarshal(buf []byte) ([]Extension, error) {
 			err = unmarshalAndAppend(buf[offset:], &UseExtendedMasterSecret{})
 		case RenegotiationInfoTypeValue:
 			err = unmarshalAndAppend(buf[offset:], &RenegotiationInfo{})
+		case ConnectionIDTypeValue:
+			err = unmarshalAndAppend(buf[offset:], &ConnectionID{})
 		default:
 		}
 		if err != nil {

--- a/pkg/protocol/extension/supported_elliptic_curves_test.go
+++ b/pkg/protocol/extension/supported_elliptic_curves_test.go
@@ -18,9 +18,9 @@ func TestExtensionSupportedGroups(t *testing.T) {
 
 	raw, err := parsedSupportedGroups.Marshal()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	} else if !reflect.DeepEqual(raw, rawSupportedGroups) {
-		t.Errorf("extensionSupportedGroups marshal: got %#v, want %#v", raw, rawSupportedGroups)
+		t.Fatalf("extensionSupportedGroups marshal: got %#v, want %#v", raw, rawSupportedGroups)
 	}
 
 	roundtrip := &SupportedEllipticCurves{}

--- a/pkg/protocol/extension/supported_point_formats_test.go
+++ b/pkg/protocol/extension/supported_point_formats_test.go
@@ -18,9 +18,9 @@ func TestExtensionSupportedPointFormats(t *testing.T) {
 
 	raw, err := parsedExtensionSupportedPointFormats.Marshal()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	} else if !reflect.DeepEqual(raw, rawExtensionSupportedPointFormats) {
-		t.Errorf("extensionSupportedPointFormats marshal: got %#v, want %#v", raw, rawExtensionSupportedPointFormats)
+		t.Fatalf("extensionSupportedPointFormats marshal: got %#v, want %#v", raw, rawExtensionSupportedPointFormats)
 	}
 
 	roundtrip := &SupportedPointFormats{}

--- a/pkg/protocol/extension/supported_signature_algorithms_test.go
+++ b/pkg/protocol/extension/supported_signature_algorithms_test.go
@@ -31,9 +31,9 @@ func TestExtensionSupportedSignatureAlgorithms(t *testing.T) {
 
 	raw, err := parsedExtensionSupportedSignatureAlgorithms.Marshal()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	} else if !reflect.DeepEqual(raw, rawExtensionSupportedSignatureAlgorithms) {
-		t.Errorf("extensionSupportedSignatureAlgorithms marshal: got %#v, want %#v", raw, rawExtensionSupportedSignatureAlgorithms)
+		t.Fatalf("extensionSupportedSignatureAlgorithms marshal: got %#v, want %#v", raw, rawExtensionSupportedSignatureAlgorithms)
 	}
 
 	roundtrip := &SupportedSignatureAlgorithms{}

--- a/pkg/protocol/recordlayer/fuzz_test.go
+++ b/pkg/protocol/recordlayer/fuzz_test.go
@@ -4,13 +4,14 @@
 package recordlayer
 
 import (
+	"reflect"
 	"testing"
 )
 
-func partialHeaderMismatch(a, b Header) bool {
+func headerMismatch(a, b Header) bool {
 	// Ignoring content length for now.
 	a.ContentLen = b.ContentLen
-	return a != b
+	return !reflect.DeepEqual(a, b)
 }
 
 func FuzzRecordLayer(f *testing.F) {
@@ -34,7 +35,7 @@ func FuzzRecordLayer(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		if partialHeaderMismatch(nr.Header, r.Header) {
+		if headerMismatch(nr.Header, r.Header) {
 			t.Fatalf("Header mismatch: %+v != %+v", nr.Header, r.Header)
 		}
 	})

--- a/pkg/protocol/recordlayer/header.go
+++ b/pkg/protocol/recordlayer/header.go
@@ -17,11 +17,16 @@ type Header struct {
 	Version        protocol.Version
 	Epoch          uint16
 	SequenceNumber uint64 // uint48 in spec
+
+	// Optional Fields
+	ConnectionID []byte
 }
 
 // RecordLayer enums
 const (
-	HeaderSize        = 13
+	// FixedHeaderSize is the size of a DTLS record header when connection IDs
+	// are not in use.
+	FixedHeaderSize   = 13
 	MaxSequenceNumber = 0x0000FFFFFFFFFFFF
 )
 
@@ -31,22 +36,33 @@ func (h *Header) Marshal() ([]byte, error) {
 		return nil, errSequenceNumberOverflow
 	}
 
-	out := make([]byte, HeaderSize)
+	hs := FixedHeaderSize + len(h.ConnectionID)
+
+	out := make([]byte, hs)
 	out[0] = byte(h.ContentType)
 	out[1] = h.Version.Major
 	out[2] = h.Version.Minor
 	binary.BigEndian.PutUint16(out[3:], h.Epoch)
 	util.PutBigEndianUint48(out[5:], h.SequenceNumber)
-	binary.BigEndian.PutUint16(out[HeaderSize-2:], h.ContentLen)
+	copy(out[11:11+len(h.ConnectionID)], h.ConnectionID)
+	binary.BigEndian.PutUint16(out[hs-2:], h.ContentLen)
 	return out, nil
 }
 
 // Unmarshal populates a TLS RecordLayer Header from binary
 func (h *Header) Unmarshal(data []byte) error {
-	if len(data) < HeaderSize {
+	if len(data) < FixedHeaderSize {
 		return errBufferTooSmall
 	}
 	h.ContentType = protocol.ContentType(data[0])
+	if h.ContentType == protocol.ContentTypeConnectionID {
+		// If a CID was expected the ConnectionID should have been initialized.
+		if len(data) < FixedHeaderSize+len(h.ConnectionID) {
+			return errBufferTooSmall
+		}
+		h.ConnectionID = data[11 : 11+len(h.ConnectionID)]
+	}
+
 	h.Version.Major = data[1]
 	h.Version.Minor = data[2]
 	h.Epoch = binary.BigEndian.Uint16(data[3:])
@@ -61,4 +77,9 @@ func (h *Header) Unmarshal(data []byte) error {
 	}
 
 	return nil
+}
+
+// Size returns the total size of the header.
+func (h *Header) Size() int {
+	return FixedHeaderSize + len(h.ConnectionID)
 }

--- a/pkg/protocol/recordlayer/inner_plaintext.go
+++ b/pkg/protocol/recordlayer/inner_plaintext.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package recordlayer
+
+import (
+	"github.com/pion/dtls/v2/pkg/protocol"
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// InnerPlaintext implements DTLSInnerPlaintext
+//
+// https://datatracker.ietf.org/doc/html/rfc9146#name-record-layer-extensions
+type InnerPlaintext struct {
+	Content  []byte
+	RealType protocol.ContentType
+	Zeros    uint
+}
+
+// Marshal encodes a DTLS InnerPlaintext to binary
+func (p *InnerPlaintext) Marshal() ([]byte, error) {
+	var out cryptobyte.Builder
+	out.AddBytes(p.Content)
+	out.AddUint8(uint8(p.RealType))
+	out.AddBytes(make([]byte, p.Zeros))
+	return out.Bytes()
+}
+
+// Unmarshal populates a DTLS InnerPlaintext from binary
+func (p *InnerPlaintext) Unmarshal(data []byte) error {
+	// Process in reverse
+	i := len(data) - 1
+	for i >= 0 {
+		if data[i] != 0 {
+			p.Zeros = uint(len(data) - 1 - i)
+			break
+		}
+		i--
+	}
+	if i == 0 {
+		return errBufferTooSmall
+	}
+	p.RealType = protocol.ContentType(data[i])
+	p.Content = append([]byte{}, data[:i]...)
+
+	return nil
+}

--- a/pkg/protocol/recordlayer/recordlayer.go
+++ b/pkg/protocol/recordlayer/recordlayer.go
@@ -11,6 +11,23 @@ import (
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 )
 
+// DTLS fixed size record layer header when Connection IDs are not in-use.
+
+// ---------------------------------
+// | Type   |   Version   |  Epoch |
+// ---------------------------------
+// | Epoch  |    Sequence Number   |
+// ---------------------------------
+// |   Sequence Number   |  Length |
+// ---------------------------------
+// | Length |      Fragment...     |
+// ---------------------------------
+
+// fixedHeaderLenIdx is the index at which the record layer content length is
+// specified in a fixed length header (i.e. one that does not include a
+// Connection ID).
+const fixedHeaderLenIdx = 11
+
 // RecordLayer which handles all data transport.
 // The record layer is assumed to sit directly on top of some
 // reliable transport such as TCP. The record layer can carry four types of content:
@@ -51,14 +68,11 @@ func (r *RecordLayer) Marshal() ([]byte, error) {
 
 // Unmarshal populates the RecordLayer from binary
 func (r *RecordLayer) Unmarshal(data []byte) error {
-	if len(data) < HeaderSize {
-		return errBufferTooSmall
-	}
 	if err := r.Header.Unmarshal(data); err != nil {
 		return err
 	}
 
-	switch protocol.ContentType(data[0]) {
+	switch r.Header.ContentType {
 	case protocol.ContentTypeChangeCipherSpec:
 		r.Content = &protocol.ChangeCipherSpec{}
 	case protocol.ContentTypeAlert:
@@ -71,7 +85,7 @@ func (r *RecordLayer) Unmarshal(data []byte) error {
 		return errInvalidContentType
 	}
 
-	return r.Content.Unmarshal(data[HeaderSize:])
+	return r.Content.Unmarshal(data[r.Header.Size()+len(r.Header.ConnectionID):])
 }
 
 // UnpackDatagram extracts all RecordLayer messages from a single datagram.
@@ -85,11 +99,40 @@ func UnpackDatagram(buf []byte) ([][]byte, error) {
 	out := [][]byte{}
 
 	for offset := 0; len(buf) != offset; {
-		if len(buf)-offset <= HeaderSize {
+		if len(buf)-offset <= FixedHeaderSize {
 			return nil, errInvalidPacketLength
 		}
 
-		pktLen := (HeaderSize + int(binary.BigEndian.Uint16(buf[offset+11:])))
+		pktLen := (FixedHeaderSize + int(binary.BigEndian.Uint16(buf[offset+11:])))
+		if offset+pktLen > len(buf) {
+			return nil, errInvalidPacketLength
+		}
+
+		out = append(out, buf[offset:offset+pktLen])
+		offset += pktLen
+	}
+
+	return out, nil
+}
+
+// ContentAwareUnpackDatagram is the same as UnpackDatagram but considers the
+// presence of a connection identifier if the record is of content type
+// tls12_cid.
+func ContentAwareUnpackDatagram(buf []byte, cidLength int) ([][]byte, error) {
+	out := [][]byte{}
+
+	for offset := 0; len(buf) != offset; {
+		headerSize := FixedHeaderSize
+		lenIdx := fixedHeaderLenIdx
+		if protocol.ContentType(buf[offset]) == protocol.ContentTypeConnectionID {
+			headerSize += cidLength
+			lenIdx += cidLength
+		}
+		if len(buf)-offset <= headerSize {
+			return nil, errInvalidPacketLength
+		}
+
+		pktLen := (headerSize + int(binary.BigEndian.Uint16(buf[offset+lenIdx:])))
 		if offset+pktLen > len(buf) {
 			return nil, errInvalidPacketLength
 		}

--- a/resume.go
+++ b/resume.go
@@ -9,11 +9,11 @@ import (
 )
 
 // Resume imports an already established dtls connection using a specific dtls state
-func Resume(state *State, conn net.Conn, config *Config) (*Conn, error) {
+func Resume(state *State, conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	if err := state.initCipherSuite(); err != nil {
 		return nil, err
 	}
-	c, err := createConn(context.Background(), conn, config, state.isClient, state)
+	c, err := createConn(context.Background(), conn, rAddr, config, state.isClient, state)
 	if err != nil {
 		return nil, err
 	}

--- a/resume_test.go
+++ b/resume_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/dtls/v2/internal/util"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	"github.com/pion/transport/v2/test"
 )
@@ -32,7 +33,7 @@ func fatal(t *testing.T, errChan chan error, err error) {
 	t.Fatal(err)
 }
 
-func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Conn, error)) {
+func DoTestResume(t *testing.T, newLocal, newRemote func(net.PacketConn, net.Addr, *Config) (*Conn, error)) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)
 	defer lim.Stop()
@@ -67,7 +68,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 	go func() {
 		var remote *Conn
 		var errR error
-		remote, errR = newRemote(remoteConn, config)
+		remote, errR = newRemote(util.FromConn(remoteConn), remoteConn.RemoteAddr(), config)
 		if errR != nil {
 			errChan <- errR
 		}
@@ -89,7 +90,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 	}()
 
 	var local *Conn
-	local, err = newLocal(localConn1, config)
+	local, err = newLocal(util.FromConn(localConn1), localConn1.RemoteAddr(), config)
 	if err != nil {
 		fatal(t, errChan, err)
 	}
@@ -132,7 +133,7 @@ func DoTestResume(t *testing.T, newLocal, newRemote func(net.Conn, *Config) (*Co
 
 	// Resume dtls connection
 	var resumed net.Conn
-	resumed, err = Resume(deserialized, localConn2, config)
+	resumed, err = Resume(deserialized, util.FromConn(localConn2), localConn2.RemoteAddr(), config)
 	if err != nil {
 		fatal(t, errChan, err)
 	}

--- a/state.go
+++ b/state.go
@@ -27,6 +27,20 @@ type State struct {
 	IdentityHint          []byte
 	SessionID             []byte
 
+	// Connection Identifiers must be negotiated afresh on session resumption.
+	// https://datatracker.ietf.org/doc/html/rfc9146#name-the-connection_id-extension
+
+	// localConnectionID is the locally generated connection ID that is expected
+	// to be received from the remote endpoint.
+	// For a server, this is the connection ID sent in ServerHello.
+	// For a client, this is the connection ID sent in the ClientHello.
+	localConnectionID []byte
+	// remoteConnectionID is the connection ID that the remote endpoint
+	// specifies should be sent.
+	// For a server, this is the connection ID received in the ClientHello.
+	// For a client, this is the connection ID received in the ServerHello.
+	remoteConnectionID []byte
+
 	isClient bool
 
 	preMasterSecret      []byte


### PR DESCRIPTION
#### Description

Implements DTLS 1.2 Connection ID support as defined in https://datatracker.ietf.org/doc/html/rfc9146.

Remaining work:
- [x] Clean up TODO's
- [x] Update `cbc` and `ccm` suites to support Connection IDs
- [x] Expand e2e tests with dedicated Connection ID tests
- [x] Expand unit tests to cover all new functionality
- [ ] Add examples for enabling Connection ID support (dependent on whether UDP connection package is implemented in this PR -- see below)
- [ ] Expand e2e tests with changing remote IP addresses (dependent on whether UDP connection package is implemented in this PR -- see below)
- [x] Clean up commit history (to be completed prior to merge)

##### Notes for early reviewers:

Currently, if you want an endpoint to be able to update its remote address, you need to implement a custom `Listener` that uses connection ID's rather than remote address to determine what `PacketServer` to route packets to. This functionality is dependent on `pion/transport/udp`, and I demonstrated what an example could look like in https://github.com/pion/transport/pull/252. However, as mentioned on that PR, the intention is to move the functionality to live here in `pion/dtls`, and I am in progress of doing so. We could feasibly make that a separate PR given that this one is "feature complete" in that it can successfully negotiate and use connection IDs as both a client and server (as demonstrated by the new e2e tests). Either way, the UDP connection package needs to be added in this PR or a subsequent one.

Another area of interest is automated testing against other libraries. The current OpenSSL tests cannot be expanded for this use-case as it does not support connection IDs. I have performed manual validation by expanding the DTLS client example in mbedTLS as demonstrated here: https://github.com/Mbed-TLS/mbedtls/compare/development...hasheddan:mbedtls:feat/cid-example. I would like to expand the e2e testing suite in this repository to include mbedTLS with connection IDs enabled, though we will need to build our own client, which could also be deferred to a subsequent PR.

An area that I _do not_ anticipate expanding scope of this PR to cover quite yet is saving connection state. For my particular use-case is is vital that we able to persist connection state across server restarts. Note that this is different from saving sessions as connection IDs must actually be renegotiated upon session resumption, whereas ideally with connection IDs enabled a server could continue receiving from an endpoint after restart by recovering all state. I _would_ like to ensure this functionality is enabled prior to cutting a `v3` release as I believe it could result in breaking changes.

Lastly, I am in progress of increasing unit test coverage across the board, though it is not anticipated that this will result in any functional changes to what is currently implemented as it is already being validated through existing unit tests (testing with connection IDs not enabled), as well as e2e test.

##### Testing Locally

If reviewers would like to experiment with enabling connection IDs locally, you can use the following commands to only run the `CID` e2e tests.

```
docker build -t pion-dtls-e2e -f e2e/Dockerfile .
```
```
docker run -i --rm --net=host pion-dtls-e2e go test -run=.*CID.* -v
```

Using the host's network namespace allows you to capture on the loopback interface in wireshark. Using the `dtls` filter will help eliminate other noise. Your output should look something like the following:

![image](https://github.com/pion/dtls/assets/31777345/82f88382-5576-4fdf-a0d1-7abbb6fb0797)


#### Reference issue

Fixes #256 
Fixes #367 