### PR TITLE
Fix incorrect client retransmissions

### DIFF
--- a/handshaker.go
+++ b/handshaker.go
@@ -338,7 +338,11 @@ func (s *handshakeFSM) finish(ctx context.Context, c flightConn) (handshakeState
 	select {
 	case state := <-c.recvHandshake():
 		close(state.done)
-		return handshakeSending, nil
+		if s.state.isClient {
+			return handshakeFinished, nil
+		} else {
+			return handshakeSending, nil
+		}
 	case <-ctx.Done():
 		return handshakeErrored, ctx.Err()
 	}

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -225,8 +225,8 @@ func TestHandshaker(t *testing.T) {
 					t.Errorf("Client is not finished")
 				}
 				// there should be no `Finished` last retransmit from client
-				if cntClientFinishedLastRetransmit != 4 {
-					t.Errorf("Number of client finished last retransmit is wrong, expected: %d times, got: %d times", 4, cntClientFinishedLastRetransmit)
+				if cntClientFinishedLastRetransmit != 0 {
+					t.Errorf("Number of client finished last retransmit is wrong, expected: %d times, got: %d times", 0, cntClientFinishedLastRetransmit)
 				}
 				if cntServerFinished < 1 {
 					t.Errorf("Number of server finished is wrong, expected: at least %d times, got: %d times", 1, cntServerFinished)


### PR DESCRIPTION
introduced by ec76652f161d0. If Client has gone to finished we know that server sent Finished. No reason to ever re-send messages.

Resolves pion/webrtc#2909
