### PR TITLE
Introduce options patterns

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,7 +23,10 @@ const keyLogLabelTLS12 = "CLIENT_RANDOM"
 
 // Config is used to configure a DTLS client or server.
 // After a Config is passed to a DTLS function it must not be modified.
-type Config struct {
+//
+// Deprecated: prefer the options-based APIs (`*WithOptions`) to construct immutable configs,
+// This will be removed in the next major version.
+type Config struct { //nolint:dupl
 	// Certificates contains certificate chain to present to the other side of the connection.
 	// Server MUST set this if PSK is non-nil
 	// client SHOULD sets this so CertificateRequests can be handled if PSK is non-nil

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -8,7 +8,6 @@ package dtls
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
@@ -44,8 +43,11 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 	cert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
 
-	config := &Config{
-		Certificates: []tls.Certificate{cert},
+	clientOpts := []ClientOption{
+		WithCertificates(cert),
+	}
+	serverOpts := []ServerOption{
+		WithCertificates(cert),
 	}
 
 	dials := map[string]struct {
@@ -57,7 +59,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := Dial("udp", addr, config)
+						conn, err := DialWithOptions("udp", addr, clientOpts...)
 						if err != nil {
 							return nil, err
 						}
@@ -75,7 +77,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), config)
+						conn, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), clientOpts...)
 						if err != nil {
 							return nil, err
 						}
@@ -94,7 +96,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := Server(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), config)
+						conn, err := ServerWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), serverOpts...)
 						if err != nil {
 							return nil, err
 						}

--- a/errors.go
+++ b/errors.go
@@ -62,11 +62,15 @@ var (
 	//nolint:err113
 	errInvalidCipherSuite = &FatalError{Err: errors.New("invalid or unknown cipher suite")}
 	//nolint:err113
+	errInvalidClientAuthType = &FatalError{Err: errors.New("invalid client auth type")}
+	//nolint:err113
 	errInvalidECDSASignature = &FatalError{Err: errors.New("ECDSA signature contained zero or negative values")}
 	//nolint:err113
 	errInvalidPrivateKey = &FatalError{Err: errors.New("invalid private key type")}
 	//nolint:err113
 	errInvalidSignatureAlgorithm = &FatalError{Err: errors.New("invalid signature algorithm")}
+	//nolint:err113
+	errInvalidExtendedMasterSecretType = &FatalError{Err: errors.New("invalid extended master secret type")}
 	//nolint:err113
 	errKeySignatureMismatch = &FatalError{Err: errors.New("expected and actual key signature do not match")}
 	//nolint:err113
@@ -136,6 +140,73 @@ var (
 	errFailedToAccessPoolReadBuffer = &InternalError{Err: errors.New("failed to access pool read buffer")}
 	//nolint:err113
 	errFragmentBufferOverflow = &InternalError{Err: errors.New("fragment buffer overflow")}
+
+	//nolint:err113
+	errEmptyCertificates = &FatalError{Err: errors.New("certificates option requires at least one certificate")}
+	//nolint:err113
+	errEmptyCipherSuites = &FatalError{Err: errors.New("cipher suites option requires at least one cipher suite")}
+	//nolint:err113
+	errNilCustomCipherSuites = &FatalError{Err: errors.New("custom cipher suites option requires a non-nil function")}
+	//nolint:err113
+	errEmptySignatureSchemes = &FatalError{Err: errors.New("signature schemes option requires at least one scheme")}
+	//nolint:err113
+	errEmptySRTPProtectionProfiles = &FatalError{
+		Err: errors.New("SRTP protection profiles option requires at least one profile"),
+	}
+	//nolint:err113
+	errInvalidFlightInterval = &FatalError{Err: errors.New("flight interval must be positive")}
+	//nolint:err113
+	errNilPSKCallback = &FatalError{Err: errors.New("PSK option requires a non-nil callback")}
+	//nolint:err113
+	errNilVerifyPeerCertificate = &FatalError{
+		Err: errors.New("verify peer certificate option requires a non-nil callback"),
+	}
+	//nolint:err113
+	errNilVerifyConnection = &FatalError{Err: errors.New("verify connection option requires a non-nil callback")}
+	//nolint:err113
+	errInvalidMTU = &FatalError{Err: errors.New("MTU must be positive")}
+	//nolint:err113
+	errInvalidReplayProtectionWindow = &FatalError{Err: errors.New("replay protection window must be non-negative")}
+	//nolint:err113
+	errEmptySupportedProtocols = &FatalError{
+		Err: errors.New("supported protocols option requires at least one protocol"),
+	}
+	//nolint:err113
+	errEmptyEllipticCurves = &FatalError{Err: errors.New("elliptic curves option requires at least one curve")}
+	//nolint:err113
+	errNilGetClientCertificate = &FatalError{
+		Err: errors.New("get client certificate option requires a non-nil callback"),
+	}
+	//nolint:err113
+	errNilConnectionIDGenerator = &FatalError{
+		Err: errors.New("connection ID generator option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilPaddingLengthGenerator = &FatalError{
+		Err: errors.New("padding length generator option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilHelloRandomBytesGenerator = &FatalError{
+		Err: errors.New("hello random bytes generator option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilClientHelloMessageHook = &FatalError{
+		Err: errors.New("client hello message hook option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilGetCertificate = &FatalError{Err: errors.New("get certificate option requires a non-nil callback")}
+	//nolint:err113
+	errNilServerHelloMessageHook = &FatalError{
+		Err: errors.New("server hello message hook option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilCertificateRequestMessageHook = &FatalError{
+		Err: errors.New("certificate request message hook option requires a non-nil function"),
+	}
+	//nolint:err113
+	errNilOnConnectionAttempt = &FatalError{
+		Err: errors.New("on connection attempt option requires a non-nil callback"),
+	}
 )
 
 // FatalError indicates that the DTLS connection is no longer available.

--- a/examples/dial/cid/main.go
+++ b/examples/dial/cid/main.go
@@ -22,23 +22,20 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		PSK: func(hint []byte) ([]byte, error) {
-			fmt.Printf("Server's hint: %s \n", hint)
-
-			return []byte{0xAB, 0xC1, 0x23}, nil
-		},
-		PSKIdentityHint:       []byte("Pion DTLS Client"),
-		CipherSuites:          []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
-		ExtendedMasterSecret:  dtls.RequireExtendedMasterSecret,
-		ConnectionIDGenerator: dtls.OnlySendCIDGenerator(),
-	}
-
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+		dtls.WithPSK(func(hint []byte) ([]byte, error) {
+			fmt.Printf("Server's hint: %s \n", hint)
+
+			return []byte{0xAB, 0xC1, 0x23}, nil
+		}),
+		dtls.WithPSKIdentityHint([]byte("Pion DTLS Client")),
+		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+		dtls.WithConnectionIDGenerator(dtls.OnlySendCIDGenerator()),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/dial/psk/main.go
+++ b/examples/dial/psk/main.go
@@ -22,22 +22,19 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		PSK: func(hint []byte) ([]byte, error) {
-			fmt.Printf("Server's hint: %s \n", hint)
-
-			return []byte{0xAB, 0xC1, 0x23}, nil
-		},
-		PSKIdentityHint:      []byte{},
-		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-	}
-
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+		dtls.WithPSK(func(hint []byte) ([]byte, error) {
+			fmt.Printf("Server's hint: %s \n", hint)
+
+			return []byte{0xAB, 0xC1, 0x23}, nil
+		}),
+		dtls.WithPSKIdentityHint([]byte{}),
+		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/dial/selfsign/main.go
+++ b/examples/dial/selfsign/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
@@ -28,17 +27,14 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		Certificates:         []tls.Certificate{certificate},
-		InsecureSkipVerify:   true,
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-	}
-
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+		dtls.WithCertificates(certificate),
+		dtls.WithInsecureSkipVerify(true),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/dial/verify/main.go
+++ b/examples/dial/verify/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -35,17 +34,14 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		Certificates:         []tls.Certificate{certificate},
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		RootCAs:              certPool,
-	}
-
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.Dial("udp", addr, config)
+	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+		dtls.WithCertificates(certificate),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+		dtls.WithRootCAs(certPool),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(dtlsConn.Close())

--- a/examples/listen/cid/main.go
+++ b/examples/listen/cid/main.go
@@ -22,21 +22,17 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		PSK: func(hint []byte) ([]byte, error) {
+	listener, err := dtls.ListenWithOptions("udp", addr,
+		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 
 			return []byte{0xAB, 0xC1, 0x23}, nil
-		},
-		PSKIdentityHint:       []byte("Pion DTLS Server"),
-		CipherSuites:          []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
-		ExtendedMasterSecret:  dtls.RequireExtendedMasterSecret,
-		ConnectionIDGenerator: dtls.RandomCIDGenerator(8),
-	}
-
-	// Connect to a DTLS server
-	listener, err := dtls.Listen("udp", addr, config)
+		}),
+		dtls.WithPSKIdentityHint([]byte("Pion DTLS Server")),
+		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+		dtls.WithConnectionIDGenerator(dtls.RandomCIDGenerator(8)),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(listener.Close())

--- a/examples/listen/psk/main.go
+++ b/examples/listen/psk/main.go
@@ -22,20 +22,16 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		PSK: func(hint []byte) ([]byte, error) {
+	listener, err := dtls.ListenWithOptions("udp", addr,
+		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 
 			return []byte{0xAB, 0xC1, 0x23}, nil
-		},
-		PSKIdentityHint:      []byte("Pion DTLS Server"),
-		CipherSuites:         []dtls.CipherSuiteID{dtls.TLS_PSK_WITH_AES_128_CCM_8},
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-	}
-
-	// Connect to a DTLS server
-	listener, err := dtls.Listen("udp", addr, config)
+		}),
+		dtls.WithPSKIdentityHint([]byte("Pion DTLS Server")),
+		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(listener.Close())

--- a/examples/listen/selfsign/main.go
+++ b/examples/listen/selfsign/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
@@ -28,14 +27,10 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		Certificates:         []tls.Certificate{certificate},
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-	}
-
-	// Connect to a DTLS server
-	listener, err := dtls.Listen("udp", addr, config)
+	listener, err := dtls.ListenWithOptions("udp", addr,
+		dtls.WithCertificates(certificate),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(listener.Close())

--- a/examples/listen/verify/main.go
+++ b/examples/listen/verify/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -35,16 +34,12 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	// Prepare the configuration of the DTLS connection
-	config := &dtls.Config{
-		Certificates:         []tls.Certificate{certificate},
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		ClientAuth:           dtls.RequireAndVerifyClientCert,
-		ClientCAs:            certPool,
-	}
-
-	// Connect to a DTLS server
-	listener, err := dtls.Listen("udp", addr, config)
+	listener, err := dtls.ListenWithOptions("udp", addr,
+		dtls.WithCertificates(certificate),
+		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
+		dtls.WithClientAuth(dtls.RequireAndVerifyClientCert),
+		dtls.WithClientCAs(certPool),
+	)
 	util.Check(err)
 	defer func() {
 		util.Check(listener.Close())

--- a/listener.go
+++ b/listener.go
@@ -13,6 +13,8 @@ import (
 )
 
 // Listen creates a DTLS listener.
+//
+// Deprecated: Use ListenWithOptions instead.
 func Listen(network string, laddr *net.UDPAddr, config *Config) (net.Listener, error) {
 	if err := validateConfig(config); err != nil {
 		return nil, err
@@ -49,7 +51,19 @@ func Listen(network string, laddr *net.UDPAddr, config *Config) (net.Listener, e
 	}, nil
 }
 
+// ListenWithOptions creates a DTLS listener.
+func ListenWithOptions(network string, laddr *net.UDPAddr, opts ...ServerOption) (net.Listener, error) {
+	config, err := buildServerConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return Listen(network, laddr, config)
+}
+
 // NewListener creates a DTLS listener which accepts connections from an inner Listener.
+//
+// Deprecated: Use NewListenerWithOptions instead.
 func NewListener(inner dtlsnet.PacketListener, config *Config) (net.Listener, error) {
 	if err := validateConfig(config); err != nil {
 		return nil, err
@@ -59,6 +73,16 @@ func NewListener(inner dtlsnet.PacketListener, config *Config) (net.Listener, er
 		config: config,
 		parent: inner,
 	}, nil
+}
+
+// NewListenerWithOptions creates a DTLS listener which accepts connections from an inner Listener.
+func NewListenerWithOptions(inner dtlsnet.PacketListener, opts ...ServerOption) (net.Listener, error) {
+	config, err := buildServerConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewListener(inner, config)
 }
 
 // listener represents a DTLS listener.
@@ -75,7 +99,7 @@ func (l *listener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	return Server(c, raddr, l.config)
+	return serverWithConfig(c, raddr, l.config)
 }
 
 // Close closes the listener.

--- a/options.go
+++ b/options.go
@@ -1,0 +1,636 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/logging"
+)
+
+// ServerOption configures a DTLS server.
+type ServerOption interface {
+	applyServer(*dtlsConfig) error
+}
+
+// ClientOption configures a DTLS client.
+type ClientOption interface {
+	applyClient(*dtlsConfig) error
+}
+
+// Option is an option that can be used with both client and server.
+// This is used for options that apply to both sides of a connection,
+// such as in the Resume function where the side is determined at runtime.
+type Option interface {
+	ServerOption
+	ClientOption
+}
+
+// defensiveCopy copies a slice. This prevents the caller from mutating
+// the config after construction. Returns empty slice if input is empty.
+func defensiveCopy[T any](t ...T) []T {
+	return append([]T{}, t...)
+}
+
+// dtlsConfig is the internal configuration structure.
+// This will eventually replace the exported Config struct.
+type dtlsConfig struct { //nolint:dupl
+	certificates                  []tls.Certificate
+	cipherSuites                  []CipherSuiteID
+	customCipherSuites            func() []CipherSuite
+	signatureSchemes              []tls.SignatureScheme
+	srtpProtectionProfiles        []SRTPProtectionProfile
+	srtpMasterKeyIdentifier       []byte
+	clientAuth                    ClientAuthType
+	extendedMasterSecret          ExtendedMasterSecretType
+	flightInterval                time.Duration
+	disableRetransmitBackoff      bool
+	psk                           PSKCallback
+	pskIdentityHint               []byte
+	insecureSkipVerify            bool
+	insecureHashes                bool
+	verifyPeerCertificate         func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
+	verifyConnection              func(*State) error
+	rootCAs                       *x509.CertPool
+	clientCAs                     *x509.CertPool
+	serverName                    string
+	loggerFactory                 logging.LoggerFactory
+	mtu                           int
+	replayProtectionWindow        int
+	keyLogWriter                  io.Writer
+	sessionStore                  SessionStore
+	supportedProtocols            []string
+	ellipticCurves                []elliptic.Curve
+	getCertificate                func(*ClientHelloInfo) (*tls.Certificate, error)
+	getClientCertificate          func(*CertificateRequestInfo) (*tls.Certificate, error)
+	insecureSkipVerifyHello       bool
+	connectionIDGenerator         func() []byte
+	paddingLengthGenerator        func(uint) uint
+	helloRandomBytesGenerator     func() [handshake.RandomBytesLength]byte
+	clientHelloMessageHook        func(handshake.MessageClientHello) handshake.Message
+	serverHelloMessageHook        func(handshake.MessageServerHello) handshake.Message
+	certificateRequestMessageHook func(handshake.MessageCertificateRequest) handshake.Message
+	onConnectionAttempt           func(net.Addr) error
+}
+
+// applyDefaults applies default values to the config.
+func (c *dtlsConfig) applyDefaults() {
+	c.extendedMasterSecret = RequestExtendedMasterSecret
+	c.flightInterval = time.Second
+	c.mtu = defaultMTU
+	c.replayProtectionWindow = defaultReplayProtectionWindow
+}
+
+// toConfig converts internal dtlsConfig to the exported Config struct.
+// This is for backward compatibility and will be removed when Config is deprecated.
+// All slice fields are copied to ensure immutability.
+func (c *dtlsConfig) toConfig() *Config {
+	config := &Config{
+		CustomCipherSuites:            c.customCipherSuites,
+		ClientAuth:                    c.clientAuth,
+		ExtendedMasterSecret:          c.extendedMasterSecret,
+		FlightInterval:                c.flightInterval,
+		DisableRetransmitBackoff:      c.disableRetransmitBackoff,
+		PSK:                           c.psk,
+		InsecureSkipVerify:            c.insecureSkipVerify,
+		InsecureHashes:                c.insecureHashes,
+		VerifyPeerCertificate:         c.verifyPeerCertificate,
+		VerifyConnection:              c.verifyConnection,
+		RootCAs:                       c.rootCAs,
+		ClientCAs:                     c.clientCAs,
+		ServerName:                    c.serverName,
+		LoggerFactory:                 c.loggerFactory,
+		MTU:                           c.mtu,
+		ReplayProtectionWindow:        c.replayProtectionWindow,
+		KeyLogWriter:                  c.keyLogWriter,
+		SessionStore:                  c.sessionStore,
+		GetCertificate:                c.getCertificate,
+		GetClientCertificate:          c.getClientCertificate,
+		InsecureSkipVerifyHello:       c.insecureSkipVerifyHello,
+		ConnectionIDGenerator:         c.connectionIDGenerator,
+		PaddingLengthGenerator:        c.paddingLengthGenerator,
+		HelloRandomBytesGenerator:     c.helloRandomBytesGenerator,
+		ClientHelloMessageHook:        c.clientHelloMessageHook,
+		ServerHelloMessageHook:        c.serverHelloMessageHook,
+		CertificateRequestMessageHook: c.certificateRequestMessageHook,
+		OnConnectionAttempt:           c.onConnectionAttempt,
+	}
+
+	if len(c.certificates) > 0 {
+		config.Certificates = append([]tls.Certificate(nil), c.certificates...)
+	}
+	if len(c.cipherSuites) > 0 {
+		config.CipherSuites = append([]CipherSuiteID(nil), c.cipherSuites...)
+	}
+	if len(c.signatureSchemes) > 0 {
+		config.SignatureSchemes = append([]tls.SignatureScheme(nil), c.signatureSchemes...)
+	}
+	if len(c.srtpProtectionProfiles) > 0 {
+		config.SRTPProtectionProfiles = append([]SRTPProtectionProfile(nil), c.srtpProtectionProfiles...)
+	}
+	if len(c.srtpMasterKeyIdentifier) > 0 {
+		config.SRTPMasterKeyIdentifier = append([]byte(nil), c.srtpMasterKeyIdentifier...)
+	}
+	if len(c.pskIdentityHint) > 0 {
+		config.PSKIdentityHint = append([]byte(nil), c.pskIdentityHint...)
+	}
+	if len(c.supportedProtocols) > 0 {
+		config.SupportedProtocols = append([]string(nil), c.supportedProtocols...)
+	}
+	if len(c.ellipticCurves) > 0 {
+		config.EllipticCurves = append([]elliptic.Curve(nil), c.ellipticCurves...)
+	}
+
+	return config
+}
+
+// buildConfig builds a Config from the provided options, for mixed client/server cases.
+func buildConfig(opts ...Option) (*Config, error) {
+	cfg := &dtlsConfig{}
+	cfg.applyDefaults()
+
+	for _, opt := range opts {
+		if err := opt.applyServer(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg.toConfig(), nil
+}
+
+// buildServerConfig builds a Config for server from the provided options.
+func buildServerConfig(opts ...ServerOption) (*Config, error) {
+	cfg := &dtlsConfig{}
+	cfg.applyDefaults()
+
+	for _, opt := range opts {
+		if err := opt.applyServer(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg.toConfig(), nil
+}
+
+// buildClientConfig builds a Config for client from the provided options.
+func buildClientConfig(opts ...ClientOption) (*Config, error) {
+	cfg := &dtlsConfig{}
+	cfg.applyDefaults()
+
+	for _, opt := range opts {
+		if err := opt.applyClient(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg.toConfig(), nil
+}
+
+// sharedOption wraps an apply function that works for both client and server.
+// This eliminates code duplication for options that behave identically on both sides.
+type sharedOption func(*dtlsConfig) error
+
+func (o sharedOption) applyServer(c *dtlsConfig) error { return o(c) }
+func (o sharedOption) applyClient(c *dtlsConfig) error { return o(c) }
+
+// WithCertificates sets the certificate chain to present to the other side of the connection.
+// For functional options, an explicitly empty slice is not allowed.
+func WithCertificates(certs ...tls.Certificate) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(certs) == 0 {
+			return errEmptyCertificates
+		}
+		c.certificates = defensiveCopy(certs...)
+
+		return nil
+	})
+}
+
+// WithCipherSuites sets the supported cipher suites.
+// For functional options, an explicitly empty slice is not allowed.
+func WithCipherSuites(suites ...CipherSuiteID) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(suites) == 0 {
+			return errEmptyCipherSuites
+		}
+		c.cipherSuites = defensiveCopy(suites...)
+
+		return nil
+	})
+}
+
+// WithCustomCipherSuites sets the custom cipher suites provider.
+// Returns an error if the provider is nil.
+func WithCustomCipherSuites(fn func() []CipherSuite) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilCustomCipherSuites
+		}
+		c.customCipherSuites = fn
+
+		return nil
+	})
+}
+
+// WithSignatureSchemes sets the signature schemes.
+// For functional options, an explicitly empty slice is not allowed.
+func WithSignatureSchemes(schemes ...tls.SignatureScheme) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(schemes) == 0 {
+			return errEmptySignatureSchemes
+		}
+		c.signatureSchemes = defensiveCopy(schemes...)
+
+		return nil
+	})
+}
+
+// WithSRTPProtectionProfiles sets the SRTP protection profiles.
+// For functional options, an explicitly empty slice is not allowed.
+func WithSRTPProtectionProfiles(profiles ...SRTPProtectionProfile) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(profiles) == 0 {
+			return errEmptySRTPProtectionProfiles
+		}
+		c.srtpProtectionProfiles = defensiveCopy(profiles...)
+
+		return nil
+	})
+}
+
+// WithSRTPMasterKeyIdentifier sets the SRTP master key identifier.
+func WithSRTPMasterKeyIdentifier(identifier []byte) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.srtpMasterKeyIdentifier = defensiveCopy(identifier...)
+
+		return nil
+	})
+}
+
+// WithExtendedMasterSecret sets the extended master secret policy.
+// Returns an error if the type is invalid.
+func WithExtendedMasterSecret(ems ExtendedMasterSecretType) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if ems < RequestExtendedMasterSecret || ems > DisableExtendedMasterSecret {
+			return errInvalidExtendedMasterSecretType
+		}
+		c.extendedMasterSecret = ems
+
+		return nil
+	})
+}
+
+// WithFlightInterval sets the flight interval for handshake messages.
+// Returns an error if the interval is not positive.
+func WithFlightInterval(interval time.Duration) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if interval <= 0 {
+			return errInvalidFlightInterval
+		}
+		c.flightInterval = interval
+
+		return nil
+	})
+}
+
+// WithDisableRetransmitBackoff disables retransmit backoff.
+func WithDisableRetransmitBackoff(disable bool) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.disableRetransmitBackoff = disable
+
+		return nil
+	})
+}
+
+// WithPSK sets the pre-shared key callback.
+// Returns an error if the callback is nil.
+func WithPSK(callback PSKCallback) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if callback == nil {
+			return errNilPSKCallback
+		}
+		c.psk = callback
+
+		return nil
+	})
+}
+
+// WithPSKIdentityHint sets the PSK identity hint.
+func WithPSKIdentityHint(hint []byte) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.pskIdentityHint = defensiveCopy(hint...)
+
+		return nil
+	})
+}
+
+// WithInsecureSkipVerify skips certificate verification.
+// This should only be used for testing.
+func WithInsecureSkipVerify(skip bool) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.insecureSkipVerify = skip
+
+		return nil
+	})
+}
+
+// WithInsecureHashes allows the use of insecure hash algorithms.
+func WithInsecureHashes(allow bool) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.insecureHashes = allow
+
+		return nil
+	})
+}
+
+// WithVerifyPeerCertificate sets the peer certificate verification callback.
+// Returns an error if the callback is nil.
+func WithVerifyPeerCertificate(fn func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilVerifyPeerCertificate
+		}
+		c.verifyPeerCertificate = fn
+
+		return nil
+	})
+}
+
+// WithVerifyConnection sets the connection verification callback.
+// Returns an error if the callback is nil.
+func WithVerifyConnection(fn func(*State) error) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilVerifyConnection
+		}
+		c.verifyConnection = fn
+
+		return nil
+	})
+}
+
+// WithRootCAs sets the root certificate authorities.
+func WithRootCAs(pool *x509.CertPool) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.rootCAs = pool
+
+		return nil
+	})
+}
+
+// WithServerName sets the server name for certificate verification.
+func WithServerName(name string) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.serverName = name
+
+		return nil
+	})
+}
+
+// WithLoggerFactory sets the logger factory for creating loggers.
+func WithLoggerFactory(factory logging.LoggerFactory) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.loggerFactory = factory
+
+		return nil
+	})
+}
+
+// WithMTU sets the maximum transmission unit.
+// Returns an error if the MTU is not positive.
+func WithMTU(mtu int) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if mtu <= 0 {
+			return errInvalidMTU
+		}
+		c.mtu = mtu
+
+		return nil
+	})
+}
+
+// WithReplayProtectionWindow sets the replay protection window size.
+// Returns an error if the window size is negative.
+func WithReplayProtectionWindow(window int) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if window < 0 {
+			return errInvalidReplayProtectionWindow
+		}
+		c.replayProtectionWindow = window
+
+		return nil
+	})
+}
+
+// WithKeyLogWriter sets the key log writer for debugging.
+// Use of KeyLogWriter compromises security and should only be used for debugging.
+func WithKeyLogWriter(writer io.Writer) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.keyLogWriter = writer
+
+		return nil
+	})
+}
+
+// WithSessionStore sets the session store for resumption.
+func WithSessionStore(store SessionStore) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		c.sessionStore = store
+
+		return nil
+	})
+}
+
+// WithSupportedProtocols sets the supported application protocols for ALPN.
+// For functional options, an explicitly empty slice is not allowed.
+func WithSupportedProtocols(protocols ...string) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(protocols) == 0 {
+			return errEmptySupportedProtocols
+		}
+		c.supportedProtocols = defensiveCopy(protocols...)
+
+		return nil
+	})
+}
+
+// WithEllipticCurves sets the elliptic curves.
+// For functional options, an explicitly empty slice is not allowed.
+func WithEllipticCurves(curves ...elliptic.Curve) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if len(curves) == 0 {
+			return errEmptyEllipticCurves
+		}
+		c.ellipticCurves = defensiveCopy(curves...)
+
+		return nil
+	})
+}
+
+// WithGetClientCertificate sets the client certificate getter callback.
+// Returns an error if the callback is nil.
+func WithGetClientCertificate(fn func(*CertificateRequestInfo) (*tls.Certificate, error)) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilGetClientCertificate
+		}
+		c.getClientCertificate = fn
+
+		return nil
+	})
+}
+
+// WithConnectionIDGenerator sets the connection ID generator.
+// Returns an error if the generator is nil.
+func WithConnectionIDGenerator(fn func() []byte) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilConnectionIDGenerator
+		}
+		c.connectionIDGenerator = fn
+
+		return nil
+	})
+}
+
+// WithPaddingLengthGenerator sets the padding length generator.
+// Returns an error if the generator is nil.
+func WithPaddingLengthGenerator(fn func(uint) uint) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilPaddingLengthGenerator
+		}
+		c.paddingLengthGenerator = fn
+
+		return nil
+	})
+}
+
+// WithHelloRandomBytesGenerator sets the hello random bytes generator.
+// Returns an error if the generator is nil.
+func WithHelloRandomBytesGenerator(fn func() [handshake.RandomBytesLength]byte) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilHelloRandomBytesGenerator
+		}
+		c.helloRandomBytesGenerator = fn
+
+		return nil
+	})
+}
+
+// WithClientHelloMessageHook sets the client hello message hook.
+// Returns an error if the hook is nil.
+func WithClientHelloMessageHook(fn func(handshake.MessageClientHello) handshake.Message) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilClientHelloMessageHook
+		}
+		c.clientHelloMessageHook = fn
+
+		return nil
+	})
+}
+
+// serverOnlyOption wraps an apply function for server-only options.
+type serverOnlyOption func(*dtlsConfig) error
+
+func (o serverOnlyOption) applyServer(c *dtlsConfig) error { return o(c) }
+
+// WithClientAuth sets the client authentication policy.
+// Returns an error if the type is invalid.
+// This option is only applicable to servers.
+func WithClientAuth(auth ClientAuthType) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		if auth < NoClientCert || auth > RequireAndVerifyClientCert {
+			return errInvalidClientAuthType
+		}
+		c.clientAuth = auth
+
+		return nil
+	})
+}
+
+// WithClientCAs sets the client certificate authorities.
+// This option is only applicable to servers.
+func WithClientCAs(pool *x509.CertPool) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		c.clientCAs = pool
+
+		return nil
+	})
+}
+
+// WithGetCertificate sets the certificate getter callback.
+// Returns an error if the callback is nil.
+// This option is only applicable to servers.
+func WithGetCertificate(fn func(*ClientHelloInfo) (*tls.Certificate, error)) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilGetCertificate
+		}
+		c.getCertificate = fn
+
+		return nil
+	})
+}
+
+// WithInsecureSkipVerifyHello skips hello verify phase on the server.
+// This has implication on DoS attack resistance.
+// This option is only applicable to servers.
+func WithInsecureSkipVerifyHello(skip bool) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		c.insecureSkipVerifyHello = skip
+
+		return nil
+	})
+}
+
+// WithServerHelloMessageHook sets the server hello message hook.
+// Returns an error if the hook is nil.
+// This option is only applicable to servers.
+func WithServerHelloMessageHook(fn func(handshake.MessageServerHello) handshake.Message) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilServerHelloMessageHook
+		}
+		c.serverHelloMessageHook = fn
+
+		return nil
+	})
+}
+
+// WithCertificateRequestMessageHook sets the certificate request message hook.
+// Returns an error if the hook is nil.
+// This option is only applicable to servers.
+func WithCertificateRequestMessageHook(fn func(handshake.MessageCertificateRequest) handshake.Message) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilCertificateRequestMessageHook
+		}
+		c.certificateRequestMessageHook = fn
+
+		return nil
+	})
+}
+
+// WithOnConnectionAttempt sets the connection attempt callback.
+// Returns an error if the callback is nil.
+// This option is only applicable to servers.
+func WithOnConnectionAttempt(fn func(net.Addr) error) ServerOption {
+	return serverOnlyOption(func(c *dtlsConfig) error {
+		if fn == nil {
+			return errNilOnConnectionAttempt
+		}
+		c.onConnectionAttempt = fn
+
+		return nil
+	})
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,457 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	dtlsnet "github.com/pion/dtls/v3/pkg/net"
+	"github.com/pion/transport/v4/dpipe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientWithOptionsValidatesOptionValues(t *testing.T) {
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	_, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
+		WithExtendedMasterSecret(ExtendedMasterSecretType(-1)))
+	require.ErrorIs(t, err, errInvalidExtendedMasterSecretType)
+}
+
+func TestServerWithOptionsValidatesOptionValues(t *testing.T) {
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	// Test invalid client auth type
+	_, err := ServerWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
+		WithClientAuth(ClientAuthType(-1)))
+	require.ErrorIs(t, err, errInvalidClientAuthType)
+}
+
+func TestWithOptionsCreatesConn(t *testing.T) {
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	cert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
+		WithCertificates(cert),
+		WithInsecureSkipVerify(true),
+	)
+	require.NoError(t, err)
+
+	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(),
+		WithCertificates(cert),
+		WithInsecureSkipVerify(true),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+	require.NoError(t, server.Close())
+}
+
+// TestEmptySliceOptionsReturnError verifies that functional options return errors
+// for empty slices (unlike struct-based Config where empty means default).
+func TestEmptySliceOptionsReturnError(t *testing.T) {
+	t.Run("EmptyCertificates", func(t *testing.T) {
+		_, err := buildClientConfig(WithCertificates())
+		require.ErrorIs(t, err, errEmptyCertificates)
+
+		_, err = buildServerConfig(WithCertificates())
+		require.ErrorIs(t, err, errEmptyCertificates)
+	})
+
+	t.Run("EmptyCipherSuites", func(t *testing.T) {
+		_, err := buildClientConfig(WithCipherSuites())
+		require.ErrorIs(t, err, errEmptyCipherSuites)
+
+		_, err = buildServerConfig(WithCipherSuites())
+		require.ErrorIs(t, err, errEmptyCipherSuites)
+	})
+
+	t.Run("EmptySignatureSchemes", func(t *testing.T) {
+		_, err := buildClientConfig(WithSignatureSchemes())
+		require.ErrorIs(t, err, errEmptySignatureSchemes)
+
+		_, err = buildServerConfig(WithSignatureSchemes())
+		require.ErrorIs(t, err, errEmptySignatureSchemes)
+	})
+
+	t.Run("EmptySRTPProtectionProfiles", func(t *testing.T) {
+		_, err := buildClientConfig(WithSRTPProtectionProfiles())
+		require.ErrorIs(t, err, errEmptySRTPProtectionProfiles)
+
+		_, err = buildServerConfig(WithSRTPProtectionProfiles())
+		require.ErrorIs(t, err, errEmptySRTPProtectionProfiles)
+	})
+
+	t.Run("EmptySupportedProtocols", func(t *testing.T) {
+		_, err := buildClientConfig(WithSupportedProtocols())
+		require.ErrorIs(t, err, errEmptySupportedProtocols)
+
+		_, err = buildServerConfig(WithSupportedProtocols())
+		require.ErrorIs(t, err, errEmptySupportedProtocols)
+	})
+
+	t.Run("EmptyEllipticCurves", func(t *testing.T) {
+		_, err := buildClientConfig(WithEllipticCurves())
+		require.ErrorIs(t, err, errEmptyEllipticCurves)
+
+		_, err = buildServerConfig(WithEllipticCurves())
+		require.ErrorIs(t, err, errEmptyEllipticCurves)
+	})
+}
+
+// TestNilCallbackOptionsReturnError verifies that functional options return errors
+// for nil callbacks.
+func TestNilCallbackOptionsReturnError(t *testing.T) {
+	t.Run("NilCustomCipherSuites", func(t *testing.T) {
+		_, err := buildClientConfig(WithCustomCipherSuites(nil))
+		require.ErrorIs(t, err, errNilCustomCipherSuites)
+
+		_, err = buildServerConfig(WithCustomCipherSuites(nil))
+		require.ErrorIs(t, err, errNilCustomCipherSuites)
+	})
+
+	t.Run("NilPSKCallback", func(t *testing.T) {
+		_, err := buildClientConfig(WithPSK(nil))
+		require.ErrorIs(t, err, errNilPSKCallback)
+
+		_, err = buildServerConfig(WithPSK(nil))
+		require.ErrorIs(t, err, errNilPSKCallback)
+	})
+
+	t.Run("NilVerifyPeerCertificate", func(t *testing.T) {
+		_, err := buildClientConfig(WithVerifyPeerCertificate(nil))
+		require.ErrorIs(t, err, errNilVerifyPeerCertificate)
+
+		_, err = buildServerConfig(WithVerifyPeerCertificate(nil))
+		require.ErrorIs(t, err, errNilVerifyPeerCertificate)
+	})
+
+	t.Run("NilVerifyConnection", func(t *testing.T) {
+		_, err := buildClientConfig(WithVerifyConnection(nil))
+		require.ErrorIs(t, err, errNilVerifyConnection)
+
+		_, err = buildServerConfig(WithVerifyConnection(nil))
+		require.ErrorIs(t, err, errNilVerifyConnection)
+	})
+
+	t.Run("NilGetClientCertificate", func(t *testing.T) {
+		_, err := buildClientConfig(WithGetClientCertificate(nil))
+		require.ErrorIs(t, err, errNilGetClientCertificate)
+
+		_, err = buildServerConfig(WithGetClientCertificate(nil))
+		require.ErrorIs(t, err, errNilGetClientCertificate)
+	})
+
+	t.Run("NilConnectionIDGenerator", func(t *testing.T) {
+		_, err := buildClientConfig(WithConnectionIDGenerator(nil))
+		require.ErrorIs(t, err, errNilConnectionIDGenerator)
+
+		_, err = buildServerConfig(WithConnectionIDGenerator(nil))
+		require.ErrorIs(t, err, errNilConnectionIDGenerator)
+	})
+
+	t.Run("NilPaddingLengthGenerator", func(t *testing.T) {
+		_, err := buildClientConfig(WithPaddingLengthGenerator(nil))
+		require.ErrorIs(t, err, errNilPaddingLengthGenerator)
+
+		_, err = buildServerConfig(WithPaddingLengthGenerator(nil))
+		require.ErrorIs(t, err, errNilPaddingLengthGenerator)
+	})
+
+	t.Run("NilHelloRandomBytesGenerator", func(t *testing.T) {
+		_, err := buildClientConfig(WithHelloRandomBytesGenerator(nil))
+		require.ErrorIs(t, err, errNilHelloRandomBytesGenerator)
+
+		_, err = buildServerConfig(WithHelloRandomBytesGenerator(nil))
+		require.ErrorIs(t, err, errNilHelloRandomBytesGenerator)
+	})
+
+	t.Run("NilClientHelloMessageHook", func(t *testing.T) {
+		_, err := buildClientConfig(WithClientHelloMessageHook(nil))
+		require.ErrorIs(t, err, errNilClientHelloMessageHook)
+
+		_, err = buildServerConfig(WithClientHelloMessageHook(nil))
+		require.ErrorIs(t, err, errNilClientHelloMessageHook)
+	})
+}
+
+// TestServerOnlyNilCallbackOptionsReturnError verifies server-only options
+// return errors for nil callbacks.
+func TestServerOnlyNilCallbackOptionsReturnError(t *testing.T) {
+	t.Run("NilGetCertificate", func(t *testing.T) {
+		_, err := buildServerConfig(WithGetCertificate(nil))
+		require.ErrorIs(t, err, errNilGetCertificate)
+	})
+
+	t.Run("NilServerHelloMessageHook", func(t *testing.T) {
+		_, err := buildServerConfig(WithServerHelloMessageHook(nil))
+		require.ErrorIs(t, err, errNilServerHelloMessageHook)
+	})
+
+	t.Run("NilCertificateRequestMessageHook", func(t *testing.T) {
+		_, err := buildServerConfig(WithCertificateRequestMessageHook(nil))
+		require.ErrorIs(t, err, errNilCertificateRequestMessageHook)
+	})
+
+	t.Run("NilOnConnectionAttempt", func(t *testing.T) {
+		_, err := buildServerConfig(WithOnConnectionAttempt(nil))
+		require.ErrorIs(t, err, errNilOnConnectionAttempt)
+	})
+}
+
+// TestInvalidNumericOptionsReturnError verifies that invalid numeric values
+// return appropriate errors.
+func TestInvalidNumericOptionsReturnError(t *testing.T) {
+	t.Run("InvalidFlightInterval", func(t *testing.T) {
+		_, err := buildClientConfig(WithFlightInterval(0))
+		require.ErrorIs(t, err, errInvalidFlightInterval)
+
+		_, err = buildClientConfig(WithFlightInterval(-time.Second))
+		require.ErrorIs(t, err, errInvalidFlightInterval)
+
+		_, err = buildServerConfig(WithFlightInterval(0))
+		require.ErrorIs(t, err, errInvalidFlightInterval)
+	})
+
+	t.Run("InvalidMTU", func(t *testing.T) {
+		_, err := buildClientConfig(WithMTU(0))
+		require.ErrorIs(t, err, errInvalidMTU)
+
+		_, err = buildClientConfig(WithMTU(-100))
+		require.ErrorIs(t, err, errInvalidMTU)
+
+		_, err = buildServerConfig(WithMTU(0))
+		require.ErrorIs(t, err, errInvalidMTU)
+	})
+
+	t.Run("InvalidReplayProtectionWindow", func(t *testing.T) {
+		_, err := buildClientConfig(WithReplayProtectionWindow(-1))
+		require.ErrorIs(t, err, errInvalidReplayProtectionWindow)
+
+		_, err = buildServerConfig(WithReplayProtectionWindow(-1))
+		require.ErrorIs(t, err, errInvalidReplayProtectionWindow)
+	})
+
+	t.Run("InvalidClientAuthType", func(t *testing.T) {
+		_, err := buildServerConfig(WithClientAuth(ClientAuthType(-1)))
+		require.ErrorIs(t, err, errInvalidClientAuthType)
+
+		_, err = buildServerConfig(WithClientAuth(ClientAuthType(100)))
+		require.ErrorIs(t, err, errInvalidClientAuthType)
+	})
+
+	t.Run("InvalidExtendedMasterSecretType", func(t *testing.T) {
+		_, err := buildClientConfig(WithExtendedMasterSecret(ExtendedMasterSecretType(-1)))
+		require.ErrorIs(t, err, errInvalidExtendedMasterSecretType)
+
+		_, err = buildServerConfig(WithExtendedMasterSecret(ExtendedMasterSecretType(100)))
+		require.ErrorIs(t, err, errInvalidExtendedMasterSecretType)
+	})
+}
+
+// TestDefaultsAreApplied verifies that defaults are applied before options.
+func TestDefaultsAreApplied(t *testing.T) {
+	t.Run("ClientDefaults", func(t *testing.T) {
+		config, err := buildClientConfig()
+		require.NoError(t, err)
+
+		require.Equal(t, RequestExtendedMasterSecret, config.ExtendedMasterSecret)
+		require.Equal(t, time.Second, config.FlightInterval)
+		require.Equal(t, defaultMTU, config.MTU)
+		require.Equal(t, defaultReplayProtectionWindow, config.ReplayProtectionWindow)
+	})
+
+	t.Run("ServerDefaults", func(t *testing.T) {
+		config, err := buildServerConfig()
+		require.NoError(t, err)
+
+		require.Equal(t, RequestExtendedMasterSecret, config.ExtendedMasterSecret)
+		require.Equal(t, time.Second, config.FlightInterval)
+		require.Equal(t, defaultMTU, config.MTU)
+		require.Equal(t, defaultReplayProtectionWindow, config.ReplayProtectionWindow)
+	})
+}
+
+// TestOptionsOverrideDefaults verifies that options override defaults.
+func TestOptionsOverrideDefaults(t *testing.T) {
+	t.Run("ClientOptionsOverrideDefaults", func(t *testing.T) {
+		config, err := buildClientConfig(
+			WithExtendedMasterSecret(RequireExtendedMasterSecret),
+			WithFlightInterval(2*time.Second),
+			WithMTU(1500),
+			WithReplayProtectionWindow(128),
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, RequireExtendedMasterSecret, config.ExtendedMasterSecret)
+		require.Equal(t, 2*time.Second, config.FlightInterval)
+		require.Equal(t, 1500, config.MTU)
+		require.Equal(t, 128, config.ReplayProtectionWindow)
+	})
+
+	t.Run("ServerOptionsOverrideDefaults", func(t *testing.T) {
+		config, err := buildServerConfig(
+			WithExtendedMasterSecret(DisableExtendedMasterSecret),
+			WithFlightInterval(3*time.Second),
+			WithMTU(1400),
+			WithReplayProtectionWindow(256),
+			WithClientAuth(RequireAndVerifyClientCert),
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, DisableExtendedMasterSecret, config.ExtendedMasterSecret)
+		require.Equal(t, 3*time.Second, config.FlightInterval)
+		require.Equal(t, 1400, config.MTU)
+		require.Equal(t, 256, config.ReplayProtectionWindow)
+		require.Equal(t, RequireAndVerifyClientCert, config.ClientAuth)
+	})
+}
+
+// TestValidOptionsSucceed verifies that valid options don't return errors.
+func TestValidOptionsSucceed(t *testing.T) {
+	cert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	t.Run("ClientValidOptions", func(t *testing.T) {
+		config, err := buildClientConfig(
+			WithCertificates(cert),
+			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+			WithSignatureSchemes(tls.ECDSAWithP256AndSHA256),
+			WithSRTPProtectionProfiles(SRTP_AES128_CM_HMAC_SHA1_80),
+			WithEllipticCurves(elliptic.P256),
+			WithSupportedProtocols("h2", "http/1.1"),
+			WithInsecureSkipVerify(true),
+			WithServerName("example.com"),
+		)
+		require.NoError(t, err)
+
+		require.Len(t, config.Certificates, 1)
+		require.Len(t, config.CipherSuites, 1)
+		require.Len(t, config.SignatureSchemes, 1)
+		require.Len(t, config.SRTPProtectionProfiles, 1)
+		require.Len(t, config.EllipticCurves, 1)
+		require.Len(t, config.SupportedProtocols, 2)
+		require.True(t, config.InsecureSkipVerify)
+		require.Equal(t, "example.com", config.ServerName)
+	})
+
+	t.Run("ServerValidOptions", func(t *testing.T) {
+		config, err := buildServerConfig(
+			WithCertificates(cert),
+			WithClientAuth(RequireAndVerifyClientCert),
+			WithInsecureSkipVerifyHello(true),
+		)
+		require.NoError(t, err)
+
+		require.Len(t, config.Certificates, 1)
+		require.Equal(t, RequireAndVerifyClientCert, config.ClientAuth)
+		require.True(t, config.InsecureSkipVerifyHello)
+	})
+}
+
+// TestOptionImmutability verifies that modifying slices after passing them to options
+// does not affect the built config.
+func TestOptionImmutability(t *testing.T) {
+	cert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	t.Run("Certificates", func(t *testing.T) {
+		certs := []tls.Certificate{cert}
+		config, err := buildClientConfig(WithCertificates(certs...))
+		require.NoError(t, err)
+
+		_ = append(certs, cert)
+
+		require.Len(t, config.Certificates, 1)
+	})
+
+	t.Run("CipherSuites", func(t *testing.T) {
+		suites := []CipherSuiteID{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
+		config, err := buildClientConfig(WithCipherSuites(suites...))
+		require.NoError(t, err)
+
+		suites[0] = TLS_PSK_WITH_AES_128_CCM_8
+
+		require.Equal(t, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, config.CipherSuites[0])
+	})
+
+	t.Run("SignatureSchemes", func(t *testing.T) {
+		schemes := []tls.SignatureScheme{tls.ECDSAWithP256AndSHA256}
+		config, err := buildClientConfig(WithSignatureSchemes(schemes...))
+		require.NoError(t, err)
+
+		schemes[0] = tls.ECDSAWithP384AndSHA384
+
+		require.Equal(t, tls.ECDSAWithP256AndSHA256, config.SignatureSchemes[0])
+	})
+
+	t.Run("SRTPProtectionProfiles", func(t *testing.T) {
+		profiles := []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80}
+		config, err := buildClientConfig(WithSRTPProtectionProfiles(profiles...))
+		require.NoError(t, err)
+
+		profiles[0] = SRTP_AES128_CM_HMAC_SHA1_32
+
+		require.Equal(t, SRTP_AES128_CM_HMAC_SHA1_80, config.SRTPProtectionProfiles[0])
+	})
+
+	t.Run("SupportedProtocols", func(t *testing.T) {
+		protocols := []string{"h2", "http/1.1"}
+		config, err := buildClientConfig(WithSupportedProtocols(protocols...))
+		require.NoError(t, err)
+
+		protocols[0] = "grpc"
+
+		require.Equal(t, "h2", config.SupportedProtocols[0])
+		require.Equal(t, "http/1.1", config.SupportedProtocols[1])
+	})
+
+	t.Run("EllipticCurves", func(t *testing.T) {
+		curves := []elliptic.Curve{elliptic.P256}
+		config, err := buildClientConfig(WithEllipticCurves(curves...))
+		require.NoError(t, err)
+
+		curves[0] = elliptic.P384
+
+		require.Equal(t, elliptic.P256, config.EllipticCurves[0])
+	})
+
+	t.Run("PSKIdentityHint", func(t *testing.T) {
+		hint := []byte("test-hint")
+		config, err := buildClientConfig(WithPSKIdentityHint(hint))
+		require.NoError(t, err)
+
+		hint[0] = 'X'
+
+		require.Equal(t, []byte("test-hint"), config.PSKIdentityHint)
+	})
+
+	t.Run("SRTPMasterKeyIdentifier", func(t *testing.T) {
+		identifier := []byte{0x01, 0x02, 0x03}
+		config, err := buildClientConfig(WithSRTPMasterKeyIdentifier(identifier))
+		require.NoError(t, err)
+
+		identifier[0] = 0xFF
+
+		require.Equal(t, []byte{0x01, 0x02, 0x03}, config.SRTPMasterKeyIdentifier)
+	})
+}

--- a/resume.go
+++ b/resume.go
@@ -8,10 +8,30 @@ import (
 )
 
 // Resume imports an already established dtls connection using a specific dtls state.
+//
+// Deprecated: Use ResumeWithOptions instead.
 func Resume(state *State, conn net.PacketConn, rAddr net.Addr, config *Config) (*Conn, error) {
 	if err := state.initCipherSuite(); err != nil {
 		return nil, err
 	}
 
+	if config == nil {
+		return nil, errNoConfigProvided
+	}
+
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+
 	return createConn(conn, rAddr, config, state.isClient, state)
+}
+
+// ResumeWithOptions imports an already established dtls connection using a specific dtls state.
+func ResumeWithOptions(state *State, conn net.PacketConn, rAddr net.Addr, opts ...Option) (*Conn, error) {
+	config, err := buildConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return Resume(state, conn, rAddr, config)
 }


### PR DESCRIPTION
#### Description
(not ready for review, I'll double review this when i wake up).
This introduces options patterns to DTLS. it's a bit tricky because dtls options are a bit complex:
1. Like ICE we apply the defaults first, then we do validations in the options calls.
2. Like MDNS we have client and servers options, and overlapping options between the two.
3. like transport we're introducing `WithOptions` helpers, and in the next major release we're going to depreciate this suffix, and change the current constructors to options first.

Updated all examples and the e2e test.

resolves: #765