### PR TITLE
Add test for ServerKeyExchange and PSK

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -969,7 +969,7 @@ func (c *Conn) isHandshakeCompletedSuccessfully() bool {
 	return boolean.bool
 }
 
-func (c *Conn) handshake(ctx context.Context, cfg *handshakeConfig, initialFlight flightVal, initialState handshakeState) error { //nolint:gocognit
+func (c *Conn) handshake(ctx context.Context, cfg *handshakeConfig, initialFlight flightVal, initialState handshakeState) error { //nolint:gocognit,contextcheck
 	c.fsm = newHandshakeFSM(&c.state, c.handshakeCache, cfg, initialFlight)
 
 	done := make(chan struct{})

--- a/examples/dial/psk/main.go
+++ b/examples/dial/psk/main.go
@@ -28,7 +28,7 @@ func main() {
 			fmt.Printf("Server's hint: %s \n", hint)
 			return []byte{0xAB, 0xC1, 0x23}, nil
 		},
-		PSKIdentityHint:      []byte("Pion DTLS Client"),
+		PSKIdentityHint:      []byte{},
 		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
 		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
 	}

--- a/examples/util/util.go
+++ b/examples/util/util.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func LoadKeyAndCertificate(keyPath string, certificatePath string) (tls.Certific
 
 // LoadCertificate Load/read certificate(s) from file
 func LoadCertificate(path string) (*tls.Certificate, error) {
-	rawData, err := ioutil.ReadFile(filepath.Clean(path))
+	rawData, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Assert that ServerKeyExchange is only sent with PSKIdentityHint is set on the server side.

Resolves #389
