### PR TITLE
Use atomic.Value to maintain Go 1.13 compatibility 

### DIFF
--- a/internal/net/udp/packet_conn.go
+++ b/internal/net/udp/packet_conn.go
@@ -269,7 +269,7 @@ type PacketConn struct {
 
 	raddr   net.Addr
 	rmraddr atomic.Value // bool
-	id      atomic.Value
+	id      atomic.Value // string
 
 	buffer *idtlsnet.PacketBuffer
 


### PR DESCRIPTION
#### Description

Updates to use atomic.Value in place of atomic.Bool such that older Go
versions can continue to be supported.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Similar fix to https://github.com/pion/transport/commit/701ff64e8ae945808b3e82c783e37d514a731c44