### PR TITLE
Re-implemented renegotiation extension to comply with RFC5746 and RFC5246

### DIFF
--- a/flight0handler.go
+++ b/flight0handler.go
@@ -81,6 +81,8 @@ func flight0Parse(
 			}
 		case *extension.ServerName:
 			state.serverName = ext.ServerName // remote server name
+		case *extension.RenegotiationInfo:
+			state.remoteSupportsRenegotiation = true
 		case *extension.ALPN:
 			state.peerSupportedProtocols = ext.ProtocolNameList
 		case *extension.ConnectionID:

--- a/flight4handler.go
+++ b/flight4handler.go
@@ -263,9 +263,8 @@ func flight4Generate(
 	_ *handshakeCache,
 	cfg *handshakeConfig,
 ) ([]*packet, *alert.Alert, error) {
-	extensions := []extension.Extension{&extension.RenegotiationInfo{
-		RenegotiatedConnection: 0,
-	}}
+	extensions := []extension.Extension{}
+
 	if (cfg.extendedMasterSecret == RequestExtendedMasterSecret ||
 		cfg.extendedMasterSecret == RequireExtendedMasterSecret) && state.extendedMasterSecret {
 		extensions = append(extensions, &extension.UseExtendedMasterSecret{
@@ -276,6 +275,11 @@ func flight4Generate(
 		extensions = append(extensions, &extension.UseSRTP{
 			ProtectionProfiles:  []SRTPProtectionProfile{state.getSRTPProtectionProfile()},
 			MasterKeyIdentifier: cfg.localSRTPMasterKeyIdentifier,
+		})
+	}
+	if state.remoteSupportsRenegotiation {
+		extensions = append(extensions, &extension.RenegotiationInfo{
+			RenegotiatedConnection: 0,
 		})
 	}
 	if state.cipherSuite.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate {

--- a/state.go
+++ b/state.go
@@ -26,6 +26,8 @@ type State struct {
 	cipherSuite               CipherSuite // nil if a cipherSuite hasn't been chosen
 	CipherSuiteID             CipherSuiteID
 
+	remoteSupportsRenegotiation bool // True when Client Hello contained renegotiation extension
+
 	srtpProtectionProfile         atomic.Value // Negotiated SRTPProtectionProfile
 	remoteSRTPMasterKeyIdentifier []byte
 


### PR DESCRIPTION
#### Description

In this pull request I have re-implemented the renegotiation extension headers to comply with RFC5746 and RFC5246. This is required for PionDTLS to work with WolfSSL which strictly follows these RFCs and stops to connection when the renegotiation extension is wrongly added to the ServerHello response.

#### Reference issue
Fixes #687 
