### PR TITLE
Restore Firefox compatibility

### DIFF
--- a/pkg/protocol/handshake/message_certificate_request.go
+++ b/pkg/protocol/handshake/message_certificate_request.go
@@ -109,9 +109,8 @@ func (m *MessageCertificateRequest) Unmarshal(data []byte) error { //nolint:cycl
 
 		scheme := binary.BigEndian.Uint16(data[offset+i : offset+i+2])
 		var alg signaturehash.Algorithm
-		err := alg.Unmarshal(tls.SignatureScheme(scheme))
-		if err != nil {
-			return errInvalidSignHashAlgorithm
+		if err := alg.Unmarshal(tls.SignatureScheme(scheme)); err != nil {
+			continue // skip unrecognized algorithms rather than failing the handshake
 		}
 		m.SignatureHashAlgorithms = append(m.SignatureHashAlgorithms, alg)
 	}

--- a/pkg/protocol/handshake/message_certificate_request_test.go
+++ b/pkg/protocol/handshake/message_certificate_request_test.go
@@ -89,6 +89,30 @@ func TestHandshakeMessageCertificateRequest(t *testing.T) {
 	}
 }
 
+// verify unrecognized signature algorithm pairs in a CertificateRequest are silently
+// skipped rather than causing a handshake failure.
+func TestHandshakeMessageCertificateRequest_SkipsUnknownAlgorithms(t *testing.T) {
+	raw := []byte{
+		0x02,       // cert types length: 2
+		0x01, 0x40, // RSASign, ECDSASign
+		0x00, 0x0C, // sig algs length: 12 bytes (6 pairs)
+		0x04, 0x03, // SHA256+ECDSA  (valid)
+		0x04, 0x01, // SHA256+RSA    (valid)
+		0x04, 0x02, // SHA256+DSA    (unknown, skip) — Firefox 0x0402
+		0x05, 0x02, // SHA384+DSA    (unknown, skip) — Firefox 0x0502
+		0x06, 0x02, // SHA512+DSA    (unknown, skip) — Firefox 0x0602
+		0x02, 0x02, // SHA1+DSA      (unknown, skip) — Firefox 0x0202
+		0x00, 0x00, // CAs length: 0
+	}
+
+	c := &MessageCertificateRequest{}
+	assert.NoError(t, c.Unmarshal(raw))
+	assert.Equal(t, []signaturehash.Algorithm{
+		{Hash: hash.SHA256, Signature: signature.ECDSA},
+		{Hash: hash.SHA256, Signature: signature.RSA},
+	}, c.SignatureHashAlgorithms)
+}
+
 func TestHandshakeMessageCertificateRequest_CertificateTypesTooLong(t *testing.T) {
 	c := &MessageCertificateRequest{
 		CertificateTypes: make([]clientcertificate.Type, 256),


### PR DESCRIPTION
#### Description

Patch #801 silently changed the way this library reacts to unknown signature algorithms - they were silently skipped before, now they cause a fatal error. This broke compatibiliy with remote peers that are advertising unhandled algorithms (like SHA256+DSA), and going all way to the top prevents Firefox from interacting with pion/webrtc.

This patch fixes the issue by restoring the old behavior of skipping unknown signature algorithms.

#### Reference issue

https://github.com/bluenviron/mediamtx/issues/5838
