### PR TITLE
Fix gosec slice bounds warnings

### DIFF
--- a/pkg/crypto/ccm/ccm.go
+++ b/pkg/crypto/ccm/ccm.go
@@ -146,8 +146,7 @@ func (c *ccm) tag(nonce, plaintext, adata []byte) ([]byte, error) {
 		if adataLength <= 0xfeff {
 			binary.BigEndian.PutUint16(block[:i], uint16(adataLength))
 		} else {
-			block[0] = 0xfe
-			block[1] = 0xff
+			binary.BigEndian.PutUint16(block[0:2], 0xfeff)
 			if adataLength < uint64(1<<32) {
 				i = 2 + 4
 				binary.BigEndian.PutUint32(block[2:i], uint32(adataLength)) //nolint:gosec // G115

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -58,40 +58,41 @@ func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 	}
 
 	for offset := 2; offset < len(buf); {
-		if len(buf) < (offset + 2) {
+		bufView := buf[offset:] //nolint:gosec // offset bounded by loop condition
+		if len(bufView) < 2 {
 			return nil, errBufferTooSmall
 		}
 		var err error
-		switch TypeValue(binary.BigEndian.Uint16(buf[offset:])) {
+		switch TypeValue(binary.BigEndian.Uint16(bufView)) {
 		case ServerNameTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &ServerName{})
+			err = unmarshalAndAppend(bufView, &ServerName{})
 		case SupportedEllipticCurvesTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &SupportedEllipticCurves{})
+			err = unmarshalAndAppend(bufView, &SupportedEllipticCurves{})
 		case SupportedPointFormatsTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &SupportedPointFormats{})
+			err = unmarshalAndAppend(bufView, &SupportedPointFormats{})
 		case SupportedSignatureAlgorithmsTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &SupportedSignatureAlgorithms{})
+			err = unmarshalAndAppend(bufView, &SupportedSignatureAlgorithms{})
 		case UseSRTPTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &UseSRTP{})
+			err = unmarshalAndAppend(bufView, &UseSRTP{})
 		case ALPNTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &ALPN{})
+			err = unmarshalAndAppend(bufView, &ALPN{})
 		case UseExtendedMasterSecretTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &UseExtendedMasterSecret{})
+			err = unmarshalAndAppend(bufView, &UseExtendedMasterSecret{})
 		case RenegotiationInfoTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &RenegotiationInfo{})
+			err = unmarshalAndAppend(bufView, &RenegotiationInfo{})
 		case ConnectionIDTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &ConnectionID{})
+			err = unmarshalAndAppend(bufView, &ConnectionID{})
 		case SupportedVersionsTypeValue:
-			err = unmarshalAndAppend(buf[offset:], &SupportedVersions{})
+			err = unmarshalAndAppend(bufView, &SupportedVersions{})
 		default:
 		}
 		if err != nil {
 			return nil, err
 		}
-		if len(buf) < (offset + 4) {
+		if len(bufView) < 4 {
 			return nil, errBufferTooSmall
 		}
-		extensionLength := binary.BigEndian.Uint16(buf[offset+2:])
+		extensionLength := binary.BigEndian.Uint16(bufView[2:])
 		offset += (4 + int(extensionLength))
 	}
 

--- a/pkg/protocol/handshake/message_client_hello.go
+++ b/pkg/protocol/handshake/message_client_hello.go
@@ -43,8 +43,7 @@ func (m *MessageClientHello) Marshal() ([]byte, error) {
 	}
 
 	out := make([]byte, handshakeMessageClientHelloVariableWidthStart)
-	out[0] = m.Version.Major
-	out[1] = m.Version.Minor
+	out[0], out[1] = m.Version.Major, m.Version.Minor //nolint:gosec // out is initialized with length 34
 
 	rand := m.Random.MarshalFixed()
 	copy(out[2:], rand[:])

--- a/pkg/protocol/recordlayer/recordlayer_test.go
+++ b/pkg/protocol/recordlayer/recordlayer_test.go
@@ -167,9 +167,9 @@ func FuzzRecordLayer_UnpackDatagram_RoundTrip(f *testing.F) {
 
 		for i := range all {
 			if len(all[i]) > 1<<14 {
-				all[i] = all[i][:1<<14]
+				all[i] = all[i][:1<<14] //nolint:gosec // i is bounded by range over all slice
 			}
-			if len(all[i]) == 0 {
+			if len(all[i]) == 0 { //nolint:gosec // i is bounded by range over all slice
 				all[i] = []byte{0} // ensure a non-empty record
 			}
 		}


### PR DESCRIPTION
Add nolint directives for safe slice accesses where bounds are guaranteed by fixed-size arrays or prior bounds checks.

