### PR TITLE
Fix not sending MasterKeyIdentifier in the use_srtp extension

### DIFF
--- a/flight3handler.go
+++ b/flight3handler.go
@@ -307,7 +307,8 @@ func flight3Generate(
 
 	if len(cfg.localSRTPProtectionProfiles) > 0 {
 		extensions = append(extensions, &extension.UseSRTP{
-			ProtectionProfiles: cfg.localSRTPProtectionProfiles,
+			ProtectionProfiles:  cfg.localSRTPProtectionProfiles,
+			MasterKeyIdentifier: cfg.localSRTPMasterKeyIdentifier,
 		})
 	}
 

--- a/pkg/protocol/extension/use_srtp.go
+++ b/pkg/protocol/extension/use_srtp.go
@@ -15,7 +15,7 @@ const (
 // UseSRTP allows a Client/Server to negotiate what SRTPProtectionProfiles
 // they both support
 //
-// https://tools.ietf.org/html/rfc8422
+// https://datatracker.ietf.org/doc/html/rfc5764
 type UseSRTP struct {
 	ProtectionProfiles  []SRTPProtectionProfile
 	MasterKeyIdentifier []byte


### PR DESCRIPTION
#### Description

Currently, the `use_srtp` extension is missing the configured `MasterKeyIdentifier` in flight 3 (the second ClientHello after a HelloVerifyRequest) 

Also updated the comment above `UseSRTP` to point to the correct RFC.