### PR TITLE
Send and require signature_algorithms

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -66,6 +66,10 @@ var (
 	//nolint:err113
 	errInvalidClientHello = &FatalError{Err: errors.New("invalid ClientHello")}
 	//nolint:err113
+	errMissingClientHelloExtension = &FatalError{
+		Err: errors.New("DTLS 1.3 ClientHello missing mandatory extension"),
+	}
+	//nolint:err113
 	errInvalidHelloRetryRequest = &FatalError{Err: errors.New("invalid HelloRetryRequest")}
 	//nolint:err113
 	errInvalidECDSASignature = &FatalError{Err: errors.New("ECDSA signature contained zero or negative values")}

--- a/flighthandlers_client_13.go
+++ b/flighthandlers_client_13.go
@@ -249,6 +249,9 @@ func flight13_1Generate(
 	if len(cfg.ellipticCurves) < 1 {
 		return nil, nil, errEmptyEllipticCurves
 	}
+	if len(cfg.localSignatureSchemes) < 1 {
+		return nil, nil, errNoAvailableSignatureSchemes
+	}
 	state.namedCurve = cfg.ellipticCurves[0]
 	state.cookie = nil
 
@@ -260,7 +263,11 @@ func flight13_1Generate(
 		state.localRandom.RandomBytes = cfg.helloRandomBytesGenerator()
 	}
 
-	extensions := []extension.Extension{}
+	extensions := []extension.Extension{
+		&extension.SupportedSignatureAlgorithms{
+			SignatureHashAlgorithms: cfg.localSignatureSchemes,
+		},
+	}
 
 	if cfg.extendedMasterSecret == RequestExtendedMasterSecret ||
 		cfg.extendedMasterSecret == RequireExtendedMasterSecret {
@@ -376,7 +383,15 @@ func flight13_3Generate(
 	_ flightConn,
 	flightCtx *handshakeContext13,
 ) ([]*packet, *alert.Alert, error) {
-	extensions := []extension.Extension{}
+	if len(flightCtx.cfg.localSignatureSchemes) < 1 {
+		return nil, nil, errNoAvailableSignatureSchemes
+	}
+
+	extensions := []extension.Extension{
+		&extension.SupportedSignatureAlgorithms{
+			SignatureHashAlgorithms: flightCtx.cfg.localSignatureSchemes,
+		},
+	}
 
 	if flightCtx.cfg.extendedMasterSecret == RequestExtendedMasterSecret ||
 		flightCtx.cfg.extendedMasterSecret == RequireExtendedMasterSecret {

--- a/flighthandlers_client_13_test.go
+++ b/flighthandlers_client_13_test.go
@@ -71,6 +71,33 @@ func marshalServerHello(
 	return rawServerHello
 }
 
+func generateFlight13_1ClientHello(t *testing.T, cfg *handshakeConfig) *handshake.MessageClientHello {
+	t.Helper()
+
+	state := &State{}
+
+	pkts, dtlsAlert, err := flight13_1Generate(nil, &handshakeContext13{
+		state: state,
+		cfg:   cfg,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, pkts, 1)
+
+	hand, ok := pkts[0].record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	raw, err := hand.Marshal()
+	require.NoError(t, err)
+
+	var parsed handshake.Handshake
+	require.NoError(t, parsed.Unmarshal(raw))
+	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
+	require.True(t, ok)
+
+	return clientHello
+}
+
 func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := &State{}
@@ -105,6 +132,47 @@ func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) 
 	require.NotNil(t, supportedVersions)
 	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
 	assert.False(t, supportedVersions.IsSelectedVersion())
+}
+
+func TestFlight13_1GenerateClientHelloIncludesSignatureAlgorithms(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cfg.localCertSignatureSchemes = cfg.localSignatureSchemes[:1]
+
+	clientHello := generateFlight13_1ClientHello(t, cfg)
+
+	var signatureAlgorithms *extension.SupportedSignatureAlgorithms
+	var signatureAlgorithmsCert *extension.SignatureAlgorithmsCert
+	for _, ext := range clientHello.Extensions {
+		switch typed := ext.(type) {
+		case *extension.SupportedSignatureAlgorithms:
+			signatureAlgorithms = typed
+		case *extension.SignatureAlgorithmsCert:
+			signatureAlgorithmsCert = typed
+		}
+	}
+
+	require.NotNil(t, signatureAlgorithms)
+	assert.Equal(t, cfg.localSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
+	require.NotNil(t, signatureAlgorithmsCert)
+	assert.Equal(t, cfg.localCertSignatureSchemes, signatureAlgorithmsCert.SignatureHashAlgorithms)
+}
+
+func TestFlight13_1GenerateClientHelloIncludesSupportedGroups(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+
+	clientHello := generateFlight13_1ClientHello(t, cfg)
+
+	var supportedGroups *extension.SupportedEllipticCurves
+	for _, ext := range clientHello.Extensions {
+		if typed, ok := ext.(*extension.SupportedEllipticCurves); ok {
+			supportedGroups = typed
+
+			break
+		}
+	}
+
+	require.NotNil(t, supportedGroups)
+	assert.Equal(t, cfg.ellipticCurves, supportedGroups.EllipticCurves)
 }
 
 func TestFlight13_1GenerateRetainsPrivateKeysForAdvertisedShares(t *testing.T) {
@@ -417,6 +485,17 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 	require.NotNil(t, supportedVersions)
 	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
 	assert.False(t, supportedVersions.IsSelectedVersion())
+
+	var signatureAlgorithms *extension.SupportedSignatureAlgorithms
+	for _, ext := range clientHello.Extensions {
+		if sigAlgs, ok := ext.(*extension.SupportedSignatureAlgorithms); ok {
+			signatureAlgorithms = sigAlgs
+
+			break
+		}
+	}
+	require.NotNil(t, signatureAlgorithms)
+	assert.Equal(t, cfg.localSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
 
 	var cookieExt *extension.CookieExt
 	for _, ext := range clientHello.Extensions {

--- a/flighthandlers_server_13.go
+++ b/flighthandlers_server_13.go
@@ -43,6 +43,112 @@ import (
 // | Flight 4c |
 // +-----------+
 
+type clientHello13ExtensionSet struct {
+	hasPreSharedKey        bool
+	hasSignatureAlgorithms bool
+	hasSupportedGroups     bool
+}
+
+type clientHello13ExtensionFailure struct {
+	alert *alert.Alert
+	err   error
+}
+
+func newClientHello13ExtensionFailure(
+	description alert.Description,
+	err error,
+) *clientHello13ExtensionFailure {
+	return &clientHello13ExtensionFailure{
+		alert: &alert.Alert{Level: alert.Fatal, Description: description},
+		err:   err,
+	}
+}
+
+func processClientHello13Extensions(
+	state *State,
+	cfg *handshakeConfig,
+	clientHello *handshake.MessageClientHello,
+) *clientHello13ExtensionFailure {
+	var seen clientHello13ExtensionSet
+
+	for _, val := range clientHello.Extensions {
+		if failure := processClientHello13SecurityExtension(state, cfg, &seen, val); failure != nil {
+			return failure
+		}
+		processClientHello13StateExtension(state, cfg, val)
+	}
+
+	if !seen.hasPreSharedKey && (!seen.hasSignatureAlgorithms || !seen.hasSupportedGroups) {
+		return newClientHello13ExtensionFailure(alert.MissingExtension, errMissingClientHelloExtension)
+	}
+
+	return nil
+}
+
+func processClientHello13SecurityExtension(
+	state *State,
+	cfg *handshakeConfig,
+	seen *clientHello13ExtensionSet,
+	val extension.Extension,
+) *clientHello13ExtensionFailure {
+	switch ext := val.(type) {
+	case *extension.SupportedEllipticCurves:
+		seen.hasSupportedGroups = true
+		if len(ext.EllipticCurves) == 0 {
+			return newClientHello13ExtensionFailure(alert.InsufficientSecurity, errNoSupportedEllipticCurves)
+		}
+		state.remoteGroups = ext.EllipticCurves
+	case *extension.UseSRTP:
+		profile, ok := findMatchingSRTPProfile(cfg.localSRTPProtectionProfiles, ext.ProtectionProfiles)
+		if !ok {
+			return newClientHello13ExtensionFailure(alert.InsufficientSecurity, errServerNoMatchingSRTPProfile)
+		}
+		state.setSRTPProtectionProfile(profile)
+		state.remoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
+	case *extension.SupportedSignatureAlgorithms:
+		seen.hasSignatureAlgorithms = true
+		state.remoteSignatureSchemes = ext.SignatureHashAlgorithms
+	case *extension.SupportedVersions:
+		if ext.IsSelectedVersion() {
+			return newClientHello13ExtensionFailure(alert.IllegalParameter, errInvalidClientHello)
+		}
+		state.remoteVersions = ext.Versions
+	case *extension.PreSharedKey:
+		seen.hasPreSharedKey = true
+	}
+
+	return nil
+}
+
+func processClientHello13StateExtension(
+	state *State,
+	cfg *handshakeConfig,
+	val extension.Extension,
+) {
+	switch ext := val.(type) {
+	case *extension.UseExtendedMasterSecret:
+		if cfg.extendedMasterSecret != DisableExtendedMasterSecret {
+			state.extendedMasterSecret = true
+		}
+	case *extension.ServerName:
+		state.serverName = ext.ServerName // remote server name
+	case *extension.RenegotiationInfo:
+		state.remoteSupportsRenegotiation = true
+	case *extension.ALPN:
+		state.peerSupportedProtocols = ext.ProtocolNameList
+	case *extension.ConnectionID:
+		// Only set connection ID to be sent if server supports connection IDs.
+		if cfg.connectionIDGenerator != nil {
+			state.remoteConnectionID = ext.CID
+		}
+	case *extension.SignatureAlgorithmsCert:
+		// Store the client's certificate signature schemes for later validation.
+		state.remoteCertSignatureSchemes = ext.SignatureHashAlgorithms
+	case *extension.KeyShare:
+		state.remoteKeyEntries = &ext.ClientShares
+	}
+}
+
 //nolint:cyclop,gocognit,gocyclo,unused
 func flight13_0Parse(
 	_ context.Context,
@@ -102,47 +208,8 @@ func flight13_0Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errCipherSuiteNoIntersection
 	}
 
-	for _, val := range clientHello.Extensions {
-		switch ext := val.(type) {
-		case *extension.SupportedEllipticCurves:
-			if len(ext.EllipticCurves) == 0 {
-				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errNoSupportedEllipticCurves
-			}
-			state.remoteGroups = ext.EllipticCurves
-		case *extension.UseSRTP:
-			profile, ok := findMatchingSRTPProfile(cfg.localSRTPProtectionProfiles, ext.ProtectionProfiles)
-			if !ok {
-				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, errServerNoMatchingSRTPProfile
-			}
-			state.setSRTPProtectionProfile(profile)
-			state.remoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
-		case *extension.UseExtendedMasterSecret:
-			if cfg.extendedMasterSecret != DisableExtendedMasterSecret {
-				state.extendedMasterSecret = true
-			}
-		case *extension.ServerName:
-			state.serverName = ext.ServerName // remote server name
-		case *extension.RenegotiationInfo:
-			state.remoteSupportsRenegotiation = true
-		case *extension.ALPN:
-			state.peerSupportedProtocols = ext.ProtocolNameList
-		case *extension.ConnectionID:
-			// Only set connection ID to be sent if server supports connection
-			// IDs.
-			if cfg.connectionIDGenerator != nil {
-				state.remoteConnectionID = ext.CID
-			}
-		case *extension.SignatureAlgorithmsCert:
-			// Store the client's certificate signature schemes for later validation
-			state.remoteCertSignatureSchemes = ext.SignatureHashAlgorithms
-		case *extension.SupportedVersions:
-			if ext.IsSelectedVersion() {
-				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, errInvalidClientHello
-			}
-			state.remoteVersions = ext.Versions
-		case *extension.KeyShare:
-			state.remoteKeyEntries = &ext.ClientShares
-		}
+	if failure := processClientHello13Extensions(state, cfg, clientHello); failure != nil {
+		return 0, failure.alert, failure.err
 	}
 
 	if !slices.Contains(state.remoteVersions, protocol.Version1_3) {
@@ -238,7 +305,6 @@ func flight13_2Parse(
 	if !ok {
 		return 0, nil, nil
 	}
-	flightCtx.state.handshakeRecvSequence = seq
 
 	clientHello, ok := msgs[handshake.TypeClientHello].(*handshake.MessageClientHello)
 	if !ok {
@@ -264,6 +330,11 @@ func flight13_2Parse(
 	if !bytes.Equal(flightCtx.state.cookie, cookie) {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, errCookieMismatch
 	}
+
+	if failure := processClientHello13Extensions(flightCtx.state, flightCtx.cfg, clientHello); failure != nil {
+		return 0, failure.alert, failure.err
+	}
+	flightCtx.state.handshakeRecvSequence = seq
 
 	return flight13_4, nil, nil
 }

--- a/flighthandlers_server_13_test.go
+++ b/flighthandlers_server_13_test.go
@@ -33,6 +33,9 @@ func TestFlight13_0ParseGeneratesKeypairForNegotiatedGroup(t *testing.T) {
 		},
 		CompressionMethods: defaultCompressionMethods(),
 		Extensions: []extension.Extension{
+			&extension.SupportedSignatureAlgorithms{
+				SignatureHashAlgorithms: cfg.localSignatureSchemes,
+			},
 			&extension.SupportedEllipticCurves{
 				EllipticCurves: []elliptic.Curve{elliptic.P384},
 			},
@@ -107,6 +110,165 @@ func TestFlight13_0ParseRejectsClientHelloWithSelectedSupportedVersion(t *testin
 	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
 	assert.Zero(t, nextFlight)
 	assert.Empty(t, state.remoteVersions)
+}
+
+func pushFlight13_0ClientHello(
+	t *testing.T,
+	cache *handshakeCache,
+	cfg *handshakeConfig,
+	exts []extension.Extension,
+) {
+	t.Helper()
+
+	clientHello := &handshake.MessageClientHello{
+		Version: protocol.Version1_2,
+		Random:  handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}},
+		CipherSuiteIDs: []uint16{
+			uint16(cfg.localCipherSuites[0].ID()),
+		},
+		CompressionMethods: defaultCompressionMethods(),
+		Extensions:         exts,
+	}
+	rawClientHello, err := (&handshake.Handshake{Message: clientHello}).Marshal()
+	require.NoError(t, err)
+
+	cache.push(rawClientHello, cfg.initialEpoch, 0, handshake.TypeClientHello, true)
+}
+
+func requiredClientHello13Extensions(t *testing.T, cfg *handshakeConfig) []extension.Extension {
+	t.Helper()
+
+	clientKeypair, err := elliptic.GenerateKeypair(cfg.ellipticCurves[0])
+	require.NoError(t, err)
+
+	return []extension.Extension{
+		&extension.SupportedSignatureAlgorithms{
+			SignatureHashAlgorithms: cfg.localSignatureSchemes,
+		},
+		&extension.SupportedEllipticCurves{
+			EllipticCurves: cfg.ellipticCurves,
+		},
+		&extension.KeyShare{
+			ClientShares: []extension.KeyShareEntry{
+				{Group: clientKeypair.Curve, KeyExchange: clientKeypair.PublicKey},
+			},
+		},
+		&extension.SupportedVersions{
+			Versions: []protocol.Version{protocol.Version1_3},
+		},
+	}
+}
+
+func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.T) {
+	t.Run("AcceptsSignatureAlgorithmsAndSupportedGroups", func(t *testing.T) {
+		cfg := testHandshakeConfig13(t)
+		state := &State{localVersion: protocol.Version1_3}
+		cache := newHandshakeCache()
+		pushFlight13_0ClientHello(t, cache, cfg, requiredClientHello13Extensions(t, cfg))
+
+		nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+		require.NoError(t, err)
+		require.Nil(t, dtlsAlert)
+		assert.Equal(t, flight13_2, nextFlight)
+		assert.Equal(t, cfg.localSignatureSchemes, state.remoteSignatureSchemes)
+		assert.Equal(t, cfg.ellipticCurves, state.remoteGroups)
+	})
+
+	t.Run("AllowsPreSharedKeyWithoutCertificateAuthExtensions", func(t *testing.T) {
+		cfg := testHandshakeConfig13(t)
+		state := &State{localVersion: protocol.Version1_3}
+		cache := newHandshakeCache()
+		binder := make([]byte, 32)
+		pushFlight13_0ClientHello(t, cache, cfg, []extension.Extension{
+			&extension.SupportedVersions{
+				Versions: []protocol.Version{protocol.Version1_3},
+			},
+			&extension.PreSharedKey{
+				Identities: []extension.PskIdentity{
+					{Identity: []byte("psk"), ObfuscatedTicketAge: 0},
+				},
+				Binders: []extension.PskBinderEntry{binder},
+			},
+		})
+
+		nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+		require.NoError(t, err)
+		require.Nil(t, dtlsAlert)
+		assert.Equal(t, flight13_2, nextFlight)
+	})
+
+	t.Run("RejectsMissingSignatureAlgorithms", func(t *testing.T) {
+		cfg := testHandshakeConfig13(t)
+		state := &State{localVersion: protocol.Version1_3}
+		cache := newHandshakeCache()
+		exts := requiredClientHello13Extensions(t, cfg)[1:]
+		pushFlight13_0ClientHello(t, cache, cfg, exts)
+
+		nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+		require.ErrorIs(t, err, errMissingClientHelloExtension)
+		require.NotNil(t, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
+		assert.Zero(t, nextFlight)
+	})
+
+	t.Run("RejectsSignatureAlgorithmsCertAsSubstitute", func(t *testing.T) {
+		cfg := testHandshakeConfig13(t)
+		state := &State{localVersion: protocol.Version1_3}
+		cache := newHandshakeCache()
+		exts := requiredClientHello13Extensions(t, cfg)[1:]
+		exts = append([]extension.Extension{
+			&extension.SignatureAlgorithmsCert{
+				SignatureHashAlgorithms: cfg.localSignatureSchemes,
+			},
+		}, exts...)
+		pushFlight13_0ClientHello(t, cache, cfg, exts)
+
+		nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+		require.ErrorIs(t, err, errMissingClientHelloExtension)
+		require.NotNil(t, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
+		assert.Zero(t, nextFlight)
+	})
+
+	t.Run("RejectsMissingSupportedGroups", func(t *testing.T) {
+		cfg := testHandshakeConfig13(t)
+		state := &State{localVersion: protocol.Version1_3}
+		cache := newHandshakeCache()
+		required := requiredClientHello13Extensions(t, cfg)
+		exts := []extension.Extension{required[0], required[2], required[3]}
+		pushFlight13_0ClientHello(t, cache, cfg, exts)
+
+		nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+		require.ErrorIs(t, err, errMissingClientHelloExtension)
+		require.NotNil(t, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
+		assert.Zero(t, nextFlight)
+	})
 }
 
 func serverHelloFromFlight13_2(t *testing.T, state *State, cfg *handshakeConfig) *handshake.MessageServerHello {
@@ -304,9 +466,8 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := newHandshakeCache()
 		cfg := testHandshakeConfig13(t)
 
-		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
-			&extension.CookieExt{Cookie: cookie},
-		})
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension.CookieExt{Cookie: cookie})
+		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13_2Parse(context.Background(), nil, flight13_2Context(state, cache, cfg))
 		require.NoError(t, err)
@@ -328,32 +489,41 @@ func TestFlight13_2Parse(t *testing.T) {
 	})
 
 	t.Run("KeepsWaitingWhenCookieNotYetEchoed", func(t *testing.T) {
-		state := &State{localVersion: protocol.Version1_3, cookie: cookie}
+		state := &State{localVersion: protocol.Version1_3, cookie: cookie, serverName: "original.example"}
 		cache := newHandshakeCache()
 		cfg := testHandshakeConfig13(t)
 
-		pushClientHello13(t, cache, protocol.Version1_2, nil)
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerName{ServerName: "poison.example"})
+		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13_2Parse(context.Background(), nil, flight13_2Context(state, cache, cfg))
 		require.NoError(t, err)
 		require.Nil(t, dtlsAlert)
 		assert.Equal(t, flightVal13(0), next)
+		assert.Equal(t, 0, state.handshakeRecvSequence)
+		assert.Equal(t, "original.example", state.serverName)
+		assert.Empty(t, state.remoteSignatureSchemes)
+		assert.Empty(t, state.remoteGroups)
 	})
 
 	t.Run("RejectsCookieMismatch", func(t *testing.T) {
-		state := &State{localVersion: protocol.Version1_3, cookie: cookie}
+		state := &State{localVersion: protocol.Version1_3, cookie: cookie, serverName: "original.example"}
 		cache := newHandshakeCache()
 		cfg := testHandshakeConfig13(t)
 
-		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
-			&extension.CookieExt{Cookie: []byte{0x00, 0x01, 0x02, 0x03}},
-		})
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerName{ServerName: "poison.example"},
+			&extension.CookieExt{Cookie: []byte{0x00, 0x01, 0x02, 0x03}})
+		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13_2Parse(context.Background(), nil, flight13_2Context(state, cache, cfg))
 		require.ErrorIs(t, err, errCookieMismatch)
 		assert.Equal(t, flightVal13(0), next)
 		require.NotNil(t, dtlsAlert)
 		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlsAlert)
+		assert.Equal(t, 0, state.handshakeRecvSequence)
+		assert.Equal(t, "original.example", state.serverName)
+		assert.Empty(t, state.remoteSignatureSchemes)
+		assert.Empty(t, state.remoteGroups)
 	})
 
 	t.Run("RejectsUnsupportedVersion", func(t *testing.T) {
@@ -370,5 +540,21 @@ func TestFlight13_2Parse(t *testing.T) {
 		assert.Equal(t, flightVal13(0), next)
 		require.NotNil(t, dtlsAlert)
 		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, dtlsAlert)
+	})
+
+	t.Run("RejectsMissingCertificateAuthExtensions", func(t *testing.T) {
+		state := &State{localVersion: protocol.Version1_3, cookie: cookie}
+		cache := newHandshakeCache()
+		cfg := testHandshakeConfig13(t)
+
+		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
+			&extension.CookieExt{Cookie: cookie},
+		})
+
+		next, dtlsAlert, err := flight13_2Parse(context.Background(), nil, flight13_2Context(state, cache, cfg))
+		require.ErrorIs(t, err, errMissingClientHelloExtension)
+		assert.Equal(t, flightVal13(0), next)
+		require.NotNil(t, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
 	})
 }

--- a/handshaker_13_test.go
+++ b/handshaker_13_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/logging"
@@ -159,6 +160,7 @@ func testHandshakeConfig13(t *testing.T) *handshakeConfig {
 		log:                         loggerFactory.NewLogger("dtls"),
 		minVersion:                  protocol.Version1_3,
 		maxVersion:                  protocol.Version1_3,
+		localSignatureSchemes:       signaturehash.Algorithms13(),
 		localCertSignatureSchemes:   nil,
 		localSRTPProtectionProfiles: nil,
 	}

--- a/pkg/protocol/alert/alert.go
+++ b/pkg/protocol/alert/alert.go
@@ -62,6 +62,7 @@ const (
 	InternalError          Description = 80
 	UserCanceled           Description = 90
 	NoRenegotiation        Description = 100
+	MissingExtension       Description = 109
 	UnsupportedExtension   Description = 110
 	NoApplicationProtocol  Description = 120
 )
@@ -116,6 +117,8 @@ func (d Description) String() string { //nolint:cyclop
 		return "UserCanceled"
 	case NoRenegotiation:
 		return "NoRenegotiation"
+	case MissingExtension:
+		return "MissingExtension"
 	case UnsupportedExtension:
 		return "UnsupportedExtension"
 	case NoApplicationProtocol:

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -103,6 +103,10 @@ func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 			err = unmarshalAndAppend(bufView, &KeyShare{})
 		case CookieTypeValue:
 			err = unmarshalAndAppend(bufView, &CookieExt{})
+		case PskKeyExchangeModesTypeValue:
+			err = unmarshalAndAppend(bufView, &PskKeyExchangeModes{})
+		case PreSharedKeyValue:
+			err = unmarshalAndAppend(bufView, &PreSharedKey{})
 		default:
 		}
 

--- a/state.go
+++ b/state.go
@@ -63,6 +63,7 @@ type State struct {
 	handshakeRecvSequence      int
 	serverName                 string
 	remoteCertRequestAlgs      []signaturehash.Algorithm
+	remoteSignatureSchemes     []signaturehash.Algorithm // signature_algorithms from peer
 	remoteCertSignatureSchemes []signaturehash.Algorithm // signature_algorithms_cert from peer
 	remoteRequestedCertificate bool                      // Did we get a CertificateRequest
 	localCertificatesVerify    []byte                    // cache CertificateVerify


### PR DESCRIPTION
#### Description
RFC 8446: defines signature_algorithms vs signature_algorithms_cert. signature_algorithms is required for certificate authentication and missing it requires missing_extension.
RFC 8446: a ClientHello without pre_shared_key must contain both signature_algorithms and supported_groups, and  ClientHellos must be rejected with missing_extension.
RFC 8446: missing_extension as alert 109.
add signature_algorithms to flight13_3Generate in retry/cookie ClientHello and errors.

This is part of handling all the different kind of cases with extensions now since flights are merged, related to https://github.com/pion/dtls/pull/829#discussion_r3448002648 
#### Reference issue
part of #825 refs #727 