### PR TITLE
Migrate elliptic curves from elliptic to ecdh

### DIFF
--- a/pkg/crypto/elliptic/elliptic_test.go
+++ b/pkg/crypto/elliptic/elliptic_test.go
@@ -4,6 +4,8 @@
 package elliptic
 
 import (
+	crand "crypto/rand"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +28,33 @@ func TestString(t *testing.T) {
 			assert.Equal(t, tt.in.String(), tt.out)
 		})
 	}
+}
+
+func TestGenerateKeypair_InvalidCurve(t *testing.T) {
+	var invalid Curve = 0 // not a supported curve
+	_, err := GenerateKeypair(invalid)
+	assert.ErrorIs(t, err, errInvalidNamedCurve)
+}
+
+// create a fake reader that is guaranteed to fail to trigger a failure in generate keypair.
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.ErrUnsupported // any error is fine here.
+}
+
+func TestGenerateKeypair_RandFailure(t *testing.T) {
+	// replace crypto/rand.Reader to force ecdh.GenerateKey to fail.
+	orig := crand.Reader
+	crand.Reader = failingReader{}
+	defer func() { crand.Reader = orig }()
+
+	_, err := GenerateKeypair(P256)
+	assert.Error(t, err)
+}
+
+func TestToECDH_InvalidCurve(t *testing.T) {
+	var invalid Curve = 0xFFFF
+	_, err := invalid.toECDH()
+	assert.ErrorIs(t, err, errInvalidNamedCurve)
 }

--- a/pkg/crypto/prf/prf.go
+++ b/pkg/crypto/prf/prf.go
@@ -5,7 +5,7 @@
 package prf
 
 import ( //nolint:gci
-	ellipticStdlib "crypto/elliptic"
+	"crypto/ecdh"
 	"crypto/hmac"
 	"encoding/binary"
 	"errors"
@@ -15,7 +15,6 @@ import ( //nolint:gci
 
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
-	"golang.org/x/crypto/curve25519"
 )
 
 const (
@@ -108,30 +107,30 @@ func EcdhePSKPreMasterSecret(psk, publicKey, privateKey []byte, curve elliptic.C
 
 // PreMasterSecret implements TLS 1.2 Premaster Secret generation given a keypair and a curve.
 func PreMasterSecret(publicKey, privateKey []byte, curve elliptic.Curve) ([]byte, error) {
+	var ec ecdh.Curve
+
 	switch curve {
 	case elliptic.X25519:
-		return curve25519.X25519(privateKey, publicKey)
+		ec = ecdh.X25519()
 	case elliptic.P256:
-		return ellipticCurvePreMasterSecret(publicKey, privateKey, ellipticStdlib.P256(), ellipticStdlib.P256())
+		ec = ecdh.P256()
 	case elliptic.P384:
-		return ellipticCurvePreMasterSecret(publicKey, privateKey, ellipticStdlib.P384(), ellipticStdlib.P384())
+		ec = ecdh.P384()
 	default:
 		return nil, errInvalidNamedCurve
 	}
-}
 
-func ellipticCurvePreMasterSecret(publicKey, privateKey []byte, c1, c2 ellipticStdlib.Curve) ([]byte, error) {
-	x, y := ellipticStdlib.Unmarshal(c1, publicKey) //nolint:staticcheck
-	if x == nil || y == nil {
-		return nil, errInvalidNamedCurve
+	sk, err := ec.NewPrivateKey(privateKey)
+	if err != nil {
+		return nil, err
 	}
 
-	result, _ := c2.ScalarMult(x, y, privateKey)
-	preMasterSecret := make([]byte, (c2.Params().BitSize+7)>>3)
-	resultBytes := result.Bytes()
-	copy(preMasterSecret[len(preMasterSecret)-len(resultBytes):], resultBytes)
+	pk, err := ec.NewPublicKey(publicKey) // NIST: SEC1 uncompressed; X25519: 32-byte u
+	if err != nil {
+		return nil, err
+	}
 
-	return preMasterSecret, nil
+	return sk.ECDH(pk)
 }
 
 // PHash is PRF is the SHA-256 hash function is used for all cipher suites


### PR DESCRIPTION
#### Description
Completes #739:
> We currently use [crypto/elliptic](https://pkg.go.dev/crypto/elliptic) library for elliptic curves. This library is currently deprecated, and we should move to the [crypto/ecdh](https://pkg.go.dev/crypto/ecdh) standard library.

#### Reference issue
Closes #739.
