### PR TITLE
Set timeout to 10 minutes on e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,7 @@ jobs:
   e2e-test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION


#### Description

Sets the timeout to 10 minutes on the e2e workflow. Previously, if the workflow did not terminate, it would run for the default of 360 minutes.

See
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes for more information.

#### Reference issue
Fixes #559 
