### PR TITLE
address #279: allow for parallel processing of handshakes

### DIFF
--- a/examples/listen/handshake_psk/main.go
+++ b/examples/listen/handshake_psk/main.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package main implements a DTLS server using a pre-shared key.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/examples/util"
+)
+
+func main() {
+	// Prepare the IP to connect to
+	addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4444}
+
+	// Create parent context to cleanup handshaking connections on exit.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//
+	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
+	//
+
+	// Prepare the configuration of the DTLS connection
+	config := &dtls.Config{
+		PSK: func(hint []byte) ([]byte, error) {
+			fmt.Printf("Client's hint: %s \n", hint)
+			return []byte{0xAB, 0xC1, 0x23}, nil
+		},
+		PSKIdentityHint:      []byte("Pion DTLS Server"),
+		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
+		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
+		// Create timeout context for accepted connection.
+		ConnectContextMaker: func() (context.Context, func()) {
+			return context.WithTimeout(ctx, 30*time.Second)
+		},
+	}
+
+	// Connect to a DTLS server
+	listener, err := dtls.Listen("udp", addr, config)
+	util.Check(err)
+	defer func() {
+		util.Check(listener.Close())
+	}()
+
+	fmt.Println("Listening")
+
+	// Simulate a chat session
+	hub := util.NewHub()
+
+	type HandshakeListener interface {
+		AcceptHandshake() (dtls.Handshaker, error)
+	}
+
+	go func() {
+		for {
+			// Wait for a connection.
+			hs, err := listener.(HandshakeListener).AcceptHandshake()
+			util.Check(err)
+			// defer conn.Close() // TODO: graceful shutdown
+
+			// `conn` is of type `net.Conn` but may be casted to `dtls.Conn`
+			// using `dtlsConn := conn.(*dtls.Conn)` in order to to expose
+			// functions like `ConnectionState` etc.
+
+			go func() {
+				conn, err := hs.Handshake()
+				util.Check(err)
+
+				// Register the connection with the chat hub
+				if err == nil {
+					hub.Register(conn)
+				}
+			}()
+		}
+	}()
+
+	// Start chatting
+	hub.Chat()
+}

--- a/listener_test.go
+++ b/listener_test.go
@@ -10,7 +10,7 @@ import (
 // TestParallelHandshakes tests that handshakes can be performed in parallel
 // using the AcceptHandshake method.
 // We create 2 connections to a listener.
-// The first is "sleepy", it takes a while to read or write.
+// The first is "sleepy", it takes a while to read.
 // The second is normal.
 // We should quickly complete a handshake with the second and start reading.
 func TestParallelHandshakes(t *testing.T) {

--- a/listener_test.go
+++ b/listener_test.go
@@ -63,7 +63,7 @@ func setupHandshakingTest(t *testing.T, port int) (ln net.Listener, done chan er
 			return []byte("testpsk"), nil
 		},
 		ConnectContextMaker: func() (context.Context, func()) {
-			return context.WithTimeout(context.Background(), time.Second*2)
+			return context.WithTimeout(context.Background(), time.Millisecond*200)
 		},
 		PSKIdentityHint: []byte("testhint"),
 		CipherSuites:         []CipherSuiteID{TLS_PSK_WITH_AES_128_CCM_8},
@@ -88,7 +88,7 @@ func setupHandshakingTest(t *testing.T, port int) (ln net.Listener, done chan er
 
 	done = make(chan error)
 	go doTestConn(sleepyConn, lnAddr, config, func(error){})
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond * 100)
 	go doTestConn(conn, lnAddr, config, func(err error) {
 		done <- err
 	})

--- a/listener_test.go
+++ b/listener_test.go
@@ -65,7 +65,7 @@ func TestParallelHandshakes(t *testing.T) {
 			t.Error(err)
 		}
 	case <-time.After(time.Millisecond*100):
-		t.Errorf("Expected second connection to be bypass first")
+		t.Errorf("Expected second connection to handshake quickly")
 	}
 }
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -14,7 +14,7 @@ import (
 // The second is normal.
 // We should quickly complete a handshake with the second and start reading.
 func TestParallelHandshakes(t *testing.T) {
-	ln, done := setupHandshakingTest(t)
+	ln, done := setupHandshakingTest(t, 5284)
 	defer ln.Close()
 
 	type AcceptHandshaker interface {
@@ -42,7 +42,7 @@ func TestParallelHandshakes(t *testing.T) {
 // TestSerialHandshakes tests that Accept uses serial handshakes.
 // This ensures that the parallel handshake test actually proves changed behavior.
 func TestSerialHandshakes(t *testing.T) {
-	ln, _ := setupHandshakingTest(t)
+	ln, _ := setupHandshakingTest(t, 5285)
 	defer ln.Close()
 	for idx := 0; idx < 2; idx++ {
 		_, err := ln.Accept()
@@ -53,10 +53,10 @@ func TestSerialHandshakes(t *testing.T) {
 }
 
 // setupHandshakingTest creates the setup for a handshaking test.
-func setupHandshakingTest(t *testing.T) (ln net.Listener, done chan error) {
+func setupHandshakingTest(t *testing.T, port int) (ln net.Listener, done chan error) {
 	lnAddr := &net.UDPAddr{
 		IP: net.IPv4(127, 0, 0, 1),
-		Port: 5284,
+		Port: port,
 	}
 	config := &Config{
 		PSK: func(b []byte) ([]byte, error) {

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,0 +1,101 @@
+package dtls
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestParallelHandshakes tests that handshakes can be performed in parallel
+// using the AcceptHandshake method.
+// We create 2 connections to a listener.
+// The first is "sleepy", it takes a while to read or write.
+// The second is normal.
+// We should quickly complete a handshake with the second and start reading.
+func TestParallelHandshakes(t *testing.T) {
+	lnAddr := &net.UDPAddr{
+		IP: net.IPv4(127, 0, 0, 1),
+		Port: 5284,
+	}
+	config := &Config{
+		PSK: func(b []byte) ([]byte, error) {
+			return []byte("testpsk"), nil
+		},
+		PSKIdentityHint: []byte("testhint"),
+		CipherSuites:         []CipherSuiteID{TLS_PSK_WITH_AES_128_CCM_8},
+		ExtendedMasterSecret: RequestExtendedMasterSecret,
+	}
+
+	ln, err := Listen("udp4", lnAddr, config)
+	if err != nil {
+		t.Fatalf("Failed creating listener: %s", err.Error())
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		t.Fatalf("Failed creating conn: %s", err.Error())
+	}
+	sleepyConn := sleepy{conn}
+
+	conn, err = net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		t.Fatalf("Failed creating conn: %s", err.Error())
+	}
+
+	done := make(chan error)
+	go doTestConn(sleepyConn, lnAddr, config, func(error){})
+	time.Sleep(time.Second)
+	go doTestConn(conn, lnAddr, config, func(err error) {
+		done <- err
+	})
+
+	type AcceptHandshaker interface {
+		AcceptHandshake() (Handshaker, error)
+	}
+
+	hs, err := ln.(AcceptHandshaker).AcceptHandshake()
+	if err != nil {
+		t.Fatalf("Failed accepting: %s", err.Error())
+	}
+	go hs.Handshake()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Error(err)
+		}
+	case <-time.After(time.Millisecond*100):
+		t.Errorf("Expected second connection to be bypass first")
+	}
+}
+
+func doTestConn(
+	inner net.PacketConn,
+	lnAddr net.Addr,
+	config *Config,
+	onDone func(error),
+) {
+	conn, err := Client(inner, lnAddr, config)
+	if err != nil {
+		onDone(err)
+		return
+	}
+
+	conn.Close()
+	onDone(nil)
+	return
+}
+
+type sleepy struct {
+	net.PacketConn
+}
+
+func (s sleepy) ReadFrom(p []byte) (n int, add net.Addr, err error) {
+	time.Sleep(time.Hour)
+	return s.PacketConn.ReadFrom(p)
+}
+
+func (s sleepy) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	time.Sleep(time.Hour)
+	return s.PacketConn.WriteTo(p, addr)
+}

--- a/listener_test.go
+++ b/listener_test.go
@@ -1,6 +1,7 @@
 package dtls
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -13,6 +14,46 @@ import (
 // The second is normal.
 // We should quickly complete a handshake with the second and start reading.
 func TestParallelHandshakes(t *testing.T) {
+	ln, done := setupHandshakingTest(t)
+	defer ln.Close()
+
+	type AcceptHandshaker interface {
+		AcceptHandshake() (Handshaker, error)
+	}
+
+	for idx := 0; idx < 2; idx++ {
+		hs, err := ln.(AcceptHandshaker).AcceptHandshake()
+		if err != nil {
+			t.Fatalf("Failed accepting: %s", err.Error())
+		}
+		go hs.Handshake()
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Error(err)
+		}
+	case <-time.After(time.Millisecond*100):
+		t.Errorf("Expected second connection to handshake quickly")
+	}
+}
+
+// TestSerialHandshakes tests that Accept uses serial handshakes.
+// This ensures that the parallel handshake test actually proves changed behavior.
+func TestSerialHandshakes(t *testing.T) {
+	ln, _ := setupHandshakingTest(t)
+	defer ln.Close()
+	for idx := 0; idx < 2; idx++ {
+		_, err := ln.Accept()
+		if err == nil {
+			t.Fatalf("Expected to fail accepting with timeout")
+		}
+	}
+}
+
+// setupHandshakingTest creates the setup for a handshaking test.
+func setupHandshakingTest(t *testing.T) (ln net.Listener, done chan error) {
 	lnAddr := &net.UDPAddr{
 		IP: net.IPv4(127, 0, 0, 1),
 		Port: 5284,
@@ -20,6 +61,9 @@ func TestParallelHandshakes(t *testing.T) {
 	config := &Config{
 		PSK: func(b []byte) ([]byte, error) {
 			return []byte("testpsk"), nil
+		},
+		ConnectContextMaker: func() (context.Context, func()) {
+			return context.WithTimeout(context.Background(), time.Second*2)
 		},
 		PSKIdentityHint: []byte("testhint"),
 		CipherSuites:         []CipherSuiteID{TLS_PSK_WITH_AES_128_CCM_8},
@@ -42,31 +86,14 @@ func TestParallelHandshakes(t *testing.T) {
 		t.Fatalf("Failed creating conn: %s", err.Error())
 	}
 
-	done := make(chan error)
+	done = make(chan error)
 	go doTestConn(sleepyConn, lnAddr, config, func(error){})
 	time.Sleep(time.Second)
 	go doTestConn(conn, lnAddr, config, func(err error) {
 		done <- err
 	})
 
-	type AcceptHandshaker interface {
-		AcceptHandshake() (Handshaker, error)
-	}
-
-	hs, err := ln.(AcceptHandshaker).AcceptHandshake()
-	if err != nil {
-		t.Fatalf("Failed accepting: %s", err.Error())
-	}
-	go hs.Handshake()
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Error(err)
-		}
-	case <-time.After(time.Millisecond*100):
-		t.Errorf("Expected second connection to handshake quickly")
-	}
+	return ln, done
 }
 
 func doTestConn(
@@ -93,9 +120,4 @@ type sleepy struct {
 func (s sleepy) ReadFrom(p []byte) (n int, add net.Addr, err error) {
 	time.Sleep(time.Hour)
 	return s.PacketConn.ReadFrom(p)
-}
-
-func (s sleepy) WriteTo(p []byte, addr net.Addr) (n int, err error) {
-	time.Sleep(time.Hour)
-	return s.PacketConn.WriteTo(p, addr)
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -14,46 +14,75 @@ import (
 // The second is normal.
 // We should quickly complete a handshake with the second and start reading.
 func TestParallelHandshakes(t *testing.T) {
-	ln, done := setupHandshakingTest(t, 5284)
-	defer ln.Close()
+	done := make(chan error)
+	doHandshakingTest(
+		t, 5284,
+		func(inner net.PacketConn, ln net.Listener, config *Config) {
+			Client(inner, ln.Addr(), config)
+		},
+		func(inner net.PacketConn, ln net.Listener, config *Config) {
+			conn, err := Client(inner, ln.Addr(), config)
+			if err != nil {
+				done <- err
+				return
+			}
 
-	type AcceptHandshaker interface {
-		AcceptHandshake() (Handshaker, error)
-	}
+			conn.Close()
+			done <- nil
+		},
+		func(ln net.Listener) {
+			type AcceptHandshaker interface {
+				AcceptHandshake() (Handshaker, error)
+			}
 
-	for idx := 0; idx < 2; idx++ {
-		hs, err := ln.(AcceptHandshaker).AcceptHandshake()
-		if err != nil {
-			t.Fatalf("Failed accepting: %s", err.Error())
-		}
-		go hs.Handshake()
-	}
+			for idx := 0; idx < 2; idx++ {
+				hs, err := ln.(AcceptHandshaker).AcceptHandshake()
+				if err != nil {
+					t.Fatalf("Failed accepting: %s", err.Error())
+				}
+				go hs.Handshake()
+			}
 
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Error(err)
-		}
-	case <-time.After(time.Millisecond*100):
-		t.Errorf("Expected second connection to handshake quickly")
-	}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Error(err)
+				}
+			case <-time.After(time.Millisecond*100):
+				t.Errorf("Expected second connection to handshake quickly")
+			}
+		},
+	)
 }
 
 // TestSerialHandshakes tests that Accept uses serial handshakes.
 // This ensures that the parallel handshake test actually proves changed behavior.
 func TestSerialHandshakes(t *testing.T) {
-	ln, _ := setupHandshakingTest(t, 5285)
-	defer ln.Close()
-	for idx := 0; idx < 2; idx++ {
-		_, err := ln.Accept()
-		if err == nil {
-			t.Fatalf("Expected to fail accepting with timeout")
-		}
-	}
+	doHandshakingTest(
+		t, 5284,
+		func(inner net.PacketConn, ln net.Listener, config *Config) {
+			Client(inner, ln.Addr(), config)
+		},
+		func(inner net.PacketConn, ln net.Listener, config *Config) {
+			Client(inner, ln.Addr(), config)
+		},
+		func(ln net.Listener) {
+			_, err := ln.Accept()
+			if err == nil {
+				t.Errorf("Expected to time out, but succeeded")
+			}
+		},
+	)
 }
 
 // setupHandshakingTest creates the setup for a handshaking test.
-func setupHandshakingTest(t *testing.T, port int) (ln net.Listener, done chan error) {
+func doHandshakingTest(
+	t *testing.T,
+	port int,
+	sleepyConnHandler func(conn net.PacketConn, ln net.Listener, config *Config),
+	normalConnHandler func(conn net.PacketConn, ln net.Listener, config *Config),
+	finisher func(ln net.Listener),
+) {
 	lnAddr := &net.UDPAddr{
 		IP: net.IPv4(127, 0, 0, 1),
 		Port: port,
@@ -74,42 +103,23 @@ func setupHandshakingTest(t *testing.T, port int) (ln net.Listener, done chan er
 	if err != nil {
 		t.Fatalf("Failed creating listener: %s", err.Error())
 	}
+	defer ln.Close()
 
 	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
 	if err != nil {
 		t.Fatalf("Failed creating conn: %s", err.Error())
 	}
 	sleepyConn := sleepy{conn}
+	go sleepyConnHandler(sleepyConn, ln, config)
+	time.Sleep(time.Millisecond * 100)
 
 	conn, err = net.ListenUDP("udp4", &net.UDPAddr{})
 	if err != nil {
 		t.Fatalf("Failed creating conn: %s", err.Error())
 	}
+	go normalConnHandler(conn, ln, config)
+	finisher(ln)
 
-	done = make(chan error)
-	go doTestConn(sleepyConn, lnAddr, config, func(error){})
-	time.Sleep(time.Millisecond * 100)
-	go doTestConn(conn, lnAddr, config, func(err error) {
-		done <- err
-	})
-
-	return ln, done
-}
-
-func doTestConn(
-	inner net.PacketConn,
-	lnAddr net.Addr,
-	config *Config,
-	onDone func(error),
-) {
-	conn, err := Client(inner, lnAddr, config)
-	if err != nil {
-		onDone(err)
-		return
-	}
-
-	conn.Close()
-	onDone(nil)
 	return
 }
 


### PR DESCRIPTION
#### Description
To allow for parallel handshake processing, I propose to introduce the `AcceptHandshake` method on `listener`. `AcceptHandshake` returns a `Handshaker` interface, which is just a conn who has not yet performed their handshake and a config for doing so. Handshakes may be processed in parallel by calling the `Handshake` method on the `Handshaker` in a background goroutine.

#### Reference issue
Fixes #279 
