### PR TITLE
Add transcript append helpers for outbound handshake

### DIFF
--- a/flighthandlers_server_13.go
+++ b/flighthandlers_server_13.go
@@ -349,6 +349,9 @@ func flight13_2Generate(
 	flightCtx *handshakeContext13,
 ) ([]*packet, *alert.Alert, error) {
 	flightCtx.state.handshakeSendSequence = 0
+	if flightCtx.state.cipherSuite == nil {
+		return nil, nil, dtlserrors.ErrCipherSuiteUnset
+	}
 
 	random := handshake.Random{}
 	random.UnmarshalFixed([32]byte(handshake.HelloRetryRequestRandom()))
@@ -356,8 +359,10 @@ func flight13_2Generate(
 	exts := []extension.Extension{}
 
 	exts = append(exts, &extension.SupportedVersions{
-		Versions: supportedVersionsRange(flightCtx.cfg.minVersion, flightCtx.cfg.maxVersion),
+		Versions:        []protocol.Version{protocol.Version1_3},
+		SelectedVersion: true,
 	})
+	cipherSuiteID := uint16(flightCtx.state.cipherSuite.ID())
 
 	if flightCtx.state.namedCurve != 0 {
 		exts = append(exts, &extension.KeyShare{
@@ -379,9 +384,11 @@ func flight13_2Generate(
 				},
 				Content: &handshake.Handshake{
 					Message: &handshake.MessageServerHello{
-						Version:    protocol.Version1_2,
-						Random:     random,
-						Extensions: exts,
+						Version:           protocol.Version1_2,
+						Random:            random,
+						CipherSuiteID:     &cipherSuiteID,
+						CompressionMethod: defaultCompressionMethods()[0],
+						Extensions:        exts,
 					},
 				},
 			},

--- a/flighthandlers_server_13_test.go
+++ b/flighthandlers_server_13_test.go
@@ -275,6 +275,9 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 func serverHelloFromFlight13_2(t *testing.T, state *State, cfg *handshakeConfig) *handshake.MessageServerHello {
 	t.Helper()
 
+	if state.cipherSuite == nil {
+		state.cipherSuite = cfg.localCipherSuites[0]
+	}
 	pkts, dtlsAlert, err := flight13_2Generate(nil, flight13_2Context(state, newHandshakeCache(), cfg))
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
@@ -334,14 +337,28 @@ func TestFlight13_2Generate(t *testing.T) {
 	})
 
 	t.Run("ResetsHandshakeSendSequence", func(t *testing.T) {
-		state := &State{localVersion: protocol.Version1_3, handshakeSendSequence: 7}
 		cfg := testHandshakeConfig13(t)
+		state := &State{
+			localVersion:          protocol.Version1_3,
+			cipherSuite:           cfg.localCipherSuites[0],
+			handshakeSendSequence: 7,
+		}
 
 		_, dtlsAlert, err := flight13_2Generate(nil, flight13_2Context(state, newHandshakeCache(), cfg))
 		require.NoError(t, err)
 		require.Nil(t, dtlsAlert)
 
 		assert.Equal(t, 0, state.handshakeSendSequence)
+	})
+
+	t.Run("RejectsWithoutCipherSuite", func(t *testing.T) {
+		state := &State{localVersion: protocol.Version1_3}
+		cfg := testHandshakeConfig13(t)
+
+		pkts, dtlsAlert, err := flight13_2Generate(nil, flight13_2Context(state, newHandshakeCache(), cfg))
+		require.ErrorIs(t, err, dtlserrors.ErrCipherSuiteUnset)
+		require.Nil(t, dtlsAlert)
+		require.Nil(t, pkts)
 	})
 
 	t.Run("AlwaysIncludesSupportedVersions", func(t *testing.T) {
@@ -352,7 +369,30 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		supportedVersions, ok := findSupportedVersions(serverHello.Extensions)
 		require.True(t, ok, "SupportedVersions extension must always be present")
-		assert.Equal(t, supportedVersionsRange(cfg.minVersion, cfg.maxVersion), supportedVersions.Versions)
+		assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
+		assert.True(t, supportedVersions.IsSelectedVersion())
+	})
+
+	t.Run("IncludesCipherSuiteAndCompressionMethod", func(t *testing.T) {
+		state := &State{localVersion: protocol.Version1_3}
+		cfg := testHandshakeConfig13(t)
+
+		serverHello := serverHelloFromFlight13_2(t, state, cfg)
+
+		require.NotNil(t, serverHello.CipherSuiteID)
+		assert.Equal(t, uint16(cfg.localCipherSuites[0].ID()), *serverHello.CipherSuiteID)
+		require.NotNil(t, serverHello.CompressionMethod)
+		assert.Equal(t, defaultCompressionMethods()[0], serverHello.CompressionMethod)
+
+		raw, err := (&handshake.Handshake{Message: serverHello}).Marshal()
+		require.NoError(t, err)
+
+		var parsed handshake.Handshake
+		require.NoError(t, parsed.Unmarshal(raw))
+		parsedServerHello, ok := parsed.Message.(*handshake.MessageServerHello)
+		require.True(t, ok)
+		require.NotNil(t, parsedServerHello.CipherSuiteID)
+		assert.Equal(t, *serverHello.CipherSuiteID, *parsedServerHello.CipherSuiteID)
 	})
 
 	t.Run("OmitsKeyShareAndCookieByDefault", func(t *testing.T) {

--- a/handshaker_13.go
+++ b/handshaker_13.go
@@ -5,6 +5,8 @@ package dtls
 
 import (
 	"context"
+	"crypto/sha256"
+	"errors"
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -275,4 +277,121 @@ func (s *handshakeFSM13) wait(ctx context.Context, conn flightConn) (handshakeSt
 
 func (s *handshakeFSM13) finish(ctx context.Context, c flightConn) (handshakeState, error) {
 	return handshakeErrored, dtlserrors.ErrStateUnimplemented13
+}
+
+func transcriptSenderForSide13(isClient bool) transcriptSender13 {
+	if isClient {
+		return transcriptClient13
+	}
+
+	return transcriptServer13
+}
+
+func selectTranscriptHashIfReady13(t *handshakeTranscript13, cipherSuite CipherSuite) error {
+	if t == nil || cipherSuite == nil {
+		return nil
+	}
+
+	err := t.selectHash(cipherSuite.HashFunc())
+	if errors.Is(err, dtlserrors.ErrHandshakeTranscriptHashAlreadySelected) {
+		return nil
+	}
+
+	return err
+}
+
+func appendOutboundHandshakeFlight13(
+	transcript *handshakeTranscript13,
+	isClient bool,
+	cipherSuite CipherSuite,
+	pkts []*packet,
+) error {
+	if transcript == nil {
+		return nil
+	}
+
+	sender := transcriptSenderForSide13(isClient)
+	for _, p := range pkts {
+		h, canonical, ok, err := canonicalOutboundHandshake13(p)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+
+		if err := appendOutboundHandshake13(transcript, sender, cipherSuite, h, canonical); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func canonicalOutboundHandshake13(p *packet) (*handshake.Handshake, []byte, bool, error) {
+	if p == nil || p.record == nil {
+		return nil, nil, false, nil
+	}
+
+	hs, ok := p.record.Content.(*handshake.Handshake)
+	if !ok || hs.Message == nil {
+		return nil, nil, false, nil
+	}
+
+	raw, err := hs.Marshal()
+	if err != nil {
+		return nil, nil, false, err
+	}
+	canonical, err := canonicalHandshake13(raw)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	return hs, canonical, true, nil
+}
+
+func appendOutboundHandshake13(
+	transcript *handshakeTranscript13,
+	sender transcriptSender13,
+	cipherSuite CipherSuite,
+	h *handshake.Handshake,
+	canonical []byte,
+) error {
+	id := transcriptMessageID13{
+		sender: sender,
+		seq:    h.Header.MessageSequence,
+	}
+	if sh, ok := h.Message.(*handshake.MessageServerHello); ok && isHelloRetryRequest(sh) {
+		duplicate, err := transcript.hasCanonical13(id, canonical)
+		if err != nil || duplicate {
+			return err
+		}
+
+		if err := selectTranscriptHashIfReady13(transcript, cipherSuite); err != nil {
+			return err
+		}
+		if err := transcript.applyHelloRetryRequest(); err != nil {
+			return err
+		}
+	}
+
+	return transcript.appendCanonical(id, canonical)
+}
+
+func (t *handshakeTranscript13) hasCanonical13(id transcriptMessageID13, message []byte) (bool, error) {
+	if err := validateCanonicalHandshake13(message); err != nil {
+		return false, err
+	}
+
+	seen, ok := t.seen[id]
+	if !ok {
+		return false, nil
+	}
+
+	fingerprint := sha256.Sum256(message)
+	if seen.length == len(message) && seen.fingerprint == fingerprint {
+		return true, nil
+	}
+
+	return false, dtlserrors.ErrHandshakeTranscriptMessageChanged
 }

--- a/handshaker_13_test.go
+++ b/handshaker_13_test.go
@@ -4,13 +4,16 @@
 package dtls
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,6 +128,26 @@ func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)
 }
 
+func TestHandshakeFSM13PrepareHelloRetryRequestDoesNotRequireSeededTranscript(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &State{
+		localVersion: protocol.Version1_3,
+		cipherSuite:  cfg.localCipherSuites[0],
+	}
+	cache := newHandshakeCache()
+
+	fsm, err := newHandshakeFSM13(state, cache, cfg, flight13_2, nil, nil)
+	require.NoError(t, err)
+
+	nextState, err := fsm.prepare(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, handshakeSending, nextState)
+	require.Len(t, fsm.flights, 1)
+	assert.Empty(t, fsm.transcript.order)
+	assert.Empty(t, fsm.transcript.transcript)
+	assert.Equal(t, 1, state.handshakeSendSequence)
+}
+
 func canonicalPacketHandshake13(t *testing.T, p *packet) []byte {
 	t.Helper()
 
@@ -164,5 +187,125 @@ func testHandshakeConfig13(t *testing.T) *handshakeConfig {
 		localSignatureSchemes:       signaturehash.Algorithms13(),
 		localCertSignatureSchemes:   nil,
 		localSRTPProtectionProfiles: nil,
+	}
+}
+
+func TestAppendOutboundHandshakeFlight13ClientHello(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 3)
+	expected := canonicalPacketHandshake13(t, pkt)
+
+	err := appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{pkt})
+	require.NoError(t, err)
+	require.Len(t, transcript.order, 1)
+	require.Len(t, transcript.pending, 1)
+
+	assert.Equal(t, transcriptMessageID13{sender: transcriptClient13, seq: 3}, transcript.order[0].id)
+	assert.Equal(t, handshake.TypeClientHello, transcript.order[0].typ)
+	assert.Equal(t, expected, transcript.pending[0])
+	assert.Equal(t, expected, transcript.transcript)
+}
+
+func TestAppendOutboundHandshakeFlight13DuplicateNoop(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
+
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{pkt}))
+	before := append([]byte(nil), transcript.transcript...)
+
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{pkt}))
+	assert.Equal(t, before, transcript.transcript)
+	assert.Len(t, transcript.order, 1)
+}
+
+func TestAppendOutboundHandshakeFlight13ChangedSameSequenceFails(t *testing.T) {
+	transcript := newHandshakeTranscript13()
+	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
+	changedPkt := transcriptTestClientHelloPacket13([]byte{0x02}, 0)
+
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{pkt}))
+	err := appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{changedPkt})
+
+	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMessageChanged)
+}
+
+func TestAppendOutboundHandshakeFlight13HelloRetryRequest(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cipherSuite := cfg.localCipherSuites[0]
+	transcript := newHandshakeTranscript13()
+	clientHello := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
+	helloRetryRequest := transcriptTestHelloRetryRequestPacket13(t, cipherSuite, 0)
+
+	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello)
+	helloRetryRequestCanonical := canonicalPacketHandshake13(t, helloRetryRequest)
+
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, cipherSuite, []*packet{clientHello}))
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, false, cipherSuite, []*packet{helloRetryRequest}))
+
+	clientHelloHash := hashTranscript13(clientHelloCanonical)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHelloHash)
+	expectedTranscript := append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...)
+	assert.Equal(t, expectedTranscript, transcript.transcript)
+
+	sum, err := transcript.sum()
+	require.NoError(t, err)
+	assert.Equal(t, hashTranscript13(messageHash, helloRetryRequestCanonical), sum)
+	require.Len(t, transcript.order, 2)
+	assert.Equal(t, handshake.TypeClientHello, transcript.order[0].typ)
+	assert.Equal(t, handshake.TypeServerHello, transcript.order[1].typ)
+
+	before := append([]byte(nil), transcript.transcript...)
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, false, cipherSuite, []*packet{helloRetryRequest}))
+	assert.Equal(t, before, transcript.transcript)
+	assert.Len(t, transcript.order, 2)
+}
+
+func transcriptTestClientHelloPacket13(sessionID []byte, seq uint16) *packet {
+	return &packet{
+		record: &recordlayer.RecordLayer{
+			Header: recordlayer.Header{
+				Version: protocol.Version1_2,
+			},
+			Content: &handshake.Handshake{
+				Header: handshake.Header{MessageSequence: seq},
+				Message: &handshake.MessageClientHello{
+					Version:            protocol.Version1_2,
+					SessionID:          sessionID,
+					CipherSuiteIDs:     []uint16{uint16(TLS_AES_128_GCM_SHA256)},
+					CompressionMethods: defaultCompressionMethods(),
+				},
+			},
+		},
+	}
+}
+
+func transcriptTestHelloRetryRequestPacket13(tb testing.TB, cipherSuite CipherSuite, seq uint16) *packet {
+	tb.Helper()
+
+	random := handshake.Random{}
+	random.UnmarshalFixed([32]byte(handshake.HelloRetryRequestRandom()))
+	cipherSuiteID := uint16(cipherSuite.ID())
+
+	return &packet{
+		record: &recordlayer.RecordLayer{
+			Header: recordlayer.Header{
+				Version: protocol.Version1_2,
+			},
+			Content: &handshake.Handshake{
+				Header: handshake.Header{MessageSequence: seq},
+				Message: &handshake.MessageServerHello{
+					Version:           protocol.Version1_2,
+					Random:            random,
+					CipherSuiteID:     &cipherSuiteID,
+					CompressionMethod: defaultCompressionMethods()[0],
+					Extensions: []extension.Extension{
+						&extension.SupportedVersions{
+							Versions:        []protocol.Version{protocol.Version1_3},
+							SelectedVersion: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
#### Description
transcript append helpers for outbound handshake messages and populate cipher suite and compression method fields for HelloRetryRequest ServerHello. 
#### Reference issue
1/2 part of #851 and blocks cipher suites and record work. refs #727 
