### PR TITLE
Added DTLS-SRTP IDs for NULL and AES256CM ciphers (V2 CP)

### DIFF
--- a/pkg/protocol/extension/srtp_protection_profile.go
+++ b/pkg/protocol/extension/srtp_protection_profile.go
@@ -22,6 +22,10 @@ func srtpProtectionProfiles() map[SRTPProtectionProfile]bool {
 	return map[SRTPProtectionProfile]bool{
 		SRTP_AES128_CM_HMAC_SHA1_80: true,
 		SRTP_AES128_CM_HMAC_SHA1_32: true,
+		SRTP_AES256_CM_SHA1_80:      true,
+		SRTP_AES256_CM_SHA1_32:      true,
+		SRTP_NULL_HMAC_SHA1_80:      true,
+		SRTP_NULL_HMAC_SHA1_32:      true,
 		SRTP_AEAD_AES_128_GCM:       true,
 		SRTP_AEAD_AES_256_GCM:       true,
 	}

--- a/pkg/protocol/extension/srtp_protection_profile.go
+++ b/pkg/protocol/extension/srtp_protection_profile.go
@@ -10,6 +10,10 @@ type SRTPProtectionProfile uint16
 const (
 	SRTP_AES128_CM_HMAC_SHA1_80 SRTPProtectionProfile = 0x0001 // nolint
 	SRTP_AES128_CM_HMAC_SHA1_32 SRTPProtectionProfile = 0x0002 // nolint
+	SRTP_AES256_CM_SHA1_80      SRTPProtectionProfile = 0x0003 // nolint
+	SRTP_AES256_CM_SHA1_32      SRTPProtectionProfile = 0x0004 // nolint
+	SRTP_NULL_HMAC_SHA1_80      SRTPProtectionProfile = 0x0005 // nolint
+	SRTP_NULL_HMAC_SHA1_32      SRTPProtectionProfile = 0x0006 // nolint
 	SRTP_AEAD_AES_128_GCM       SRTPProtectionProfile = 0x0007 // nolint
 	SRTP_AEAD_AES_256_GCM       SRTPProtectionProfile = 0x0008 // nolint
 )

--- a/srtp_protection_profile.go
+++ b/srtp_protection_profile.go
@@ -12,6 +12,10 @@ type SRTPProtectionProfile = extension.SRTPProtectionProfile
 const (
 	SRTP_AES128_CM_HMAC_SHA1_80 SRTPProtectionProfile = extension.SRTP_AES128_CM_HMAC_SHA1_80 // nolint:revive,stylecheck
 	SRTP_AES128_CM_HMAC_SHA1_32 SRTPProtectionProfile = extension.SRTP_AES128_CM_HMAC_SHA1_32 // nolint:revive,stylecheck
+	SRTP_AES256_CM_SHA1_80      SRTPProtectionProfile = extension.SRTP_AES256_CM_SHA1_80      // nolint:revive,stylecheck
+	SRTP_AES256_CM_SHA1_32      SRTPProtectionProfile = extension.SRTP_AES256_CM_SHA1_32      // nolint:revive,stylecheck
+	SRTP_NULL_HMAC_SHA1_80      SRTPProtectionProfile = extension.SRTP_NULL_HMAC_SHA1_80      // nolint:revive,stylecheck
+	SRTP_NULL_HMAC_SHA1_32      SRTPProtectionProfile = extension.SRTP_NULL_HMAC_SHA1_32      // nolint:revive,stylecheck
 	SRTP_AEAD_AES_128_GCM       SRTPProtectionProfile = extension.SRTP_AEAD_AES_128_GCM       // nolint:revive,stylecheck
 	SRTP_AEAD_AES_256_GCM       SRTPProtectionProfile = extension.SRTP_AEAD_AES_256_GCM       // nolint:revive,stylecheck
 )


### PR DESCRIPTION
Added DTLS-SRTP IDs for NULL and AES256CM ciphers

Mark NULL and AES256CM SRTP ciphers as supported

DTLS server checks this list during handshake. Without this change new
NULL and AES256CM SRTP ciphers were ignored.

This is V2 CP of PRs from master.