### PR TITLE
Increase E2E test timeout

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -350,7 +350,7 @@ func testPionE2ESimple(t *testing.T, server, client func(*comm), opts ...dtlsTes
 		dtls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 	} {
 		t.Run(cipherSuite.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 			defer cancel()
 
 			cert, err := selfsign.GenerateSelfSignedWithDNS("localhost")
@@ -397,7 +397,7 @@ func testPionE2ESimpleRSA(t *testing.T, server, client func(*comm), opts ...dtls
 		dtls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 	} {
 		t.Run(cipherSuite.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 			defer cancel()
 
 			priv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -444,7 +444,7 @@ func testPionE2EChaCha20Poly1305(t *testing.T, server, client func(*comm), opts 
 		dtls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	} {
 		t.Run(cipherSuite.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 			defer cancel()
 
 			cert, err := selfsign.GenerateSelfSignedWithDNS("localhost")
@@ -489,7 +489,7 @@ func testPionE2EChaCha20Poly1305RSA(t *testing.T, server, client func(*comm), op
 		dtls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 	} {
 		t.Run(cipherSuite.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 			defer cancel()
 
 			priv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -540,7 +540,7 @@ func testPionE2ESimplePSK(t *testing.T, server, client func(*comm), opts ...dtls
 		dtls.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
 	} {
 		t.Run(cipherSuite.String(), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 			defer cancel()
 
 			clientOpts := []dtls.ClientOption{
@@ -588,7 +588,7 @@ func testPionE2EChaCha20Poly1305PSK(t *testing.T, server, client func(*comm), op
 
 	cipherSuite := dtls.TLS_PSK_WITH_CHACHA20_POLY1305_SHA256
 	t.Run(cipherSuite.String(), func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 		defer cancel()
 
 		pskFunc := func([]byte) ([]byte, error) {
@@ -877,7 +877,7 @@ func testPionE2ESimpleClientHelloHook(t *testing.T, server, client func(*comm), 
 	defer report()
 
 	t.Run("ClientHello hook", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 		defer cancel()
 
 		cert, err := selfsign.GenerateSelfSignedWithDNS("localhost")
@@ -938,7 +938,7 @@ func testPionE2ESimpleServerHelloHook(t *testing.T, server, client func(*comm), 
 	defer report()
 
 	t.Run("ServerHello hook", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeLimit)
 		defer cancel()
 
 		cert, err := selfsign.GenerateSelfSignedWithDNS("localhost")


### PR DESCRIPTION
RSA Key generation is timing out some tests. Use a already available constant