### PR TITLE
 DTLS 1.3 cipher-suite metadata and version-aware filtering/validation helpers

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -11,9 +11,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"hash"
+	"slices"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
@@ -22,6 +24,10 @@ type CipherSuiteID = ciphersuite.ID
 
 // Supported Cipher Suites.
 const (
+	// TLS 1.3.
+	TLS_AES_128_GCM_SHA256       CipherSuiteID = ciphersuite.TLS_AES_128_GCM_SHA256       // nolint: revive,staticcheck,lll
+	TLS_AES_256_GCM_SHA384       CipherSuiteID = ciphersuite.TLS_AES_256_GCM_SHA384       // nolint: revive,staticcheck,lll
+	TLS_CHACHA20_POLY1305_SHA256 CipherSuiteID = ciphersuite.TLS_CHACHA20_POLY1305_SHA256 // nolint: revive,staticcheck,lll
 
 	// nolint: godot
 	// AES-128-CCM
@@ -110,6 +116,9 @@ type CipherSuite interface {
 // VersionDTLS12 is the DTLS version in the same style as VersionTLSXX from crypto/tls.
 const VersionDTLS12 = 0xfefd
 
+// VersionDTLS13 is the DTLS version in the same style as VersionTLSXX from crypto/tls.
+const VersionDTLS13 = 0xfefc
+
 // CipherSuiteName provides the same functionality as tls.CipherSuiteName
 // that appeared first in Go 1.14.
 //
@@ -129,12 +138,12 @@ func toTLSCipherSuite(c CipherSuite) *tls.CipherSuite {
 	return &tls.CipherSuite{
 		ID:                uint16(c.ID()),
 		Name:              c.String(),
-		SupportedVersions: []uint16{VersionDTLS12},
+		SupportedVersions: cipherSuiteSupportedVersionIDs(c.ID()),
 		Insecure:          false,
 	}
 }
 
-// CipherSuites returns a list of cipher suites currently implemented by this
+// CipherSuites returns a list of cipher suites currently known by this
 // package, excluding those with security issues, which are returned by
 // InsecureCipherSuites.
 func CipherSuites() []*tls.CipherSuite {
@@ -160,6 +169,12 @@ func InsecureCipherSuites() []*tls.CipherSuite {
 // function.
 func cipherSuiteForID(id CipherSuiteID, customCiphers func() []CipherSuite) CipherSuite { //nolint:cyclop
 	switch id { //nolint:exhaustive
+	case TLS_AES_128_GCM_SHA256:
+		return ciphersuite.NewTLSAes128GcmSha256()
+	case TLS_AES_256_GCM_SHA384:
+		return ciphersuite.NewTLSAes256GcmSha384()
+	case TLS_CHACHA20_POLY1305_SHA256:
+		return ciphersuite.NewTLSChacha20Poly1305Sha256()
 	case TLS_ECDHE_ECDSA_WITH_AES_128_CCM:
 		return ciphersuite.NewTLSEcdheEcdsaWithAes128Ccm()
 	case TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8:
@@ -207,6 +222,15 @@ func cipherSuiteForID(id CipherSuiteID, customCiphers func() []CipherSuite) Ciph
 	return nil
 }
 
+// TLS 1.3 CipherSuites we support in order of preference.
+func defaultCipherSuites13() []CipherSuite {
+	return []CipherSuite{
+		ciphersuite.NewTLSAes128GcmSha256(),
+		ciphersuite.NewTLSAes256GcmSha384(),
+		ciphersuite.NewTLSChacha20Poly1305Sha256(),
+	}
+}
+
 // CipherSuites we support in order of preference.
 func defaultCipherSuites() []CipherSuite {
 	return []CipherSuite{
@@ -223,6 +247,9 @@ func defaultCipherSuites() []CipherSuite {
 
 func allCipherSuites() []CipherSuite {
 	return []CipherSuite{
+		ciphersuite.NewTLSAes128GcmSha256(),
+		ciphersuite.NewTLSAes256GcmSha384(),
+		ciphersuite.NewTLSChacha20Poly1305Sha256(),
 		ciphersuite.NewTLSEcdheEcdsaWithAes128Ccm(),
 		ciphersuite.NewTLSEcdheEcdsaWithAes128Ccm8(),
 		&ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256{},
@@ -250,11 +277,132 @@ func cipherSuiteIDs(cipherSuites []CipherSuite) []uint16 {
 	return rtrn
 }
 
+func defaultCipherSuitesForVersions(minVersion, maxVersion protocol.Version) []CipherSuite {
+	cipherSuites := []CipherSuite{}
+	for _, version := range supportedVersionsRange(minVersion, maxVersion) {
+		switch {
+		case version.Equal(protocol.Version1_3):
+			cipherSuites = append(cipherSuites, defaultCipherSuites13()...)
+		case version.Equal(protocol.Version1_2):
+			cipherSuites = append(cipherSuites, defaultCipherSuites()...)
+		}
+	}
+
+	return cipherSuites
+}
+
+func knownCipherSuiteSupportedVersions(id CipherSuiteID) ([]protocol.Version, bool) {
+	switch id { //nolint:exhaustive
+	case TLS_AES_128_GCM_SHA256,
+		TLS_AES_256_GCM_SHA384,
+		TLS_CHACHA20_POLY1305_SHA256:
+		return []protocol.Version{protocol.Version1_3}, true
+	case TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
+		TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
+		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		TLS_PSK_WITH_AES_128_CCM,
+		TLS_PSK_WITH_AES_128_CCM_8,
+		TLS_PSK_WITH_AES_256_CCM_8,
+		TLS_PSK_WITH_AES_128_GCM_SHA256,
+		TLS_PSK_WITH_AES_128_CBC_SHA256,
+		TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
+		TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		TLS_PSK_WITH_CHACHA20_POLY1305_SHA256:
+		return []protocol.Version{protocol.Version1_2}, true
+	default:
+		return nil, false
+	}
+}
+
+func cipherSuiteSupportedVersions(id CipherSuiteID) []protocol.Version {
+	if versions, ok := knownCipherSuiteSupportedVersions(id); ok {
+		return versions
+	}
+
+	return []protocol.Version{protocol.Version1_2}
+}
+
+func cipherSuiteSupportedVersionIDs(id CipherSuiteID) []uint16 {
+	versions := cipherSuiteSupportedVersions(id)
+	ids := make([]uint16, 0, len(versions))
+	for _, version := range versions {
+		ids = append(ids, protocolVersionID(version))
+	}
+
+	return ids
+}
+
+func protocolVersionID(version protocol.Version) uint16 {
+	return uint16(version.Major)<<8 | uint16(version.Minor)
+}
+
+func cipherSuiteIDSupportsVersion(id CipherSuiteID, version protocol.Version) bool {
+	return slices.ContainsFunc(cipherSuiteSupportedVersions(id), version.Equal)
+}
+
+func cipherSuiteIDSupportsVersions(id CipherSuiteID, minVersion, maxVersion protocol.Version) bool {
+	for _, version := range supportedVersionsRange(minVersion, maxVersion) {
+		if cipherSuiteIDSupportsVersion(id, version) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func filterCipherSuitesForVersion(cipherSuites []CipherSuite, version protocol.Version) []CipherSuite {
+	filtered := make([]CipherSuite, 0, len(cipherSuites))
+	for _, c := range cipherSuites {
+		if cipherSuiteIDSupportsVersion(c.ID(), version) {
+			filtered = append(filtered, c)
+		}
+	}
+
+	return filtered
+}
+
+func filterCipherSuitesForVersions(
+	cipherSuites []CipherSuite,
+	minVersion, maxVersion protocol.Version,
+) []CipherSuite {
+	filtered := make([]CipherSuite, 0, len(cipherSuites))
+	for _, c := range cipherSuites {
+		if cipherSuiteIDSupportsVersions(c.ID(), minVersion, maxVersion) {
+			filtered = append(filtered, c)
+		}
+	}
+
+	return filtered
+}
+
 //nolint:cyclop
 func parseCipherSuites(
 	userSelectedSuites []CipherSuiteID,
 	customCipherSuites func() []CipherSuite,
 	includeCertificateSuites, includePSKSuites bool,
+) ([]CipherSuite, error) {
+	return parseCipherSuitesForVersions(
+		userSelectedSuites,
+		customCipherSuites,
+		includeCertificateSuites,
+		includePSKSuites,
+		protocol.Version1_2,
+		protocol.Version1_2,
+	)
+}
+
+//nolint:cyclop
+func parseCipherSuitesForVersions(
+	userSelectedSuites []CipherSuiteID,
+	customCipherSuites func() []CipherSuite,
+	includeCertificateSuites, includePSKSuites bool,
+	minVersion, maxVersion protocol.Version,
 ) ([]CipherSuite, error) {
 	cipherSuitesForIDs := func(ids []CipherSuiteID) ([]CipherSuite, error) {
 		cipherSuites := []CipherSuite{}
@@ -280,7 +428,7 @@ func parseCipherSuites(
 			return nil, err
 		}
 	} else {
-		cipherSuites = defaultCipherSuites()
+		cipherSuites = defaultCipherSuitesForVersions(minVersion, maxVersion)
 	}
 
 	// Put CustomCipherSuites before ID selected suites
@@ -288,26 +436,31 @@ func parseCipherSuites(
 		cipherSuites = append(customCipherSuites(), cipherSuites...)
 	}
 
-	var foundCertificateSuite, foundPSKSuite, foundAnonymousSuite bool
-	for _, c := range cipherSuites {
+	cipherSuites = filterCipherSuitesForVersions(cipherSuites, minVersion, maxVersion)
+
+	var foundCertificateSuite, foundPSKSuite, foundAnonymousSuite, foundTLS13Suite bool
+	for _, cipher := range cipherSuites {
 		switch {
-		case includeCertificateSuites && c.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate:
+		case includeCertificateSuites && cipher.AuthenticationType() == CipherSuiteAuthenticationTypeCertificate:
 			foundCertificateSuite = true
-		case includePSKSuites && c.AuthenticationType() == CipherSuiteAuthenticationTypePreSharedKey:
+		case includePSKSuites && cipher.AuthenticationType() == CipherSuiteAuthenticationTypePreSharedKey:
 			foundPSKSuite = true
-		case c.AuthenticationType() == CipherSuiteAuthenticationTypeAnonymous:
+		case cipher.AuthenticationType() == CipherSuiteAuthenticationTypeAnonymous:
 			foundAnonymousSuite = true
+			if cipherSuiteIDSupportsVersion(cipher.ID(), protocol.Version1_3) {
+				foundTLS13Suite = true
+			}
 		default:
 			continue
 		}
-		cipherSuites[i] = c
+		cipherSuites[i] = cipher
 		i++
 	}
 
 	switch {
 	case includeCertificateSuites && !foundCertificateSuite && !foundAnonymousSuite:
 		return nil, errNoAvailableCertificateCipherSuite
-	case includePSKSuites && !foundPSKSuite:
+	case includePSKSuites && !foundPSKSuite && !foundTLS13Suite:
 		return nil, errNoAvailablePSKCipherSuite
 	case i == 0:
 		return nil, errNoAvailableCipherSuites

--- a/cipher_suite_test.go
+++ b/cipher_suite_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsnet "github.com/pion/dtls/v3/pkg/net"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/transport/v4/dpipe"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCipherSuiteName(t *testing.T) {
@@ -20,6 +22,9 @@ func TestCipherSuiteName(t *testing.T) {
 		suite    CipherSuiteID
 		expected string
 	}{
+		{TLS_AES_128_GCM_SHA256, "TLS_AES_128_GCM_SHA256"},
+		{TLS_AES_256_GCM_SHA384, "TLS_AES_256_GCM_SHA384"},
+		{TLS_CHACHA20_POLY1305_SHA256, "TLS_CHACHA20_POLY1305_SHA256"},
 		{TLS_ECDHE_ECDSA_WITH_AES_128_CCM, "TLS_ECDHE_ECDSA_WITH_AES_128_CCM"},
 		{TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"},
 		{TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"},
@@ -50,11 +55,148 @@ func TestCipherSuites(t *testing.T) {
 			cipher := theirs[i]
 			assert.Equal(t, cipher.ID, uint16(s.ID()))
 			assert.Equal(t, cipher.Name, s.String())
-			assert.Equal(t, 1, len(cipher.SupportedVersions), "Expected SupportedVersion to be 1")
-			assert.Equal(t, uint16(VersionDTLS12), cipher.SupportedVersions[0], "Expected SupportedVersion to match")
+			assert.Equal(t, cipherSuiteSupportedVersionIDs(s.ID()), cipher.SupportedVersions)
 			assert.False(t, cipher.Insecure, "Expected Insecure")
 		})
 	}
+}
+
+func TestCipherSuiteSupportedVersions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		suite    CipherSuiteID
+		expected []protocol.Version
+	}{
+		{
+			name:     "TLS 1.3",
+			suite:    TLS_AES_128_GCM_SHA256,
+			expected: []protocol.Version{protocol.Version1_3},
+		},
+		{
+			name:     "DTLS 1.2",
+			suite:    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			expected: []protocol.Version{protocol.Version1_2},
+		},
+		{
+			name:     "custom suites default to DTLS 1.2",
+			suite:    0xffff,
+			expected: []protocol.Version{protocol.Version1_2},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, cipherSuiteSupportedVersions(testCase.suite))
+		})
+	}
+}
+
+func TestParseCipherSuitesForVersions(t *testing.T) {
+	t.Run("default DTLS 1.2", func(t *testing.T) {
+		suites, err := parseCipherSuitesForVersions(
+			nil,
+			nil,
+			true,
+			false,
+			protocol.Version1_2,
+			protocol.Version1_2,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, suites)
+
+		for _, suite := range suites {
+			assert.True(t, cipherSuiteIDSupportsVersion(suite.ID(), protocol.Version1_2))
+			assert.False(t, cipherSuiteIDSupportsVersion(suite.ID(), protocol.Version1_3))
+		}
+	})
+
+	t.Run("default DTLS 1.3", func(t *testing.T) {
+		suites, err := parseCipherSuitesForVersions(
+			nil,
+			nil,
+			true,
+			false,
+			protocol.Version1_3,
+			protocol.Version1_3,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []uint16{
+			uint16(TLS_AES_128_GCM_SHA256),
+			uint16(TLS_AES_256_GCM_SHA384),
+			uint16(TLS_CHACHA20_POLY1305_SHA256),
+		}, cipherSuiteIDs(suites))
+	})
+
+	t.Run("default dual stack", func(t *testing.T) {
+		suites, err := parseCipherSuitesForVersions(
+			nil,
+			nil,
+			true,
+			false,
+			protocol.Version1_2,
+			protocol.Version1_3,
+		)
+		require.NoError(t, err)
+		require.Greater(t, len(suites), len(defaultCipherSuites13()))
+
+		assert.Equal(t, uint16(TLS_AES_128_GCM_SHA256), cipherSuiteIDs(suites)[0])
+		assert.Contains(t, cipherSuiteIDs(suites), uint16(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256))
+	})
+
+	t.Run("selected suites are filtered by version", func(t *testing.T) {
+		suites, err := parseCipherSuitesForVersions(
+			[]CipherSuiteID{
+				TLS_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			},
+			nil,
+			true,
+			false,
+			protocol.Version1_2,
+			protocol.Version1_2,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []uint16{uint16(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)}, cipherSuiteIDs(suites))
+	})
+
+	t.Run("selected suite must match version", func(t *testing.T) {
+		_, err := parseCipherSuitesForVersions(
+			[]CipherSuiteID{TLS_AES_128_GCM_SHA256},
+			nil,
+			true,
+			false,
+			protocol.Version1_2,
+			protocol.Version1_2,
+		)
+		require.ErrorIs(t, err, errNoAvailableCertificateCipherSuite)
+	})
+
+	t.Run("TLS 1.3 suites are authentication neutral", func(t *testing.T) {
+		suites, err := parseCipherSuitesForVersions(
+			[]CipherSuiteID{TLS_AES_128_GCM_SHA256},
+			nil,
+			false,
+			true,
+			protocol.Version1_3,
+			protocol.Version1_3,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []uint16{uint16(TLS_AES_128_GCM_SHA256)}, cipherSuiteIDs(suites))
+	})
+
+	t.Run("custom anonymous suites do not satisfy PSK configs", func(t *testing.T) {
+		_, err := parseCipherSuitesForVersions(
+			[]CipherSuiteID{},
+			func() []CipherSuite {
+				return []CipherSuite{&testCustomCipherSuite{authenticationType: CipherSuiteAuthenticationTypeAnonymous}}
+			},
+			false,
+			true,
+			protocol.Version1_2,
+			protocol.Version1_2,
+		)
+		require.ErrorIs(t, err, errNoAvailablePSKCipherSuite)
+	})
 }
 
 // CustomCipher that is just used to assert Custom IDs work.

--- a/config.go
+++ b/config.go
@@ -306,8 +306,10 @@ func validateConfig(config *Config) error { //nolint:cyclop
 		}
 	}
 
-	_, err := parseCipherSuites(
+	minVersion, maxVersion := normalizeProtocolVersionRange(config.minVersion, config.maxVersion)
+	_, err := parseCipherSuitesForVersions(
 		config.CipherSuites, config.CustomCipherSuites, config.includeCertificateSuites(), config.PSK != nil,
+		minVersion, maxVersion,
 	)
 
 	return err

--- a/conn.go
+++ b/conn.go
@@ -145,11 +145,15 @@ func createConn(
 		paddingLengthGenerator = func(uint) uint { return 0 }
 	}
 
-	cipherSuites, err := parseCipherSuites(
+	minVersion, maxVersion := normalizeProtocolVersionRange(config.minVersion, config.maxVersion)
+
+	cipherSuites, err := parseCipherSuitesForVersions(
 		config.CipherSuites,
 		config.CustomCipherSuites,
 		config.includeCertificateSuites(),
 		config.PSK != nil,
+		minVersion,
+		maxVersion,
 	)
 	if err != nil {
 		return nil, err
@@ -198,16 +202,6 @@ func createConn(
 			}
 		}
 		curves = filtered
-	}
-
-	minVersion := config.minVersion
-	if !minVersion.Equal(protocol.Version1_3) {
-		minVersion = protocol.Version1_2
-	}
-
-	maxVersion := config.maxVersion
-	if !maxVersion.Equal(protocol.Version1_3) {
-		maxVersion = protocol.Version1_2
 	}
 
 	handshakeConfig := &handshakeConfig{
@@ -335,6 +329,14 @@ func (c *Conn) HandshakeContext(ctx context.Context) error { //nolint:cyclop
 		return err
 	}
 
+	c.handshakeConfig.localCipherSuites = filterCipherSuitesForVersion(
+		c.handshakeConfig.localCipherSuites,
+		c.state.localVersion,
+	)
+	if len(c.handshakeConfig.localCipherSuites) == 0 {
+		return errNoAvailableCipherSuites
+	}
+
 	if err := c.handshake(ctx, start); err != nil {
 		return err
 	}
@@ -365,6 +367,7 @@ func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error
 		c.state.localVersion = protocol.Version1_2
 		if c.handshakeConfig.resumeState != nil {
 			c.state = *c.handshakeConfig.resumeState
+			c.state.localVersion = protocol.Version1_2
 
 			return handshakeStart{flight: flight5, fsmState: handshakeFinished}, nil
 		}
@@ -374,6 +377,7 @@ func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error
 		c.state.localVersion = protocol.Version1_2
 		if c.handshakeConfig.resumeState != nil {
 			c.state = *c.handshakeConfig.resumeState
+			c.state.localVersion = protocol.Version1_2
 
 			return handshakeStart{flight: flight6, fsmState: handshakeFinished}, nil
 		}

--- a/flight0handler.go
+++ b/flight0handler.go
@@ -66,6 +66,8 @@ func flight0Parse(
 		}
 	}
 
+	cipherSuites = filterCipherSuitesForVersion(cipherSuites, protocol.Version1_2)
+
 	if state.cipherSuite, ok = findMatchingCipherSuite(cipherSuites, cfg.localCipherSuites); !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
 	}

--- a/flight3handler.go
+++ b/flight3handler.go
@@ -103,6 +103,9 @@ func flight3Parse(
 		if remoteCipherSuite == nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
 		}
+		if !cipherSuiteIDSupportsVersion(remoteCipherSuite.ID(), protocol.Version1_2) {
+			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errInvalidCipherSuite
+		}
 
 		selectedCipherSuite, found := findMatchingCipherSuite([]CipherSuite{remoteCipherSuite}, cfg.localCipherSuites)
 		if !found {

--- a/handshaker_13_test.go
+++ b/handshaker_13_test.go
@@ -139,7 +139,14 @@ func canonicalPacketHandshake13(t *testing.T, p *packet) []byte {
 func testHandshakeConfig13(t *testing.T) *handshakeConfig {
 	t.Helper()
 
-	cipherSuites, err := parseCipherSuites(nil, nil, true, false)
+	cipherSuites, err := parseCipherSuitesForVersions(
+		nil,
+		nil,
+		true,
+		false,
+		protocol.Version1_3,
+		protocol.Version1_3,
+	)
 	require.NoError(t, err)
 
 	loggerFactory := logging.NewDefaultLoggerFactory()

--- a/internal/ciphersuite/ciphersuite.go
+++ b/internal/ciphersuite/ciphersuite.go
@@ -55,6 +55,12 @@ func (i ID) String() string { //nolint:cyclop
 		return "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
 	case TLS_PSK_WITH_CHACHA20_POLY1305_SHA256:
 		return "TLS_PSK_WITH_CHACHA20_POLY1305_SHA256"
+	case TLS_AES_128_GCM_SHA256:
+		return "TLS_AES_128_GCM_SHA256"
+	case TLS_AES_256_GCM_SHA384:
+		return "TLS_AES_256_GCM_SHA384"
+	case TLS_CHACHA20_POLY1305_SHA256:
+		return "TLS_CHACHA20_POLY1305_SHA256"
 	default:
 		return fmt.Sprintf("unknown(%v)", uint16(i))
 	}
@@ -88,6 +94,11 @@ const (
 	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 ID = 0xcca9 // nolint: revive,staticcheck
 	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   ID = 0xcca8 // nolint: revive,staticcheck
 	TLS_PSK_WITH_CHACHA20_POLY1305_SHA256         ID = 0xccab // nolint: revive,staticcheck
+
+	// TLS 1.3 cipher suites.
+	TLS_AES_128_GCM_SHA256       ID = 0x1301 // nolint: revive,staticcheck
+	TLS_AES_256_GCM_SHA384       ID = 0x1302 // nolint: revive,staticcheck
+	TLS_CHACHA20_POLY1305_SHA256 ID = 0x1303 // nolint: revive,staticcheck
 )
 
 // AuthenticationType controls what authentication method is using during the handshake.

--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package ciphersuite
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"hash"
+
+	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
+)
+
+var errCipherSuiteRecordProtectionNotImplemented = &protocol.TemporaryError{
+	// todo: implement
+	// nolint:godox
+	Err: errors.New("DTLS 1.3 cipher suite record protection is not implemented"), //nolint:err113
+}
+
+// TLS13CipherSuite is metadata for a TLS 1.3 cipher suite. TLS 1.3 cipher
+// suites only identify the AEAD and hash; authentication and key exchange are
+// negotiated independently.
+type TLS13CipherSuite struct {
+	id       ID
+	hashFunc func() hash.Hash
+}
+
+// NewTLSAes128GcmSha256 returns metadata for TLS_AES_128_GCM_SHA256.
+func NewTLSAes128GcmSha256() *TLS13CipherSuite {
+	return &TLS13CipherSuite{id: TLS_AES_128_GCM_SHA256, hashFunc: sha256.New}
+}
+
+// NewTLSAes256GcmSha384 returns metadata for TLS_AES_256_GCM_SHA384.
+func NewTLSAes256GcmSha384() *TLS13CipherSuite {
+	return &TLS13CipherSuite{id: TLS_AES_256_GCM_SHA384, hashFunc: sha512.New384}
+}
+
+// NewTLSChacha20Poly1305Sha256 returns metadata for TLS_CHACHA20_POLY1305_SHA256.
+func NewTLSChacha20Poly1305Sha256() *TLS13CipherSuite {
+	return &TLS13CipherSuite{id: TLS_CHACHA20_POLY1305_SHA256, hashFunc: sha256.New}
+}
+
+func (c *TLS13CipherSuite) CertificateType() clientcertificate.Type {
+	return 0
+}
+
+func (c *TLS13CipherSuite) KeyExchangeAlgorithm() KeyExchangeAlgorithm {
+	return KeyExchangeAlgorithmNone
+}
+
+func (c *TLS13CipherSuite) ECC() bool {
+	return true
+}
+
+func (c *TLS13CipherSuite) ID() ID {
+	return c.id
+}
+
+func (c *TLS13CipherSuite) String() string {
+	return c.ID().String()
+}
+
+func (c *TLS13CipherSuite) HashFunc() func() hash.Hash {
+	return c.hashFunc
+}
+
+func (c *TLS13CipherSuite) AuthenticationType() AuthenticationType {
+	return AuthenticationTypeAnonymous
+}
+
+func (c *TLS13CipherSuite) IsInitialized() bool {
+	return false
+}
+
+func (c *TLS13CipherSuite) Init(_, _, _ []byte, _ bool) error {
+	return errCipherSuiteRecordProtectionNotImplemented
+}
+
+func (c *TLS13CipherSuite) Encrypt(_ *recordlayer.RecordLayer, _ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("%w, unable to encrypt", errCipherSuiteRecordProtectionNotImplemented)
+}
+
+func (c *TLS13CipherSuite) Decrypt(_ recordlayer.Header, _ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("%w, unable to decrypt", errCipherSuiteRecordProtectionNotImplemented)
+}

--- a/pkg/crypto/elliptic/elliptic.go
+++ b/pkg/crypto/elliptic/elliptic.go
@@ -54,13 +54,10 @@ type Curve uint16
 
 // Curve enums.
 const (
-	P256   Curve = 0x0017
-	P384   Curve = 0x0018
-	X25519 Curve = 0x001d
-	// X25519MLKEM768
-	// https://pkg.go.dev/crypto/internal/fips140/mlkem
-	// https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/
-	// https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem/
+	P256           Curve = 0x0017
+	P384           Curve = 0x0018
+	X25519         Curve = 0x001d
+	X25519MLKEM768 Curve = 0x11ec
 )
 
 func (c Curve) String() string {
@@ -71,6 +68,8 @@ func (c Curve) String() string {
 		return "P-384"
 	case X25519:
 		return "X25519"
+	case X25519MLKEM768:
+		return "X25519MLKEM768"
 	}
 
 	return fmt.Sprintf("%#x", uint16(c))

--- a/pkg/crypto/elliptic/elliptic_test.go
+++ b/pkg/crypto/elliptic/elliptic_test.go
@@ -19,6 +19,7 @@ func TestString(t *testing.T) {
 		{X25519, "X25519"},
 		{P256, "P-256"},
 		{P384, "P-384"},
+		{X25519MLKEM768, "X25519MLKEM768"},
 		{0, "0x0"},
 	}
 
@@ -32,6 +33,13 @@ func TestString(t *testing.T) {
 func TestGenerateKeypair_InvalidCurve(t *testing.T) {
 	var invalid Curve = 0 // not a supported curve
 	_, err := GenerateKeypair(invalid)
+	assert.ErrorIs(t, err, errInvalidNamedCurve)
+}
+
+func TestX25519MLKEM768MetadataOnly(t *testing.T) {
+	assert.False(t, Curves()[X25519MLKEM768])
+
+	_, err := GenerateKeypair(X25519MLKEM768)
 	assert.ErrorIs(t, err, errInvalidNamedCurve)
 }
 

--- a/util.go
+++ b/util.go
@@ -9,6 +9,18 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 )
 
+func normalizeProtocolVersionRange(minVersion, maxVersion protocol.Version) (protocol.Version, protocol.Version) {
+	if !minVersion.Equal(protocol.Version1_3) {
+		minVersion = protocol.Version1_2
+	}
+
+	if !maxVersion.Equal(protocol.Version1_3) {
+		maxVersion = protocol.Version1_2
+	}
+
+	return minVersion, maxVersion
+}
+
 // supportedVersionsRange returns the supported DTLS versions from maxVersion
 // down to minVersion, in preference order (newest first). Only DTLS 1.2 and
 // 1.3 are emitted.


### PR DESCRIPTION
#### Description
Adds DTLS 1.3 cipher-suite IDs and metadata.

#### Reference issue
Fixes #854
