### PR TITLE
Export CipherSuiteID in connection State

### DIFF
--- a/state.go
+++ b/state.go
@@ -21,6 +21,7 @@ type State struct {
 	localRandom, remoteRandom handshake.Random
 	masterSecret              []byte
 	cipherSuite               CipherSuite // nil if a cipherSuite hasn't been chosen
+	CipherSuiteID             CipherSuiteID
 
 	srtpProtectionProfile SRTPProtectionProfile // Negotiated SRTPProtectionProfile
 	PeerCertificates      [][]byte
@@ -138,7 +139,8 @@ func (s *State) deserialize(serialized serializedState) {
 	s.masterSecret = serialized.MasterSecret
 
 	// Set cipher suite
-	s.cipherSuite = cipherSuiteForID(CipherSuiteID(serialized.CipherSuiteID), nil)
+	s.CipherSuiteID = CipherSuiteID(serialized.CipherSuiteID)
+	s.cipherSuite = cipherSuiteForID(s.CipherSuiteID, nil)
 
 	atomic.StoreUint64(&s.localSequenceNumber[epoch], serialized.SequenceNumber)
 	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)


### PR DESCRIPTION
#### Description
This commit exports the `CipherSuiteID`  in connection state for further use, e.g. to get the name of the CipherSuite via `CipherSuiteName()`
#### Reference issue
Fixes #584 
