### PR TITLE
Implement TLS_EMPTY_RENEGOTIATION_INFO_SCSV

### DIFF
--- a/flight0handler.go
+++ b/flight0handler.go
@@ -14,7 +14,11 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
-//nolint:cyclop
+// renegotiationInfoSCSV is TLS_EMPTY_RENEGOTIATION_INFO_SCSV defined in RFC 5746.
+// https://datatracker.ietf.org/doc/html/rfc5746#section-3.3.
+const renegotiationInfoSCSV uint16 = 0x00ff
+
+//nolint:cyclop,gocognit
 func flight0Parse(
 	_ context.Context,
 	_ flightConn,
@@ -52,6 +56,11 @@ func flight0Parse(
 
 	cipherSuites := []CipherSuite{}
 	for _, id := range clientHello.CipherSuiteIDs {
+		if id == renegotiationInfoSCSV {
+			state.remoteSupportsRenegotiation = true
+
+			continue
+		}
 		if c := cipherSuiteForID(CipherSuiteID(id), cfg.customCipherSuites); c != nil {
 			cipherSuites = append(cipherSuites, c)
 		}


### PR DESCRIPTION
#### Description
We used to send `renegotiation_info` all the time, which was incorrect and caused some clients to break until the fix in https://github.com/pion/dtls/pull/711 this implements extra detection via `TLS_EMPTY_RENEGOTIATION_INFO_SCSV`. 

>  Both the SSLv3 and TLS 1.0/TLS 1.1 specifications require
   implementations to ignore data following the ClientHello (i.e.,
   extensions) if they do not understand it.  However, some SSLv3 and
   TLS 1.0 implementations incorrectly fail the handshake in such a
   case.  This means that clients that offer the "renegotiation_info"
   extension may encounter handshake failures.  In order to enhance
   compatibility with such servers, this document defines a second
   signaling mechanism via a special Signaling Cipher Suite Value (SCSV)
   "TLS_EMPTY_RENEGOTIATION_INFO_SCSV", with code point {0x00, 0xFF}.
   This SCSV is not a true cipher suite (it does not correspond to any
   valid set of algorithms) and cannot be negotiated.  Instead, it has
   the same semantics as an empty "renegotiation_info" extension, as
   described in the following sections.  Because SSLv3 and TLS
   implementations reliably ignore unknown cipher suites, the SCSV may
   be safely sent to any server.  The SCSV can also be included in the
   SSLv2 backward compatible CLIENT-HELLO (see Appendix E.2 of
   [RFC5246]).
   
https://datatracker.ietf.org/doc/html/rfc5746#section-3.3
#### Reference issue
fixes https://github.com/pion/webrtc/issues/3264 
