### PR TITLE
Mark NULL and AES256CM SRTP ciphers as supported

### DIFF
--- a/pkg/protocol/extension/srtp_protection_profile.go
+++ b/pkg/protocol/extension/srtp_protection_profile.go
@@ -22,6 +22,10 @@ func srtpProtectionProfiles() map[SRTPProtectionProfile]bool {
 	return map[SRTPProtectionProfile]bool{
 		SRTP_AES128_CM_HMAC_SHA1_80: true,
 		SRTP_AES128_CM_HMAC_SHA1_32: true,
+		SRTP_AES256_CM_SHA1_80:      true,
+		SRTP_AES256_CM_SHA1_32:      true,
+		SRTP_NULL_HMAC_SHA1_80:      true,
+		SRTP_NULL_HMAC_SHA1_32:      true,
 		SRTP_AEAD_AES_128_GCM:       true,
 		SRTP_AEAD_AES_256_GCM:       true,
 	}


### PR DESCRIPTION
DTLS server checks this list during handshake. Without this change new NULL and AES256CM SRTP ciphers were ignored.
