### PR TITLE
DTLS 1.3: Add flight 3

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -118,6 +118,16 @@ var (
 	//nolint:err113
 	errInvalidServerHello = &FatalError{Err: errors.New("invalid ServerHello")}
 	//nolint:err113
+	errUnexpectedSecondHelloRetryRequest = &FatalError{
+		Err: errors.New("server sent a second HelloRetryRequest"),
+	}
+	//nolint:err113
+	errServerKeyShareMissing = &FatalError{Err: errors.New("ServerHello did not contain a key_share entry")}
+	//nolint:err113
+	errServerKeyShareUnknownGroup = &FatalError{
+		Err: errors.New("ServerHello key_share selected a group the client did not offer"),
+	}
+	//nolint:err113
 	errPSKAndIdentityMustBeSetForClient = &FatalError{
 		Err: errors.New("PSK and PSK Identity Hint must both be set for client"),
 	}

--- a/flighthandler_13.go
+++ b/flighthandler_13.go
@@ -35,6 +35,8 @@ func (f flightVal13) getFlightParser13() (flightParser13, error) {
 		return flight13_1Parse, nil
 	case flight13_2:
 		return flight13_2Parse, nil
+	case flight13_3:
+		return flight13_3Parse, nil
 
 	default:
 		return nil, errFlightUnimplemented13
@@ -49,6 +51,8 @@ func (f flightVal13) getFlightGenerator13() (gen flightGenerator13, retransmit b
 		return flight13_1Generate, true, nil
 	case flight13_2:
 		return flight13_2Generate, false, nil
+	case flight13_3:
+		return flight13_3Generate, true, nil
 	default:
 		return nil, false, errFlightUnimplemented13
 	}

--- a/flighthandlers_client_13.go
+++ b/flighthandlers_client_13.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"maps"
 	"slices"
 
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
@@ -429,9 +430,7 @@ func flight13_3Generate(
 		if flightCtx.state.localKeypairs == nil {
 			flightCtx.state.localKeypairs = make(map[elliptic.Curve]*elliptic.Keypair, len(newKeypairs))
 		}
-		for group, keypair := range newKeypairs {
-			flightCtx.state.localKeypairs[group] = keypair
-		}
+		maps.Copy(flightCtx.state.localKeypairs, newKeypairs)
 	}
 	extensions = append(extensions, &extension.KeyShare{
 		ClientShares: flightCtx.state.localKeyEntries,

--- a/flighthandlers_client_13.go
+++ b/flighthandlers_client_13.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
@@ -144,13 +146,92 @@ func flight13_1Parse(
 	return flight13_3, nil, nil
 }
 
-//nolint:unused
+//nolint:cyclop
 func flight13_3Parse(
-	ctx context.Context,
-	conn flightConn,
+	_ context.Context,
+	_ flightConn,
 	flightCtx *handshakeContext13,
 ) (flightVal13, *alert.Alert, error) {
-	return 0, nil, errFlightUnimplemented13
+	seq, msgs, ok := flightCtx.cache.fullPullMap(flightCtx.state.handshakeRecvSequence, flightCtx.state.cipherSuite,
+		handshakeCachePullRule{handshake.TypeServerHello, flightCtx.cfg.initialEpoch, false, false},
+	)
+	if !ok {
+		return 0, nil, nil
+	}
+
+	serverHello, ok := msgs[handshake.TypeServerHello].(*handshake.MessageServerHello)
+	if !ok {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
+	}
+
+	if isHelloRetryRequest(serverHello) {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage},
+			errUnexpectedSecondHelloRetryRequest
+	}
+
+	if !serverHello.Version.Equal(protocol.Version1_2) {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, errUnsupportedProtocolVersion
+	}
+
+	versions, seenSupportedVersions, err := serverHelloSelectedVersions(serverHello.Extensions)
+	if err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, errInvalidServerHello
+	}
+	if !seenSupportedVersions || !versions[0].Equal(protocol.Version1_3) {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, errUnsupportedProtocolVersion
+	}
+	flightCtx.state.remoteVersions = versions
+	flightCtx.state.localVersion = protocol.Version1_3
+
+	if serverHello.CipherSuiteID == nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, errInvalidServerHello
+	}
+	remoteCipherSuite := cipherSuiteForID(CipherSuiteID(*serverHello.CipherSuiteID), flightCtx.cfg.customCipherSuites)
+	if remoteCipherSuite == nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
+	}
+	if !cipherSuiteIDSupportsVersion(remoteCipherSuite.ID(), protocol.Version1_3) {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errInvalidCipherSuite
+	}
+	selectedCipherSuite, found := findMatchingCipherSuite(
+		[]CipherSuite{remoteCipherSuite}, flightCtx.cfg.localCipherSuites,
+	)
+	if !found {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errInvalidCipherSuite
+	}
+	flightCtx.state.cipherSuite = selectedCipherSuite
+	flightCtx.state.remoteRandom = serverHello.Random
+	flightCtx.cfg.log.Tracef("[handshake13] use cipher suite: %s", selectedCipherSuite.String())
+
+	var serverShare *extension.KeyShareEntry
+	for _, ext := range serverHello.Extensions {
+		keyShare, isKeyShare := ext.(*extension.KeyShare)
+		if isKeyShare && keyShare.ServerShare != nil {
+			serverShare = keyShare.ServerShare
+
+			break
+		}
+	}
+	if serverShare == nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, errServerKeyShareMissing
+	}
+
+	localKeypair, ok := flightCtx.state.localKeypairs[serverShare.Group]
+	if !ok || localKeypair == nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, errServerKeyShareUnknownGroup
+	}
+
+	preMasterSecret, err := prf.PreMasterSecret(serverShare.KeyExchange, localKeypair.PrivateKey, serverShare.Group)
+	if err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
+	flightCtx.state.preMasterSecret = preMasterSecret
+	flightCtx.state.namedCurve = serverShare.Group
+	flightCtx.state.remoteKeyEntries = &[]extension.KeyShareEntry{*serverShare}
+
+	flightCtx.state.handshakeRecvSequence = seq
+
+	return flight13_5, nil, nil
 }
 
 //nolint:cyclop
@@ -273,6 +354,131 @@ func flight13_1Generate(
 
 	if cfg.clientHelloMessageHook != nil {
 		content = handshake.Handshake{Message: cfg.clientHelloMessageHook(*clientHello)}
+	} else {
+		content = handshake.Handshake{Message: clientHello}
+	}
+
+	return []*packet{
+		{
+			record: &recordlayer.RecordLayer{
+				Header: recordlayer.Header{
+					Version: protocol.Version1_2,
+				},
+				Content: &content,
+			},
+		},
+	}, nil, nil
+}
+
+// nolint:cyclop
+func flight13_3Generate(
+	_ flightConn,
+	flightCtx *handshakeContext13,
+) ([]*packet, *alert.Alert, error) {
+	extensions := []extension.Extension{}
+
+	if flightCtx.cfg.extendedMasterSecret == RequestExtendedMasterSecret ||
+		flightCtx.cfg.extendedMasterSecret == RequireExtendedMasterSecret {
+		extensions = append(extensions, &extension.UseExtendedMasterSecret{
+			Supported: true,
+		})
+	}
+
+	extensions = append(extensions, &extension.RenegotiationInfo{
+		RenegotiatedConnection: 0,
+	})
+
+	if flightCtx.state.namedCurve != 0 {
+		extensions = append(extensions, []extension.Extension{
+			&extension.SupportedEllipticCurves{
+				EllipticCurves: flightCtx.cfg.ellipticCurves,
+			},
+			&extension.SupportedPointFormats{
+				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
+			},
+		}...)
+	}
+
+	if len(flightCtx.cfg.supportedProtocols) > 0 {
+		extensions = append(extensions, &extension.ALPN{ProtocolNameList: flightCtx.cfg.supportedProtocols})
+	}
+
+	var localGroups []elliptic.Curve
+	var newEntries []extension.KeyShareEntry
+	newKeypairs := map[elliptic.Curve]*elliptic.Keypair{}
+	if flightCtx.state.remoteKeyEntries != nil {
+		for _, entry := range flightCtx.state.localKeyEntries {
+			localGroups = append(localGroups, entry.Group)
+		}
+
+		for _, entry := range *flightCtx.state.remoteKeyEntries {
+			if !slices.Contains(localGroups, entry.Group) && slices.Contains(flightCtx.cfg.ellipticCurves, entry.Group) {
+				keypair, err := elliptic.GenerateKeypair(entry.Group)
+				if err != nil {
+					return nil, nil, err
+				}
+				newEntries = append(newEntries, extension.KeyShareEntry{
+					Group: keypair.Curve, KeyExchange: keypair.PublicKey,
+				})
+				newKeypairs[keypair.Curve] = keypair
+			}
+		}
+	}
+	if len(newEntries) > 0 {
+		flightCtx.state.localKeyEntries = append(newEntries, flightCtx.state.localKeyEntries...)
+		if flightCtx.state.localKeypairs == nil {
+			flightCtx.state.localKeypairs = make(map[elliptic.Curve]*elliptic.Keypair, len(newKeypairs))
+		}
+		for group, keypair := range newKeypairs {
+			flightCtx.state.localKeypairs[group] = keypair
+		}
+	}
+	extensions = append(extensions, &extension.KeyShare{
+		ClientShares: flightCtx.state.localKeyEntries,
+	})
+
+	if !slices.Contains(flightCtx.state.remoteVersions, protocol.Version1_3) {
+		return nil, nil, errNoCommonProtocolVersion
+	}
+	extensions = append(extensions, &extension.SupportedVersions{
+		Versions: supportedVersionsRange(flightCtx.cfg.minVersion, flightCtx.cfg.maxVersion),
+	})
+
+	if len(flightCtx.cfg.localCertSignatureSchemes) > 0 {
+		extensions = append(extensions, &extension.SignatureAlgorithmsCert{
+			SignatureHashAlgorithms: flightCtx.cfg.localCertSignatureSchemes,
+		})
+	}
+
+	if len(flightCtx.cfg.serverName) > 0 {
+		extensions = append(extensions, &extension.ServerName{ServerName: flightCtx.cfg.serverName})
+	}
+
+	if len(flightCtx.cfg.localSRTPProtectionProfiles) > 0 {
+		extensions = append(extensions, &extension.UseSRTP{
+			ProtectionProfiles:  flightCtx.cfg.localSRTPProtectionProfiles,
+			MasterKeyIdentifier: flightCtx.cfg.localSRTPMasterKeyIdentifier,
+		})
+	}
+
+	if len(flightCtx.state.cookie) > 0 {
+		extensions = append(extensions, &extension.CookieExt{Cookie: flightCtx.state.cookie})
+	}
+
+	clientHello := &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		SessionID:          flightCtx.state.SessionID,
+		Cookie:             []byte{},
+		Random:             flightCtx.state.localRandom,
+		CipherSuiteIDs:     cipherSuiteIDs(flightCtx.cfg.localCipherSuites),
+		CompressionMethods: defaultCompressionMethods(),
+		Extensions:         extensions,
+	}
+
+	var content handshake.Handshake
+
+	if flightCtx.cfg.clientHelloMessageHook != nil {
+		content = handshake.Handshake{Message: flightCtx.cfg.clientHelloMessageHook(*clientHello)}
 	} else {
 		content = handshake.Handshake{Message: clientHello}
 	}

--- a/flighthandlers_client_13_test.go
+++ b/flighthandlers_client_13_test.go
@@ -363,3 +363,375 @@ func TestPickVersionFromServerResponseRejectsServerHelloWithClientHelloSupported
 	assert.False(t, ok)
 	assert.Equal(t, protocol.Version{}, conn.state.localVersion)
 }
+
+func TestFlight13_3GenerateRejectsWithoutCommonVersion(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	require.NoError(t, state.localRandom.Populate())
+
+	pkts, dtlsAlert, err := flight13_3Generate(nil, &handshakeContext13{
+		state: state,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errNoCommonProtocolVersion)
+	require.Nil(t, dtlsAlert)
+	require.Nil(t, pkts)
+}
+
+func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{
+		cookie:         []byte{0x01, 0x02, 0x03, 0x04},
+		remoteVersions: []protocol.Version{protocol.Version1_3},
+	}
+	require.NoError(t, state.localRandom.Populate())
+
+	pkts, dtlsAlert, err := flight13_3Generate(nil, &handshakeContext13{
+		state: state,
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, pkts, 1)
+
+	hand, ok := pkts[0].record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	raw, err := hand.Marshal()
+	require.NoError(t, err)
+
+	var parsed handshake.Handshake
+	require.NoError(t, parsed.Unmarshal(raw))
+	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
+	require.True(t, ok)
+
+	var supportedVersions *extension.SupportedVersions
+	for _, ext := range clientHello.Extensions {
+		if sv, ok := ext.(*extension.SupportedVersions); ok {
+			supportedVersions = sv
+
+			break
+		}
+	}
+	require.NotNil(t, supportedVersions)
+	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
+	assert.False(t, supportedVersions.IsSelectedVersion())
+
+	var cookieExt *extension.CookieExt
+	for _, ext := range clientHello.Extensions {
+		if c, ok := ext.(*extension.CookieExt); ok {
+			cookieExt = c
+
+			break
+		}
+	}
+	require.NotNil(t, cookieExt)
+	assert.Equal(t, state.cookie, cookieExt.Cookie)
+}
+
+func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	selectedGroup := elliptic.P384
+
+	originalKeypair, err := elliptic.GenerateKeypair(elliptic.X25519)
+	require.NoError(t, err)
+	state := &State{
+		remoteVersions: []protocol.Version{protocol.Version1_3},
+		localKeyEntries: []extension.KeyShareEntry{
+			{Group: originalKeypair.Curve, KeyExchange: originalKeypair.PublicKey},
+		},
+		remoteKeyEntries: &[]extension.KeyShareEntry{{Group: selectedGroup}},
+	}
+	require.NoError(t, state.localRandom.Populate())
+
+	pkts, dtlsAlert, err := flight13_3Generate(nil, &handshakeContext13{
+		state: state,
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, pkts, 1)
+
+	hand, ok := pkts[0].record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	raw, err := hand.Marshal()
+	require.NoError(t, err)
+
+	var parsed handshake.Handshake
+	require.NoError(t, parsed.Unmarshal(raw))
+	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
+	require.True(t, ok)
+
+	var keyShare *extension.KeyShare
+	for _, ext := range clientHello.Extensions {
+		if ks, ok := ext.(*extension.KeyShare); ok {
+			keyShare = ks
+
+			break
+		}
+	}
+	require.NotNil(t, keyShare)
+	require.Len(t, keyShare.ClientShares, 2)
+	assert.Equal(t, selectedGroup, keyShare.ClientShares[0].Group)
+	assert.NotEmpty(t, keyShare.ClientShares[0].KeyExchange)
+	assert.Equal(t, elliptic.X25519, keyShare.ClientShares[1].Group)
+
+	selectedKeypair := state.localKeypairs[selectedGroup]
+	require.NotNil(t, selectedKeypair)
+	assert.Equal(t, keyShare.ClientShares[0].KeyExchange, selectedKeypair.PublicKey)
+}
+
+func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	selectedGroup := elliptic.X25519
+
+	keypair, err := elliptic.GenerateKeypair(selectedGroup)
+	require.NoError(t, err)
+	state := &State{
+		remoteVersions: []protocol.Version{protocol.Version1_3},
+		localKeyEntries: []extension.KeyShareEntry{
+			{Group: keypair.Curve, KeyExchange: keypair.PublicKey},
+		},
+		remoteKeyEntries: &[]extension.KeyShareEntry{{Group: selectedGroup}},
+	}
+	require.NoError(t, state.localRandom.Populate())
+
+	pkts, dtlsAlert, err := flight13_3Generate(nil, &handshakeContext13{
+		state: state,
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, pkts, 1)
+
+	hand, ok := pkts[0].record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	raw, err := hand.Marshal()
+	require.NoError(t, err)
+
+	var parsed handshake.Handshake
+	require.NoError(t, parsed.Unmarshal(raw))
+	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
+	require.True(t, ok)
+
+	var keyShare *extension.KeyShare
+	for _, ext := range clientHello.Extensions {
+		if ks, ok := ext.(*extension.KeyShare); ok {
+			keyShare = ks
+
+			break
+		}
+	}
+	require.NotNil(t, keyShare)
+	require.Len(t, keyShare.ClientShares, 1)
+	assert.Equal(t, selectedGroup, keyShare.ClientShares[0].Group)
+}
+
+func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+
+	group := cfg.ellipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+
+	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01, 0x02, 0x03}}
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_5, nextFlight)
+
+	assert.Equal(t, protocol.Version1_3, state.localVersion)
+	assert.Equal(t, []protocol.Version{protocol.Version1_3}, state.remoteVersions)
+	require.NotNil(t, state.cipherSuite)
+	assert.Equal(t, cfg.localCipherSuites[0].ID(), state.cipherSuite.ID())
+	assert.Equal(t, group, state.namedCurve)
+	assert.Equal(t, random.RandomBytes, state.remoteRandom.RandomBytes)
+	require.NotNil(t, state.remoteKeyEntries)
+	require.Len(t, *state.remoteKeyEntries, 1)
+	assert.Equal(t, group, (*state.remoteKeyEntries)[0].Group)
+
+	clientKeypair := state.localKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	expected, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	assert.Equal(t, expected, state.preMasterSecret)
+	assert.NotEmpty(t, state.preMasterSecret)
+}
+
+func TestFlight13_3ParseKeepsReadingWithoutServerHello(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: newHandshakeCache(),
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Zero(t, nextFlight)
+}
+
+func TestFlight13_3ParseRejectsSecondHelloRetryRequest(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+
+	rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errUnexpectedSecondHelloRetryRequest)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
+	assert.Equal(t, alert.UnexpectedMessage, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+}
+
+func TestFlight13_3ParseRejectsWrongLegacyVersion(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+
+	group := cfg.ellipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+
+	cipherSuiteID := uint16(cfg.localCipherSuites[0].ID())
+	serverHello := &handshake.MessageServerHello{
+		Version:           protocol.Version1_0,
+		Random:            handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}},
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: defaultCompressionMethods()[0],
+		Extensions: []extension.Extension{
+			&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+			&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+		},
+	}
+	rawServerHello, err := (&handshake.Handshake{Message: serverHello}).Marshal()
+	require.NoError(t, err)
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errUnsupportedProtocolVersion)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.ProtocolVersion, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+}
+
+func TestFlight13_3ParseRejectsMissingSupportedVersions(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+
+	group := cfg.ellipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+
+	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errUnsupportedProtocolVersion)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.ProtocolVersion, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+}
+
+func TestFlight13_3ParseRejectsMissingKeyShare(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+
+	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errServerKeyShareMissing)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+}
+
+func TestFlight13_3ParseRejectsUnofferedKeyShareGroup(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{}
+
+	group := cfg.ellipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+
+	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state: state,
+		cache: cache,
+		cfg:   cfg,
+	})
+
+	require.ErrorIs(t, err, errServerKeyShareUnknownGroup)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+}


### PR DESCRIPTION
#### Description

This PR aims to implement flight 3 (sending second CH and parsing SH) for DTLS 1.3.

Blocked by https://github.com/pion/dtls/pull/738 (copied code / commits)

#### Reference issue

Partly https://github.com/pion/dtls/issues/825