### PR TITLE
Correctly identify client and server with PSK ID

### DIFF
--- a/examples/dial/cid/main.go
+++ b/examples/dial/cid/main.go
@@ -28,7 +28,7 @@ func main() {
 			fmt.Printf("Server's hint: %s \n", hint)
 			return []byte{0xAB, 0xC1, 0x23}, nil
 		},
-		PSKIdentityHint:       []byte("Pion DTLS Server"),
+		PSKIdentityHint:       []byte("Pion DTLS Client"),
 		CipherSuites:          []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret:  dtls.RequireExtendedMasterSecret,
 		ConnectionIDGenerator: dtls.OnlySendCIDGenerator(),

--- a/examples/dial/psk/main.go
+++ b/examples/dial/psk/main.go
@@ -28,7 +28,7 @@ func main() {
 			fmt.Printf("Server's hint: %s \n", hint)
 			return []byte{0xAB, 0xC1, 0x23}, nil
 		},
-		PSKIdentityHint:      []byte("Pion DTLS Server"),
+		PSKIdentityHint:      []byte("Pion DTLS Client"),
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 	}

--- a/examples/listen/cid/main.go
+++ b/examples/listen/cid/main.go
@@ -32,7 +32,7 @@ func main() {
 			fmt.Printf("Client's hint: %s \n", hint)
 			return []byte{0xAB, 0xC1, 0x23}, nil
 		},
-		PSKIdentityHint:      []byte("Pion DTLS Client"),
+		PSKIdentityHint:      []byte("Pion DTLS Server"),
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		// Create timeout context for accepted connection.

--- a/examples/listen/psk/main.go
+++ b/examples/listen/psk/main.go
@@ -32,7 +32,7 @@ func main() {
 			fmt.Printf("Client's hint: %s \n", hint)
 			return []byte{0xAB, 0xC1, 0x23}, nil
 		},
-		PSKIdentityHint:      []byte("Pion DTLS Client"),
+		PSKIdentityHint:      []byte("Pion DTLS Server"),
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 		// Create timeout context for accepted connection.


### PR DESCRIPTION


#### Description

Updates the PSK ID hints on the client and server examples to match the type of endpoint they represent.