### PR TITLE
Add ability to select certificate based on ClientHello random bytes

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -9,6 +9,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
+
+	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 )
 
 // ClientHelloInfo contains information from a ClientHello message in order to
@@ -22,6 +24,9 @@ type ClientHelloInfo struct {
 	// CipherSuites lists the CipherSuites supported by the client (e.g.
 	// TLS_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256).
 	CipherSuites []CipherSuiteID
+
+	// RandomBytes stores the client hello random bytes
+	RandomBytes [handshake.RandomBytesLength]byte
 }
 
 // CertificateRequestInfo contains information from a server's

--- a/config.go
+++ b/config.go
@@ -198,6 +198,9 @@ type Config struct {
 	// https://datatracker.ietf.org/doc/html/rfc9146#section-4
 	PaddingLengthGenerator func(uint) uint
 
+	// HelloRandomBytesGenerator generates custom client hello random bytes.
+	HelloRandomBytesGenerator func() [handshake.RandomBytesLength]byte
+
 	// Handshake hooks: hooks can be used for testing invalid messages,
 	// mimicking other implementations or randomizing fields, which is valuable
 	// for applications that need censorship-resistance by making

--- a/conn.go
+++ b/conn.go
@@ -212,6 +212,7 @@ func handshakeConn(ctx context.Context, conn *Conn, config *Config, isClient boo
 		localGetClientCertificate:     config.GetClientCertificate,
 		insecureSkipHelloVerify:       config.InsecureSkipVerifyHello,
 		connectionIDGenerator:         config.ConnectionIDGenerator,
+		helloRandomBytesGenerator:     config.HelloRandomBytesGenerator,
 		clientHelloMessageHook:        config.ClientHelloMessageHook,
 		serverHelloMessageHook:        config.ServerHelloMessageHook,
 		certificateRequestMessageHook: config.CertificateRequestMessageHook,

--- a/flight1handler.go
+++ b/flight1handler.go
@@ -57,6 +57,10 @@ func flight1Generate(c flightConn, state *State, _ *handshakeCache, cfg *handsha
 		return nil, nil, err
 	}
 
+	if cfg.helloRandomBytesGenerator != nil {
+		state.localRandom.RandomBytes = cfg.helloRandomBytesGenerator()
+	}
+
 	extensions := []extension.Extension{
 		&extension.SupportedSignatureAlgorithms{
 			SignatureHashAlgorithms: cfg.localSignatureSchemes,

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -300,6 +300,7 @@ func flight4Generate(_ flightConn, state *State, _ *handshakeCache, cfg *handsha
 		certificate, err := cfg.getCertificate(&ClientHelloInfo{
 			ServerName:   state.serverName,
 			CipherSuites: []ciphersuite.ID{state.cipherSuite.ID()},
+			RandomBytes:  state.remoteRandom.RandomBytes,
 		})
 		if err != nil {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, err

--- a/handshaker.go
+++ b/handshaker.go
@@ -114,6 +114,7 @@ type handshakeConfig struct {
 	ellipticCurves              []elliptic.Curve
 	insecureSkipHelloVerify     bool
 	connectionIDGenerator       func() []byte
+	helloRandomBytesGenerator   func() [handshake.RandomBytesLength]byte
 
 	onFlightState func(flightVal, handshakeState)
 	log           logging.LeveledLogger

--- a/state.go
+++ b/state.go
@@ -258,3 +258,8 @@ func (s *State) getSRTPProtectionProfile() SRTPProtectionProfile {
 
 	return 0
 }
+
+// RemoteRandomBytes returns the remote client hello random bytes
+func (s *State) RemoteRandomBytes() [handshake.RandomBytesLength]byte {
+	return s.remoteRandom.RandomBytes
+}


### PR DESCRIPTION
#### Description

This PR lets clients to modify the client hello random bytes and lets servers to choose certificates based on the ClientHello random bytes using the `GetCertificate` function. 

This serves a similar purpose to ServerName in the ClientHello, where the server can use different certificate based on the ServerName in the ClientHello. This change would be useful for censorship resistance settings where the client does not want to add extra extension like ServerName in the ClientHello to prevent censors from fingerprinting the connection. 