### PR TITLE
Fix for issue 418 with unit test

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -38,6 +38,7 @@ Lukas Lihotzki <lukas@lihotzki.de>
 ManuelBk <26275612+ManuelBk@users.noreply.github.com>
 Michael Zabka <zabka.michael@gmail.com>
 Michiel De Backker <mail@backkem.me>
+mschexnaydre <mschex@viasat.com>
 Rachel Chen <rachel@chens.email>
 Robert Eperjesi <eperjesi@uber.com>
 Ryan Gordon <ryan.gordon@getcruise.com>
@@ -53,6 +54,7 @@ Steffen Vogel <post@steffenvogel.de>
 Vadim <fffilimonov@yandex.ru>
 Vadim Filimonov <fffilimonov@yandex.ru>
 wmiao <wu.miao@viasat.com>
+Xinjun Ma <xinjun.ma@qq.com>
 ZHENK <chengzhenyang@gmail.com>
 吕海涛 <hi@taoshu.in>
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -864,6 +864,14 @@ func TestClientCertificate(t *testing.T) {
 					ClientAuth:   RequireAnyClientCert,
 				},
 			},
+			"RequestClientCert_cert_sigscheme": { // specify signature algorithm
+				clientCfg: &Config{RootCAs: srvCAPool, Certificates: []tls.Certificate{cert}},
+				serverCfg: &Config{
+					SignatureSchemes: []tls.SignatureScheme{tls.ECDSAWithP521AndSHA512},
+					Certificates:     []tls.Certificate{srvCert},
+					ClientAuth:       RequestClientCert,
+				},
+			},
 			"RequestClientCert_cert": {
 				clientCfg: &Config{RootCAs: srvCAPool, Certificates: []tls.Certificate{cert}},
 				serverCfg: &Config{

--- a/crypto.go
+++ b/crypto.go
@@ -9,7 +9,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
@@ -118,11 +117,7 @@ func generateCertificateVerify(handshakeBodies []byte, privateKey crypto.Private
 		return p.Sign(rand.Reader, handshakeBodies, crypto.Hash(0))
 	}
 
-	h := sha256.New()
-	if _, err := h.Write(handshakeBodies); err != nil {
-		return nil, err
-	}
-	hashed := h.Sum(nil)
+	hashed := hashAlgorithm.Digest(handshakeBodies)
 
 	switch p := privateKey.(type) {
 	case *ecdsa.PrivateKey:

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -153,7 +153,8 @@ func flight3Parse(ctx context.Context, c flightConn, state *State, cache *handsh
 		}
 	}
 
-	if _, ok := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
+	if creq, ok := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
+		state.remoteCertRequestAlgs = creq.SignatureHashAlgorithms
 		state.remoteRequestedCertificate = true
 	}
 

--- a/flight5handler.go
+++ b/flight5handler.go
@@ -193,7 +193,8 @@ func flight5Generate(c flightConn, state *State, cache *handshakeCache, cfg *han
 		), merged...)
 
 		// Find compatible signature scheme
-		signatureHashAlgo, err := signaturehash.SelectSignatureScheme(cfg.localSignatureSchemes, privateKey)
+
+		signatureHashAlgo, err := signaturehash.SelectSignatureScheme(state.remoteCertRequestAlgs, privateKey)
 		if err != nil {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, err
 		}

--- a/state.go
+++ b/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pion/dtls/v2/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v2/pkg/crypto/prf"
+	"github.com/pion/dtls/v2/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v2/pkg/protocol/handshake"
 	"github.com/pion/transport/v3/replaydetector"
 )
@@ -53,6 +54,7 @@ type State struct {
 	handshakeSendSequence      int
 	handshakeRecvSequence      int
 	serverName                 string
+	remoteCertRequestAlgs      []signaturehash.Algorithm
 	remoteRequestedCertificate bool   // Did we get a CertificateRequest
 	localCertificatesVerify    []byte // cache CertificateVerify
 	localVerifyData            []byte // cached VerifyData


### PR DESCRIPTION
For RFC compliance only algorithms in the certificate request shall be used.

Description
We should only be using one of the signature algorithms specified in the CertificateRequest message when generating the CertificateVerify message. Prior to this fix SHA-256 was always being used.

This change stores the HASH algorithm from the CertificateRequest message in the State object so that we can reference these later when generating the CertificateVerify message.

Removed hard-coded usage of SHA-256 in generateCertificateVerify, now uses the Digest method of the passed in algorithm.

Added unit test in conn_test that specifies SignatureSchemes with a non SHA256 only option.  This causes the unit test to fail prior to this fix.

Reference issue
Fixes https://github.com/pion/dtls/issues/418