### PR TITLE
Wrap Alerts when CID is negotiated

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -953,6 +953,7 @@ func (c *Conn) notify(ctx context.Context, level alert.Level, desc alert.Descrip
 					Description: desc,
 				},
 			},
+			shouldWrapCID: len(c.state.remoteConnectionID) > 0,
 			shouldEncrypt: c.isHandshakeCompletedSuccessfully(),
 		},
 	})


### PR DESCRIPTION


#### Description

Updates to conditionally wrap Alert messages when a non-zero length connection ID has been negotiated. From the DTLS 1.2 Connection ID RFC:

If DTLS peers have negotiated the use of a non-zero-length CID for a given direction, then once encryption is enabled, they MUST send with the record format defined in Figure 3 (see Section 4) with the new Message Authentication Code (MAC) computation defined in Section 5 and the content type tls12_cid. Plaintext payloads never use the new record format or the CID content type.

https://datatracker.ietf.org/doc/html/rfc9146#section-3

After this patchset, connection IDs are used properly for encrypted alerts. This example is from the PSK sample client and server on `exit`.
![image](https://github.com/pion/dtls/assets/31777345/1706fa94-0b77-4df3-98c4-1008d75269ca)

