### PR TITLE
Fix panic unmarshaling ECDHE_PSK ServerKeyExchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Native [DTLS 1.2][rfc6347] implementation in the Go programming language.
 
 A long term goal is a professional security review, and maybe an inclusion in stdlib.
 
+> [!WARNING]
+> This branch is currently frozen from tagging while DTLS 1.3 work is underway.
+>
+> DTLS 1.3 and breaking changes should target the `main` branch. Bug fixes and DTLS 1.2 improvments should target the `dtls-1.2` branch, which can be used for tags until DTLS 1.3 is ready.
+
 ### RFCs
 #### Implemented
 - **RFC 6347**: [Datagram Transport Layer Security Version 1.2][rfc6347]

--- a/pkg/protocol/content.go
+++ b/pkg/protocol/content.go
@@ -23,3 +23,7 @@ type Content interface {
 	Marshal() ([]byte, error)
 	Unmarshal(data []byte) error
 }
+
+func IsDTLS13Ciphertext(ct ContentType) bool {
+	return ct > 31 && ct < 64
+}

--- a/pkg/protocol/handshake/message_server_key_exchange.go
+++ b/pkg/protocol/handshake/message_server_key_exchange.go
@@ -96,6 +96,10 @@ func (m *MessageServerKeyExchange) Unmarshal(data []byte) error { //nolint:cyclo
 		return errLengthMismatch
 	}
 
+	if len(data) == 0 {
+		return errBufferTooSmall
+	}
+
 	if _, ok := elliptic.CurveTypes()[elliptic.CurveType(data[0])]; ok {
 		m.EllipticCurveType = elliptic.CurveType(data[0])
 	} else {

--- a/pkg/protocol/handshake/message_server_key_exchange_test.go
+++ b/pkg/protocol/handshake/message_server_key_exchange_test.go
@@ -71,3 +71,118 @@ func TestHandshakeMessageServerKeyExchange(t *testing.T) {
 		test(rawServerKeyExchange, parsedServerKeyExchange)
 	})
 }
+
+func TestHandshakeMessageServerKeyExchangeUnmarshalErrors(t *testing.T) {
+	for _, test := range []struct {
+		name                 string
+		keyExchangeAlgorithm types.KeyExchangeAlgorithm
+		data                 []byte
+		expectedErr          error
+	}{
+		{
+			name:                 "BufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x00},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			name:                 "CipherSuiteUnset",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmNone,
+			data:                 []byte{0x00, 0x00},
+			expectedErr:          errCipherSuiteUnset,
+		},
+		{
+			// PSK-only: a non-empty body remains after the identity hint.
+			name:                 "PskLengthMismatch",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmPsk,
+			data:                 []byte{0x00, 0x00, 0xAA},
+			expectedErr:          errLengthMismatch,
+		},
+		{
+			// An algorithm that is neither PSK nor ECDHE is unsupported here.
+			name:                 "UnsupportedKeyExchangeAlgorithm",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithm(1),
+			data:                 []byte{0x00, 0x00},
+			expectedErr:          errLengthMismatch,
+		},
+		{
+			// ECDHE_PSK where the (empty) identity hint consumes the whole body,
+			// leaving nothing for the ECDHE parameters. Previously panicked.
+			name:                 "EcdhePskEmptyHintConsumesBody",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmPsk | types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x00, 0x00},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			name:                 "InvalidEllipticCurveType",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x99, 0x00},
+			expectedErr:          errInvalidEllipticCurveType,
+		},
+		{
+			// Valid curve type but not enough bytes for the named curve.
+			name:                 "NamedCurveBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			name:                 "InvalidNamedCurve",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0xFF, 0xFF},
+			expectedErr:          errInvalidNamedCurve,
+		},
+		{
+			// Valid curve type and named curve but missing the public key length.
+			name:                 "PublicKeyLengthBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			// Public key length exceeds the remaining body.
+			name:                 "PublicKeyBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x05},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			name:                 "InvalidHashAlgorithm",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x00, 0x07},
+			expectedErr:          errInvalidHashAlgorithm,
+		},
+		{
+			// Valid hash algorithm but missing the signature algorithm byte.
+			name:                 "SignatureAlgorithmBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x00, 0x04},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			name:                 "InvalidSignatureAlgorithm",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x00, 0x04, 0x02},
+			expectedErr:          errInvalidSignatureAlgorithm,
+		},
+		{
+			// Valid hash and signature algorithms but missing the signature length.
+			name:                 "SignatureLengthBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x00, 0x04, 0x03},
+			expectedErr:          errBufferTooSmall,
+		},
+		{
+			// Signature length exceeds the remaining body.
+			name:                 "SignatureBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x03, 0x00, 0x1d, 0x00, 0x04, 0x03, 0x00, 0x05},
+			expectedErr:          errBufferTooSmall,
+		},
+	} {
+		c := &MessageServerKeyExchange{
+			KeyExchangeAlgorithm: test.keyExchangeAlgorithm,
+		}
+		assert.ErrorIs(t, c.Unmarshal(test.data), test.expectedErr, test.name)
+	}
+}

--- a/pkg/protocol/recordlayer/errors.go
+++ b/pkg/protocol/recordlayer/errors.go
@@ -16,9 +16,22 @@ var (
 	ErrInvalidPacketLength = &protocol.TemporaryError{
 		Err: errors.New("packet length and declared length do not match"), //nolint:err113
 	}
-
-	errBufferTooSmall             = &protocol.TemporaryError{Err: errors.New("buffer is too small")}      //nolint:err113
-	errSequenceNumberOverflow     = &protocol.InternalError{Err: errors.New("sequence number overflow")}  //nolint:err113
-	errUnsupportedProtocolVersion = &protocol.FatalError{Err: errors.New("unsupported protocol version")} //nolint:err113
-	errInvalidContentType         = &protocol.TemporaryError{Err: errors.New("invalid content type")}     //nolint:err113
+	errBufferTooSmall = &protocol.TemporaryError{
+		Err: errors.New("buffer is too small"), //nolint:err113
+	}
+	errSequenceNumberOverflow = &protocol.InternalError{
+		Err: errors.New("sequence number overflow"), //nolint:err113
+	}
+	errUnsupportedProtocolVersion = &protocol.FatalError{
+		Err: errors.New("unsupported protocol version"), //nolint:err113
+	}
+	errInvalidContentType = &protocol.TemporaryError{
+		Err: errors.New("invalid content type"), //nolint:err113
+	}
+	errCIDTooBig = &protocol.InternalError{
+		Err: errors.New("connection ID size is too big"), //nolint:err113
+	}
+	errInvalidUnifiedHeaderFormat = &protocol.FatalError{
+		Err: errors.New("invalid dtls 1.3 unified header format"), //nolint:err113
+	}
 )

--- a/pkg/protocol/recordlayer/header_13.go
+++ b/pkg/protocol/recordlayer/header_13.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package recordlayer
+
+import (
+	"math"
+
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// UnifiedHeader implements the DTLS 1.3 Unified Header.
+// See RFC 9147 section 4. The DTLS Record Layer
+//
+// https://datatracker.ietf.org/doc/html/rfc9147#name-the-dtls-record-layer
+//
+//	 0 1 2 3 4 5 6 7
+//	+-+-+-+-+-+-+-+-+
+//	|0|0|1|C|S|L|E E|
+//	+-+-+-+-+-+-+-+-+
+//	| Connection ID |   Legend:
+//	| (if any,      |
+//	/  length as    /   C   - Connection ID (CID) present
+//	|  negotiated)  |   S   - Sequence number length
+//	+-+-+-+-+-+-+-+-+   L   - Length present
+//	|  8 or 16 bit  |   E   - Epoch
+//	|Sequence Number|
+//	+-+-+-+-+-+-+-+-+
+//	| 16 bit Length |
+//	| (if present)  |
+//	+-+-+-+-+-+-+-+-+
+type UnifiedHeader struct {
+	ConnectionID   []byte // size of array should be expected CID length
+	SequenceNumber uint16
+	SeqBit         bool
+	Length         uint16
+	LengthBit      bool
+	EpochLow       uint8
+}
+
+const (
+	UnifiedHeaderFixedBits = 0b00100000
+	UnifiedHeaderCIDBit    = 0b00010000
+	UnifiedHeaderSeqBit    = 0b00001000
+	UnifiedHeaderLengthBit = 0b00000100
+	TwoLowBitsMask         = 0b11
+)
+
+// Marshal encodes a DTLS 1.3 Unified Header to binary.
+func (u *UnifiedHeader) Marshal() ([]byte, error) {
+	var contentType uint8
+	var head cryptobyte.Builder
+	contentType = UnifiedHeaderFixedBits
+
+	cidSz := len(u.ConnectionID)
+	if cidSz > 0 {
+		contentType |= UnifiedHeaderCIDBit
+		if cidSz > math.MaxUint8 {
+			return []byte{}, errCIDTooBig
+		}
+		head.AddBytes(u.ConnectionID)
+	}
+
+	if u.SeqBit {
+		contentType |= UnifiedHeaderSeqBit
+		head.AddUint16(u.SequenceNumber)
+	} else {
+		head.AddUint8(uint8(u.SequenceNumber)) //nolint:gosec
+	}
+
+	if u.LengthBit {
+		contentType |= UnifiedHeaderLengthBit
+		head.AddUint16(u.Length)
+	}
+
+	contentType |= u.EpochLow & TwoLowBitsMask
+
+	headBytes, err := head.Bytes()
+	if err != nil {
+		return []byte{}, err
+	}
+	out := make([]byte, 1+len(headBytes))
+	out[0] = contentType
+	copy(out[1:], headBytes)
+
+	return out, nil
+}
+
+// Unmarshal populates a DTLS 1.3 Unified Header from binary.
+func (u *UnifiedHeader) Unmarshal(data []byte) error {
+	str := cryptobyte.String(data)
+
+	var ct uint8
+	if !str.ReadUint8(&ct) || !protocol.IsDTLS13Ciphertext(protocol.ContentType(ct)) {
+		return errInvalidContentType
+	}
+
+	if ct&UnifiedHeaderCIDBit != 0 {
+		size := len(u.ConnectionID)
+		if !str.ReadBytes(&u.ConnectionID, size) {
+			return errInvalidUnifiedHeaderFormat
+		}
+	} else {
+		u.ConnectionID = []byte{}
+	}
+
+	if ct&UnifiedHeaderSeqBit != 0 {
+		var seq uint16
+		if !str.ReadUint16(&seq) {
+			return errInvalidUnifiedHeaderFormat
+		}
+		u.SequenceNumber = seq
+		u.SeqBit = true
+	} else {
+		var seq uint8
+		if !str.ReadUint8(&seq) {
+			return errInvalidUnifiedHeaderFormat
+		}
+		u.SequenceNumber = uint16(seq)
+	}
+
+	u.EpochLow = ct & TwoLowBitsMask
+
+	if ct&UnifiedHeaderLengthBit != 0 {
+		var length uint16
+		if !str.ReadUint16(&length) {
+			return errInvalidUnifiedHeaderFormat
+		}
+		u.Length = length
+		u.LengthBit = true
+	} else {
+		u.Length = 0
+	}
+
+	return nil
+}
+
+func (u *UnifiedHeader) Size() int {
+	var size int
+	size += 1
+	size += len(u.ConnectionID)
+	if u.SequenceNumber > math.MaxUint8 {
+		size += 2
+	} else {
+		size += 1
+	}
+	if u.Length > 0 {
+		size += 2
+	}
+
+	return size
+}

--- a/pkg/protocol/recordlayer/header_13_test.go
+++ b/pkg/protocol/recordlayer/header_13_test.go
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package recordlayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnifiedHeader(t *testing.T) {
+	uh := UnifiedHeader{SequenceNumber: 0xaabb, SeqBit: true, Length: 42, LengthBit: true, EpochLow: 15}
+
+	raw, err := uh.Marshal()
+	assert.NoError(t, err)
+
+	expect := []byte{
+		0x2f,       // 0b00101111
+		0xaa, 0xbb, // Sequence number
+		0x00, 0x2a, // length
+	}
+	assert.Equal(t, expect, raw)
+
+	newUh := UnifiedHeader{}
+	err = newUh.Unmarshal(expect)
+
+	assert.NoError(t, err)
+	assert.Empty(t, newUh.ConnectionID)
+	assert.Equal(t, uh.SequenceNumber, newUh.SequenceNumber)
+	assert.True(t, newUh.SeqBit)
+	assert.Equal(t, uh.Length, newUh.Length)
+	assert.True(t, newUh.LengthBit)
+	assert.Equal(t, uh.EpochLow&0b11, newUh.EpochLow)
+}
+
+func TestUnifiedHeader_Minimal(t *testing.T) {
+	uh := UnifiedHeader{SequenceNumber: 0x42}
+
+	raw, err := uh.Marshal()
+	assert.NoError(t, err)
+
+	expect := []byte{
+		0x20, // 0b00100000
+		0x42, // Sequence number
+	}
+	assert.Equal(t, expect, raw)
+
+	newUh := UnifiedHeader{}
+	err = newUh.Unmarshal(expect)
+
+	assert.NoError(t, err)
+	assert.Empty(t, newUh.ConnectionID)
+	assert.Equal(t, uh.SequenceNumber, newUh.SequenceNumber)
+	assert.False(t, newUh.SeqBit)
+	assert.Equal(t, uh.Length, newUh.Length)
+	assert.False(t, newUh.LengthBit)
+	assert.Equal(t, uint8(0b00), newUh.EpochLow)
+}
+
+func TestUnifiedHeader_CID(t *testing.T) {
+	CID := []byte{0x1, 0x2, 0x3, 0x4}
+	uh := UnifiedHeader{ConnectionID: CID, SequenceNumber: 0xaa}
+
+	raw, err := uh.Marshal()
+	assert.NoError(t, err)
+
+	expect := []byte{
+		0x30,      // 0b00110000
+		0x01, 0x2, // CID
+		0x03, 0x4, // CID
+		0xaa, // Seq no
+	}
+	assert.Equal(t, expect, raw)
+
+	newUh := UnifiedHeader{ConnectionID: make([]byte, len(CID))}
+	err = newUh.Unmarshal(expect)
+
+	assert.NoError(t, err)
+	assert.Equal(t, uh.ConnectionID, newUh.ConnectionID)
+	assert.Equal(t, uh.SequenceNumber, newUh.SequenceNumber)
+	assert.False(t, newUh.SeqBit)
+	assert.Equal(t, uh.Length, newUh.Length)
+	assert.False(t, newUh.LengthBit)
+	assert.Equal(t, uint8(0b00), newUh.EpochLow)
+}
+
+func FuzzUnifiedHeaderUnmarshal(f *testing.F) {
+	testcases := [][]byte{
+		{
+			0x2f,       // 0b00101111
+			0xaa, 0xbb, // Sequence number
+			0x00, 0x2a, // length
+		},
+		{
+			0x20, // 0b00100000
+			0x42, // Sequence number
+		},
+		{
+			0x30,      // 0b00110000
+			0x01, 0x2, // CID
+			0x03, 0x4, // CID
+			0xaa, // Seq no
+		},
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		uh := UnifiedHeader{}
+		err := uh.Unmarshal(data)
+		if err != nil {
+			return
+		}
+		content := data[0]
+		assert.Less(t, int(content), 64)
+		assert.Greater(t, int(content), 31)
+		parsedLength := len(uh.ConnectionID)
+		assert.Zero(t, parsedLength)
+		assert.LessOrEqual(t, uh.EpochLow, uint8(0b000000011))
+	})
+}
+
+func FuzzUnifiedHeaderCIDUnmarshal(f *testing.F) {
+	testcases := [][]byte{
+		{
+			0x2f,       // 0b00101111
+			0xaa, 0xbb, // Sequence number
+			0x00, 0x2a, // length
+		},
+		{
+			0x20, // 0b00100000
+			0x42, // Sequence number
+		},
+		{
+			0x30,      // 0b00110000
+			0x01, 0x2, // CID
+			0x03, 0x4, // CID
+			0xaa, // Seq no
+		},
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cidLength := 32
+		uh := UnifiedHeader{ConnectionID: make([]byte, cidLength)}
+		err := uh.Unmarshal(data)
+		if err != nil {
+			return
+		}
+		content := data[0]
+		assert.Less(t, int(content), 64)
+		assert.Greater(t, int(content), 31)
+		if (content & UnifiedHeaderCIDBit) != 0 {
+			parsedLength := len(uh.ConnectionID)
+			assert.Equal(t, cidLength, parsedLength)
+		}
+		assert.LessOrEqual(t, uh.EpochLow, uint8(0b000000011))
+	})
+}


### PR DESCRIPTION
Missing bounds check a invalid ServerKeyExchange message could cause crash.

Reported by Karolina GORNA