### PR TITLE
Convert nil CIDs to empty byte slice

### DIFF
--- a/flight1handler.go
+++ b/flight1handler.go
@@ -123,6 +123,13 @@ func flight1Generate(c flightConn, state *State, _ *handshakeCache, cfg *handsha
 	// use.
 	if cfg.connectionIDGenerator != nil {
 		state.localConnectionID = cfg.connectionIDGenerator()
+		// The presence of a generator indicates support for connection IDs. We
+		// use the presence of a non-nil local CID in flight 3 to determine
+		// whether we send a CID in the second ClientHello, so we convert any
+		// nil CID returned by a generator to []byte{}.
+		if state.localConnectionID == nil {
+			state.localConnectionID = []byte{}
+		}
 		extensions = append(extensions, &extension.ConnectionID{CID: state.localConnectionID})
 	}
 


### PR DESCRIPTION
#### Description

Adds a check on the generated CID in flight 1 to convert to an empty
byte slice if the CID is nil. This allows us to distinguish not
supporting CIDs to only suppporting sending CIDs in the second
ClientHello in flight 3.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

While the existing functionality actually results in a successful handshake with the server (if that server is `pion/dtls`), it has the undesirable effect of sending a different set of extensions on the first client hello and the second. This is due to the fact that we decide to send the CID on the second if we sent it on the first, but because we were using a `nil` CID when only indicating support, that resulted in us dropping the CID on the second client hello.

https://github.com/pion/dtls/blob/83b125485ec0277011ba97d26c2c5578ea96d8a7/flight3handler.go#L283-L285

Example from previous functionality:
![Screenshot from 2023-08-22 17-06-17](https://github.com/pion/dtls/assets/31777345/6e5e7271-b977-44fa-b3be-d793ba1ec42e)

After the changes in this patchset:
![Screenshot from 2023-08-22 17-05-24](https://github.com/pion/dtls/assets/31777345/9cb72399-a31d-4776-aded-6b5c46740daf)

