### PR TITLE
Implement DTLS 1.3 handshake transcript

### DIFF
--- a/handshake_transcript_13.go
+++ b/handshake_transcript_13.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"crypto/sha256"
+	"errors"
+	"hash"
+
+	"github.com/pion/dtls/v3/internal/util"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+)
+
+const tlsHandshakeHeaderLength13 = 4
+
+var (
+	errInvalidHandshakeTranscriptMessage = &protocol.InternalError{
+		Err: errors.New("invalid DTLS 1.3 handshake transcript message"), //nolint:err113
+	}
+	errHandshakeTranscriptHashNotSelected = &protocol.InternalError{
+		Err: errors.New("DTLS 1.3 handshake transcript hash is not selected"), //nolint:err113
+	}
+	errHandshakeTranscriptHashAlreadySelected = &protocol.InternalError{
+		Err: errors.New("DTLS 1.3 handshake transcript hash is already selected"), //nolint:err113
+	}
+	errHandshakeTranscriptMessageChanged = &protocol.InternalError{
+		Err: errors.New("DTLS 1.3 handshake transcript message changed during retransmission"), //nolint:err113
+	}
+	errHandshakeTranscriptHelloRetryRequestInvalid = &protocol.InternalError{
+		Err: errors.New("invalid DTLS 1.3 HelloRetryRequest transcript transition"), //nolint:err113
+	}
+)
+
+type transcriptSender13 uint8
+
+const (
+	transcriptClient13 transcriptSender13 = iota
+	transcriptServer13
+)
+
+type transcriptMessageID13 struct {
+	sender transcriptSender13
+	seq    uint16
+}
+
+type seenTranscriptMessage13 struct {
+	length      int
+	fingerprint [sha256.Size]byte
+}
+
+type transcriptMessage13 struct {
+	id  transcriptMessageID13
+	typ handshake.Type
+}
+
+type handshakeTranscript13 struct {
+	newHash func() hash.Hash
+	h       hash.Hash
+
+	pending    [][]byte
+	transcript []byte
+	seen       map[transcriptMessageID13]seenTranscriptMessage13
+	order      []transcriptMessage13
+
+	helloRetryApplied bool
+}
+
+func newHandshakeTranscript13() *handshakeTranscript13 {
+	return &handshakeTranscript13{
+		seen: make(map[transcriptMessageID13]seenTranscriptMessage13),
+	}
+}
+
+func canonicalHandshake13(raw []byte) ([]byte, error) {
+	if len(raw) < handshake.HeaderLength {
+		return nil, errBufferTooSmall
+	}
+
+	var header handshake.Header
+	if err := header.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+
+	if header.FragmentOffset != 0 ||
+		header.FragmentLength != header.Length ||
+		len(raw) != handshake.HeaderLength+int(header.Length) {
+		return nil, errInvalidHandshakeTranscriptMessage
+	}
+
+	out := make([]byte, tlsHandshakeHeaderLength13+int(header.Length))
+	copy(out[:tlsHandshakeHeaderLength13], raw[:tlsHandshakeHeaderLength13])
+	copy(out[tlsHandshakeHeaderLength13:], raw[handshake.HeaderLength:])
+
+	return out, nil
+}
+
+func (t *handshakeTranscript13) selectHash(newHash func() hash.Hash) error {
+	if newHash == nil {
+		return errHandshakeTranscriptHashNotSelected
+	}
+	if t.h != nil {
+		return errHandshakeTranscriptHashAlreadySelected
+	}
+
+	h := newHash()
+	if h == nil {
+		return errHandshakeTranscriptHashNotSelected
+	}
+
+	for _, message := range t.pending {
+		if _, err := h.Write(message); err != nil {
+			return err
+		}
+	}
+	t.newHash = newHash
+	t.h = h
+	t.pending = nil
+
+	return nil
+}
+
+func (t *handshakeTranscript13) appendCanonical(id transcriptMessageID13, message []byte) error {
+	if err := validateCanonicalHandshake13(message); err != nil {
+		return err
+	}
+
+	fingerprint := sha256.Sum256(message)
+	if seen, ok := t.seen[id]; ok {
+		if seen.length == len(message) && seen.fingerprint == fingerprint {
+			return nil
+		}
+
+		return errHandshakeTranscriptMessageChanged
+	}
+
+	messageCopy := append([]byte(nil), message...)
+	t.seen[id] = seenTranscriptMessage13{
+		length:      len(messageCopy),
+		fingerprint: fingerprint,
+	}
+	t.order = append(t.order, transcriptMessage13{
+		id:  id,
+		typ: handshake.Type(messageCopy[0]),
+	})
+	t.transcript = append(t.transcript, messageCopy...)
+
+	if t.h == nil {
+		t.pending = append(t.pending, messageCopy)
+
+		return nil
+	}
+
+	_, err := t.h.Write(messageCopy)
+
+	return err
+}
+
+func (t *handshakeTranscript13) sum() ([]byte, error) {
+	if t.h == nil {
+		return nil, errHandshakeTranscriptHashNotSelected
+	}
+
+	return t.h.Sum(nil), nil
+}
+
+func (t *handshakeTranscript13) sumWithSuffix(suffix []byte) ([]byte, error) {
+	if t.h == nil {
+		return nil, errHandshakeTranscriptHashNotSelected
+	}
+
+	h := t.newHash()
+	if h == nil {
+		return nil, errHandshakeTranscriptHashNotSelected
+	}
+	if _, err := h.Write(t.transcript); err != nil {
+		return nil, err
+	}
+	if _, err := h.Write(suffix); err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
+}
+
+func (t *handshakeTranscript13) applyHelloRetryRequest() error {
+	if t.h == nil {
+		return errHandshakeTranscriptHashNotSelected
+	}
+	if t.helloRetryApplied ||
+		len(t.order) != 1 ||
+		t.order[0].id.sender != transcriptClient13 ||
+		t.order[0].typ != handshake.TypeClientHello {
+		return errHandshakeTranscriptHelloRetryRequestInvalid
+	}
+
+	clientHelloDigest := t.h.Sum(nil)
+	messageHash := make([]byte, tlsHandshakeHeaderLength13+len(clientHelloDigest))
+	messageHash[0] = byte(handshake.TypeMessageHash)
+	util.PutBigEndianUint24(messageHash[1:], uint32(len(clientHelloDigest))) //nolint:gosec // G115
+	copy(messageHash[tlsHandshakeHeaderLength13:], clientHelloDigest)
+
+	h := t.newHash()
+	if h == nil {
+		return errHandshakeTranscriptHashNotSelected
+	}
+	if _, err := h.Write(messageHash); err != nil {
+		return err
+	}
+	t.h = h
+	t.transcript = append(t.transcript[:0], messageHash...)
+	t.helloRetryApplied = true
+
+	return nil
+}
+
+func validateCanonicalHandshake13(message []byte) error {
+	if len(message) < tlsHandshakeHeaderLength13 {
+		return errBufferTooSmall
+	}
+	if int(util.BigEndianUint24(message[1:])) != len(message)-tlsHandshakeHeaderLength13 {
+		return errInvalidHandshakeTranscriptMessage
+	}
+
+	return nil
+}

--- a/handshake_transcript_13_test.go
+++ b/handshake_transcript_13_test.go
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/pion/dtls/v3/internal/util"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanonicalHandshake13(t *testing.T) {
+	const bodyLen = 3
+
+	body := []byte{0xaa, 0xbb, 0xcc}
+	raw := makeRawHandshake13(t, handshake.Header{
+		Type:            handshake.TypeClientHello,
+		Length:          bodyLen,
+		MessageSequence: 7,
+		FragmentLength:  bodyLen,
+	}, body)
+
+	canonical, err := canonicalHandshake13(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{
+		byte(handshake.TypeClientHello), 0x00, 0x00, 0x03,
+		0xaa, 0xbb, 0xcc,
+	}, canonical)
+}
+
+func TestCanonicalHandshake13RejectsInvalidMessages(t *testing.T) {
+	const bodyLen = 2
+
+	body := []byte{0xaa, 0xbb}
+
+	for _, test := range []struct {
+		name string
+		raw  []byte
+		err  error
+	}{
+		{
+			name: "too small",
+			raw:  []byte{byte(handshake.TypeClientHello)},
+			err:  errBufferTooSmall,
+		},
+		{
+			name: "fragment offset",
+			raw: makeRawHandshake13(t, handshake.Header{
+				Type:            handshake.TypeClientHello,
+				Length:          bodyLen,
+				MessageSequence: 1,
+				FragmentOffset:  1,
+				FragmentLength:  bodyLen,
+			}, body),
+			err: errInvalidHandshakeTranscriptMessage,
+		},
+		{
+			name: "fragment length",
+			raw: makeRawHandshake13(t, handshake.Header{
+				Type:            handshake.TypeClientHello,
+				Length:          bodyLen,
+				MessageSequence: 1,
+				FragmentLength:  bodyLen - 1,
+			}, body),
+			err: errInvalidHandshakeTranscriptMessage,
+		},
+		{
+			name: "body length",
+			raw: makeRawHandshake13(t, handshake.Header{
+				Type:            handshake.TypeClientHello,
+				Length:          bodyLen + 1,
+				MessageSequence: 1,
+				FragmentLength:  bodyLen + 1,
+			}, body),
+			err: errInvalidHandshakeTranscriptMessage,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := canonicalHandshake13(test.raw)
+			assert.ErrorIs(t, err, test.err)
+		})
+	}
+}
+
+func TestHandshakeTranscript13DeferredHashSelection(t *testing.T) {
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01, 0x02})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x03, 0x04})
+	expectedClientHello := append([]byte(nil), clientHello...)
+
+	transcript := newHandshakeTranscript13()
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+	clientHello[len(clientHello)-1] = 0xff
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+
+	assert.NoError(t, transcript.selectHash(sha256.New))
+
+	sum, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.Equal(t, hashTranscript13(expectedClientHello, serverHello), sum)
+}
+
+func TestHandshakeTranscript13RejectsSumBeforeHashSelection(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+
+	_, err := transcript.sum()
+	assert.ErrorIs(t, err, errHandshakeTranscriptHashNotSelected)
+}
+
+func TestHandshakeTranscript13RejectsHashReselection(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+	assert.NoError(t, transcript.selectHash(sha256.New))
+
+	err := transcript.selectHash(sha256.New)
+	assert.ErrorIs(t, err, errHandshakeTranscriptHashAlreadySelected)
+}
+
+func TestHandshakeTranscript13DuplicateHandling(t *testing.T) {
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	changedClientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x02})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x03})
+
+	transcript := newHandshakeTranscript13()
+	assert.NoError(t, transcript.selectHash(sha256.New))
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+
+	err := transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, changedClientHello)
+	assert.ErrorIs(t, err, errHandshakeTranscriptMessageChanged)
+
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+
+	sum, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.Equal(t, hashTranscript13(clientHello, serverHello), sum)
+}
+
+func TestHandshakeTranscript13RejectsInvalidCanonicalMessage(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+
+	err := transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, []byte{
+		byte(handshake.TypeClientHello), 0x00, 0x00, 0x02, 0x01,
+	})
+	assert.ErrorIs(t, err, errInvalidHandshakeTranscriptMessage)
+}
+
+func TestHandshakeTranscript13HelloRetryRequest(t *testing.T) {
+	clientHello1 := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	helloRetryRequest := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+	clientHello2 := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x03})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x04})
+
+	transcript := newHandshakeTranscript13()
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello1))
+	assert.NoError(t, transcript.selectHash(sha256.New))
+	assert.NoError(t, transcript.applyHelloRetryRequest())
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, helloRetryRequest))
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13, seq: 1}, clientHello2))
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13, seq: 1}, serverHello))
+
+	clientHello1Hash := hashTranscript13(clientHello1)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
+	expected := hashTranscript13(messageHash, helloRetryRequest, clientHello2, serverHello)
+
+	sum, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, sum)
+	assert.Equal(t, "MessageHash", handshake.TypeMessageHash.String())
+}
+
+func TestHandshakeTranscript13HelloRetryRequestBinderFork(t *testing.T) {
+	clientHello1 := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	helloRetryRequest := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+	placeholderBinder := make([]byte, sha256.Size)
+	_, truncatedClientHello2 := pskClientHelloTranscript13(t, placeholderBinder)
+
+	transcript := newHandshakeTranscript13()
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello1))
+	assert.NoError(t, transcript.selectHash(sha256.New))
+	assert.NoError(t, transcript.applyHelloRetryRequest())
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, helloRetryRequest))
+
+	mainSumBefore, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.ErrorIs(t, validateCanonicalHandshake13(truncatedClientHello2), errInvalidHandshakeTranscriptMessage)
+
+	binderTranscriptHash, err := transcript.sumWithSuffix(truncatedClientHello2)
+	assert.NoError(t, err)
+
+	clientHello1Hash := hashTranscript13(clientHello1)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
+	expectedBinderTranscriptHash := hashTranscript13(messageHash, helloRetryRequest, truncatedClientHello2)
+	assert.Equal(t, expectedBinderTranscriptHash, binderTranscriptHash)
+
+	binderKey := []byte("binder key")
+	binder := hmacSHA25613(binderKey, binderTranscriptHash)
+	expectedBinder := hmacSHA25613(binderKey, expectedBinderTranscriptHash)
+	assert.Equal(t, expectedBinder, binder)
+
+	mainSumAfter, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.Equal(t, mainSumBefore, mainSumAfter)
+
+	clientHello2, truncatedClientHello2WithBinder := pskClientHelloTranscript13(t, binder)
+	assert.Equal(t, truncatedClientHello2, truncatedClientHello2WithBinder)
+	assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13, seq: 1}, clientHello2))
+
+	sum, err := transcript.sum()
+	assert.NoError(t, err)
+	assert.Equal(t, hashTranscript13(messageHash, helloRetryRequest, clientHello2), sum)
+}
+
+func TestHandshakeTranscript13HelloRetryRequestErrors(t *testing.T) {
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+
+	t.Run("hash not selected", func(t *testing.T) {
+		transcript := newHandshakeTranscript13()
+		assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+
+		err := transcript.applyHelloRetryRequest()
+		assert.ErrorIs(t, err, errHandshakeTranscriptHashNotSelected)
+	})
+
+	t.Run("not first client hello only", func(t *testing.T) {
+		transcript := newHandshakeTranscript13()
+		assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+		assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+		assert.NoError(t, transcript.selectHash(sha256.New))
+
+		err := transcript.applyHelloRetryRequest()
+		assert.ErrorIs(t, err, errHandshakeTranscriptHelloRetryRequestInvalid)
+	})
+
+	t.Run("server message", func(t *testing.T) {
+		transcript := newHandshakeTranscript13()
+		assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+		assert.NoError(t, transcript.selectHash(sha256.New))
+
+		err := transcript.applyHelloRetryRequest()
+		assert.ErrorIs(t, err, errHandshakeTranscriptHelloRetryRequestInvalid)
+	})
+
+	t.Run("already applied", func(t *testing.T) {
+		transcript := newHandshakeTranscript13()
+		assert.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+		assert.NoError(t, transcript.selectHash(sha256.New))
+		assert.NoError(t, transcript.applyHelloRetryRequest())
+
+		err := transcript.applyHelloRetryRequest()
+		assert.ErrorIs(t, err, errHandshakeTranscriptHelloRetryRequestInvalid)
+	})
+}
+
+func FuzzCanonicalHandshake13(f *testing.F) {
+	f.Add(makeRawHandshake13(f, handshake.Header{
+		Type:           handshake.TypeClientHello,
+		Length:         2,
+		FragmentLength: 2,
+	}, []byte{0x01, 0x02}))
+	f.Add([]byte{byte(handshake.TypeClientHello), 0x00, 0x00, 0x01})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		canonical, err := canonicalHandshake13(data)
+		if err != nil {
+			return
+		}
+		if !assert.GreaterOrEqual(t, len(canonical), tlsHandshakeHeaderLength13) {
+			return
+		}
+		assert.Equal(t, len(canonical)-tlsHandshakeHeaderLength13, int(util.BigEndianUint24(canonical[1:])))
+		assert.Equal(t, data[0], canonical[0])
+		assert.Equal(t, data[handshake.HeaderLength:], canonical[tlsHandshakeHeaderLength13:])
+	})
+}
+
+func makeRawHandshake13(tb testing.TB, header handshake.Header, body []byte) []byte {
+	tb.Helper()
+
+	rawHeader, err := header.Marshal()
+	assert.NoError(tb, err)
+
+	return append(rawHeader, body...)
+}
+
+func canonicalTranscriptHandshake13(typ handshake.Type, body []byte) []byte {
+	out := make([]byte, tlsHandshakeHeaderLength13+len(body))
+	out[0] = byte(typ)
+	util.PutBigEndianUint24(out[1:], uint32(len(body))) //nolint:gosec // G115
+	copy(out[tlsHandshakeHeaderLength13:], body)
+
+	return out
+}
+
+func hashTranscript13(messages ...[]byte) []byte {
+	hash := sha256.New()
+	for _, message := range messages {
+		_, _ = hash.Write(message)
+	}
+
+	return hash.Sum(nil)
+}
+
+func pskClientHelloTranscript13(tb testing.TB, binder []byte) ([]byte, []byte) {
+	tb.Helper()
+
+	msg := &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CipherSuiteIDs:     []uint16{0x1301},
+		CompressionMethods: []*protocol.CompressionMethod{{}},
+		Extensions: []extension.Extension{
+			&extension.PreSharedKey{
+				Identities: []extension.PskIdentity{
+					{
+						Identity:            []byte("psk-identity"),
+						ObfuscatedTicketAge: 0x01020304,
+					},
+				},
+				Binders: []extension.PskBinderEntry{binder},
+			},
+		},
+	}
+
+	body, err := msg.Marshal()
+	assert.NoError(tb, err)
+
+	full := canonicalTranscriptHandshake13(handshake.TypeClientHello, body)
+	truncatedLen := len(full) - (2 + 1 + len(binder))
+	assert.Greater(tb, truncatedLen, tlsHandshakeHeaderLength13)
+
+	return full, append([]byte(nil), full[:truncatedLen]...)
+}
+
+func hmacSHA25613(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(data)
+
+	return mac.Sum(nil)
+}

--- a/pkg/protocol/handshake/handshake.go
+++ b/pkg/protocol/handshake/handshake.go
@@ -27,6 +27,9 @@ const (
 	TypeCertificateVerify  Type = 15
 	TypeClientKeyExchange  Type = 16
 	TypeFinished           Type = 20
+
+	// TypeMessageHash is a synthetic TLS 1.3 transcript-only handshake type.
+	TypeMessageHash Type = 254
 )
 
 // String returns the string representation of this type.
@@ -54,6 +57,8 @@ func (t Type) String() string { //nolint:cyclop
 		return "ClientKeyExchange"
 	case TypeFinished:
 		return "Finished"
+	case TypeMessageHash:
+		return "MessageHash"
 	}
 
 	return ""


### PR DESCRIPTION
#### Description

This just implements the transcript hash and doesn't wire it [RFC 8446 section 4.4.1](https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.1).

I had this change and other for the longest time, but I was waiting for FSM to merge to actually wire, but I think we can just have it ready for review now, and have all the wiring and the handshake auth integration done after FSM PRs are merged. https://github.com/pion/dtls/pull/738

Part of https://github.com/pion/dtls/issues/826 refs #727 

