### PR TITLE
Append inbound handshakes to transcript

### DIFF
--- a/flighthandlers_client_13.go
+++ b/flighthandlers_client_13.go
@@ -78,6 +78,34 @@ func validateHelloRetryRequestSelectedVersion(extensions []extension.Extension) 
 	return nil
 }
 
+func selectServerHelloCipherSuite13(
+	serverHello *handshake.MessageServerHello,
+	cfg *handshakeConfig,
+) (CipherSuite, *alert.Alert, error) {
+	if serverHello.CipherSuiteID == nil {
+		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+			dtlserrors.ErrInvalidServerHello
+	}
+	remoteCipherSuite := cipherSuiteForID(CipherSuiteID(*serverHello.CipherSuiteID), cfg.customCipherSuites)
+	if remoteCipherSuite == nil {
+		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity},
+			dtlserrors.ErrCipherSuiteNoIntersection
+	}
+	if !cipherSuiteIDSupportsVersion(remoteCipherSuite.ID(), protocol.Version1_3) {
+		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity},
+			dtlserrors.ErrInvalidCipherSuite
+	}
+	selectedCipherSuite, found := findMatchingCipherSuite(
+		[]CipherSuite{remoteCipherSuite}, cfg.localCipherSuites,
+	)
+	if !found {
+		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity},
+			dtlserrors.ErrInvalidCipherSuite
+	}
+
+	return selectedCipherSuite, nil, nil
+}
+
 // nolint:unused,cyclop
 func flight13_1Parse(
 	ctx context.Context,
@@ -88,7 +116,7 @@ func flight13_1Parse(
 	cache := flightCtx.cache
 	cfg := flightCtx.cfg
 
-	seq, msgs, ok := cache.fullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
+	seq, msgs, items, ok := cache.fullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		handshakeCachePullRule{handshake.TypeServerHello, cfg.initialEpoch, false, true},
 	)
 	if !ok {
@@ -120,6 +148,11 @@ func flight13_1Parse(
 
 		return 0, &alert.Alert{Level: alert.Fatal, Description: description}, err
 	}
+	selectedCipherSuite, dtlsAlert, err := selectServerHelloCipherSuite13(sh, cfg)
+	if err != nil {
+		return 0, dtlsAlert, err
+	}
+	state.CipherSuite = selectedCipherSuite
 
 	// nolint:godox
 	// TODO: negotiate minimial set of extensions necessary for the client
@@ -144,6 +177,9 @@ func flight13_1Parse(
 		}
 	}
 
+	if err := appendInboundHandshakeCacheItems13(flightCtx.transcript, state.CipherSuite, items); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
 	state.HandshakeRecvSequence = seq
 
 	return flight13_3, nil, nil
@@ -155,7 +191,8 @@ func flight13_3Parse(
 	_ flightConn,
 	flightCtx *handshakeContext13,
 ) (flightVal13, *alert.Alert, error) {
-	seq, msgs, ok := flightCtx.cache.fullPullMap(flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
+	seq, msgs, items, ok := flightCtx.cache.fullPullMapItems(
+		flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
 		handshakeCachePullRule{handshake.TypeServerHello, flightCtx.cfg.initialEpoch, false, false},
 	)
 	if !ok {
@@ -188,21 +225,9 @@ func flight13_3Parse(
 	flightCtx.state.RemoteVersions = versions
 	flightCtx.state.LocalVersion = protocol.Version1_3
 
-	if serverHello.CipherSuiteID == nil {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlserrors.ErrInvalidServerHello
-	}
-	remoteCipherSuite := cipherSuiteForID(CipherSuiteID(*serverHello.CipherSuiteID), flightCtx.cfg.customCipherSuites)
-	if remoteCipherSuite == nil {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrCipherSuiteNoIntersection //nolint:lll
-	}
-	if !cipherSuiteIDSupportsVersion(remoteCipherSuite.ID(), protocol.Version1_3) {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrInvalidCipherSuite
-	}
-	selectedCipherSuite, found := findMatchingCipherSuite(
-		[]CipherSuite{remoteCipherSuite}, flightCtx.cfg.localCipherSuites,
-	)
-	if !found {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrInvalidCipherSuite
+	selectedCipherSuite, dtlsAlert, err := selectServerHelloCipherSuite13(serverHello, flightCtx.cfg)
+	if err != nil {
+		return 0, dtlsAlert, err
 	}
 	flightCtx.state.CipherSuite = selectedCipherSuite
 	flightCtx.state.RemoteRandom = serverHello.Random
@@ -235,6 +260,9 @@ func flight13_3Parse(
 	flightCtx.state.NamedCurve = serverShare.Group
 	flightCtx.state.RemoteKeyEntries = &[]extension.KeyShareEntry{*serverShare}
 
+	if err := appendInboundHandshakeCacheItems13(flightCtx.transcript, flightCtx.state.CipherSuite, items); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
 	flightCtx.state.HandshakeRecvSequence = seq
 
 	return flight13_5, nil, nil

--- a/flighthandlers_client_13_test.go
+++ b/flighthandlers_client_13_test.go
@@ -59,6 +59,18 @@ func marshalServerHello(
 ) []byte {
 	t.Helper()
 
+	return marshalServerHelloWithSequence(t, cfg, random, extensions, 0)
+}
+
+func marshalServerHelloWithSequence(
+	t *testing.T,
+	cfg *handshakeConfig,
+	random handshake.Random,
+	extensions []extension.Extension,
+	seq uint16,
+) []byte {
+	t.Helper()
+
 	cipherSuiteID := uint16(cfg.localCipherSuites[0].ID())
 	serverHello := &handshake.MessageServerHello{
 		Version:           protocol.Version1_2,
@@ -67,7 +79,10 @@ func marshalServerHello(
 		CompressionMethod: defaultCompressionMethods()[0],
 		Extensions:        extensions,
 	}
-	rawServerHello, err := (&handshake.Handshake{Message: serverHello}).Marshal()
+	rawServerHello, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: seq},
+		Message: serverHello,
+	}).Marshal()
 	require.NoError(t, err)
 
 	return rawServerHello
@@ -655,6 +670,145 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, state.PreMasterSecret)
 	assert.NotEmpty(t, state.PreMasterSecret)
+}
+
+func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &dtlsstate.State{}
+	transcript := newHandshakeTranscript13()
+
+	pkts, dtlsAlert, err := flight13_1Generate(nil, &handshakeContext13{
+		state:      state,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	appended, err := appendClientHelloInitialFlights13(transcript, pkts)
+	require.NoError(t, err)
+	require.True(t, appended)
+	clientHelloCanonical := canonicalPacketHandshake13(t, pkts[0])
+
+	group := cfg.ellipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
+		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
+	}, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
+	require.NoError(t, err)
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_1Parse(context.Background(), nil, &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_5, nextFlight)
+	assert.Equal(t, []transcriptMessage13{
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 0}, typ: handshake.TypeClientHello},
+		{id: transcriptMessageID13{sender: transcriptServer13, seq: 0}, typ: handshake.TypeServerHello},
+	}, transcript.order)
+	assert.Equal(t, append(append([]byte(nil), clientHelloCanonical...), serverHelloCanonical...), transcript.transcript)
+}
+
+func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &dtlsstate.State{}
+	transcript := newHandshakeTranscript13()
+
+	pkts, dtlsAlert, err := flight13_1Generate(nil, &handshakeContext13{
+		state:      state,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	appended, err := appendClientHelloInitialFlights13(transcript, pkts)
+	require.NoError(t, err)
+	require.True(t, appended)
+	clientHello1Canonical := canonicalPacketHandshake13(t, pkts[0])
+
+	group := cfg.ellipticCurves[0]
+	rawHelloRetryRequest := marshalHelloRetryRequestServerHello(t, cfg, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{SelectedGroup: &group},
+	})
+	helloRetryRequestCanonical, err := canonicalHandshake13(rawHelloRetryRequest)
+	require.NoError(t, err)
+
+	cache := newHandshakeCache()
+	cache.push(rawHelloRetryRequest, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
+	nextFlight, dtlsAlert, err := flight13_1Parse(context.Background(), nil, &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_3, nextFlight)
+
+	clientHello2, dtlsAlert, err := flight13_3Generate(nil, &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, clientHello2, 1)
+	clientHello2Handshake, ok := clientHello2[0].record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	clientHello2Handshake.Header.MessageSequence = 1
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, state.CipherSuite, clientHello2))
+	clientHello2Canonical := canonicalPacketHandshake13(t, clientHello2[0])
+
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+	rawServerHello := marshalServerHelloWithSequence(
+		t,
+		cfg,
+		handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x02}},
+		[]extension.Extension{
+			&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+			&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+		},
+		1,
+	)
+	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
+	require.NoError(t, err)
+	cache.push(rawServerHello, cfg.initialEpoch, 1, handshake.TypeServerHello, false)
+
+	nextFlight, dtlsAlert, err = flight13_3Parse(context.Background(), nil, &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_5, nextFlight)
+
+	clientHello1Hash := hashTranscript13(clientHello1Canonical)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
+	expectedTranscript := append(append(append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...),
+		clientHello2Canonical...), serverHelloCanonical...)
+	assert.Equal(t, []transcriptMessage13{
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 0}, typ: handshake.TypeClientHello},
+		{id: transcriptMessageID13{sender: transcriptServer13, seq: 0}, typ: handshake.TypeServerHello},
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 1}, typ: handshake.TypeClientHello},
+		{id: transcriptMessageID13{sender: transcriptServer13, seq: 1}, typ: handshake.TypeServerHello},
+	}, transcript.order)
+	assert.Equal(t, expectedTranscript, transcript.transcript)
 }
 
 func TestFlight13_3ParseKeepsReadingWithoutServerHello(t *testing.T) {

--- a/flighthandlers_server_13.go
+++ b/flighthandlers_server_13.go
@@ -165,7 +165,7 @@ func flight13_0Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
 			dtlserrors.ErrInvalidProtocolVersionState
 	}
-	seq, msgs, ok := cache.fullPullMap(0, state.CipherSuite,
+	seq, msgs, items, ok := cache.fullPullMapItems(0, state.CipherSuite,
 		handshakeCachePullRule{handshake.TypeClientHello, cfg.initialEpoch, true, false},
 	)
 	if !ok {
@@ -267,6 +267,10 @@ func flight13_0Parse(
 		nextFlight = flight13_4
 	}
 
+	if err := appendInboundHandshakeCacheItems13(flightCtx.transcript, state.CipherSuite, items); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
+
 	return nextFlight, nil, nil
 }
 
@@ -304,7 +308,8 @@ func flight13_2Parse(
 	_ flightConn,
 	flightCtx *handshakeContext13,
 ) (flightVal13, *alert.Alert, error) {
-	seq, msgs, ok := flightCtx.cache.fullPullMap(flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
+	seq, msgs, items, ok := flightCtx.cache.fullPullMapItems(
+		flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
 		handshakeCachePullRule{handshake.TypeClientHello, flightCtx.cfg.initialEpoch, true, false},
 	)
 	if !ok {
@@ -339,6 +344,9 @@ func flight13_2Parse(
 
 	if failure := processClientHello13Extensions(flightCtx.state, flightCtx.cfg, clientHello); failure != nil {
 		return 0, failure.alert, failure.err
+	}
+	if err := appendInboundHandshakeCacheItems13(flightCtx.transcript, flightCtx.state.CipherSuite, items); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
 	flightCtx.state.HandshakeRecvSequence = seq
 

--- a/flighthandlers_server_13_test.go
+++ b/flighthandlers_server_13_test.go
@@ -119,7 +119,7 @@ func pushFlight13_0ClientHello(
 	cache *handshakeCache,
 	cfg *handshakeConfig,
 	exts []extension.Extension,
-) {
+) []byte {
 	t.Helper()
 
 	clientHello := &handshake.MessageClientHello{
@@ -135,6 +135,8 @@ func pushFlight13_0ClientHello(
 	require.NoError(t, err)
 
 	cache.push(rawClientHello, cfg.initialEpoch, 0, handshake.TypeClientHello, true)
+
+	return rawClientHello
 }
 
 func requiredClientHello13Extensions(t *testing.T, cfg *handshakeConfig) []extension.Extension {
@@ -271,6 +273,85 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
 		assert.Zero(t, nextFlight)
 	})
+}
+
+func TestFlight13ServerParseAppendsNoHRRTranscriptOrder(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cfg.insecureSkipHelloVerify = true
+	state := &dtlsstate.State{LocalVersion: protocol.Version1_3}
+	cache := newHandshakeCache()
+	rawClientHello := pushFlight13_0ClientHello(t, cache, cfg, requiredClientHello13Extensions(t, cfg))
+	clientHelloCanonical, err := canonicalHandshake13(rawClientHello)
+	require.NoError(t, err)
+	transcript := newHandshakeTranscript13()
+
+	nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_4, nextFlight)
+	assert.Equal(t, []transcriptMessage13{
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 0}, typ: handshake.TypeClientHello},
+	}, transcript.order)
+	assert.Equal(t, clientHelloCanonical, transcript.transcript)
+}
+
+func TestFlight13ServerParseAppendsHRRTranscriptOrder(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cookie := []byte{0xde, 0xad, 0xbe, 0xef}
+	state := &dtlsstate.State{
+		LocalVersion: protocol.Version1_3,
+		Cookie:       cookie,
+	}
+	cache := newHandshakeCache()
+	rawClientHello1 := pushFlight13_0ClientHello(t, cache, cfg, requiredClientHello13Extensions(t, cfg))
+	clientHello1Canonical, err := canonicalHandshake13(rawClientHello1)
+	require.NoError(t, err)
+	transcript := newHandshakeTranscript13()
+	flightCtx := &handshakeContext13{
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
+	}
+
+	nextFlight, dtlsAlert, err := flight13_0Parse(context.Background(), nil, flightCtx)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_2, nextFlight)
+
+	helloRetryRequest, dtlsAlert, err := flight13_2Generate(nil, flightCtx)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, helloRetryRequest, 1)
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, false, state.CipherSuite, helloRetryRequest))
+	helloRetryRequestCanonical := canonicalPacketHandshake13(t, helloRetryRequest[0])
+
+	exts := append(requiredClientHello13Extensions(t, cfg), &extension.CookieExt{Cookie: cookie})
+	rawClientHello2 := pushClientHello13WithSequence(t, cache, protocol.Version1_2, 1, exts)
+	clientHello2Canonical, err := canonicalHandshake13(rawClientHello2)
+	require.NoError(t, err)
+
+	nextFlight, dtlsAlert, err = flight13_2Parse(context.Background(), nil, flightCtx)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, flight13_4, nextFlight)
+
+	clientHello1Hash := hashTranscript13(clientHello1Canonical)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
+	expectedTranscript := append(append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...),
+		clientHello2Canonical...)
+	assert.Equal(t, []transcriptMessage13{
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 0}, typ: handshake.TypeClientHello},
+		{id: transcriptMessageID13{sender: transcriptServer13, seq: 0}, typ: handshake.TypeServerHello},
+		{id: transcriptMessageID13{sender: transcriptClient13, seq: 1}, typ: handshake.TypeClientHello},
+	}, transcript.order)
+	assert.Equal(t, expectedTranscript, transcript.transcript)
 }
 
 func serverHelloFromFlight13_2(
@@ -469,8 +550,20 @@ func pushClientHello13(
 ) {
 	t.Helper()
 
+	pushClientHello13WithSequence(t, cache, version, 0, exts)
+}
+
+func pushClientHello13WithSequence(
+	t *testing.T,
+	cache *handshakeCache,
+	version protocol.Version,
+	seq uint16,
+	exts []extension.Extension,
+) []byte {
+	t.Helper()
+
 	content := &handshake.Handshake{
-		Header: handshake.Header{MessageSequence: 0},
+		Header: handshake.Header{MessageSequence: seq},
 		Message: &handshake.MessageClientHello{
 			Version:            version,
 			Random:             handshake.Random{},
@@ -483,7 +576,9 @@ func pushClientHello13(
 	raw, err := content.Marshal()
 	require.NoError(t, err)
 
-	cache.push(raw, 0, 0, handshake.TypeClientHello, true)
+	cache.push(raw, 0, seq, handshake.TypeClientHello, true)
+
+	return raw
 }
 
 func flight13_2Context(state *dtlsstate.State, cache *handshakeCache, cfg *handshakeConfig) *handshakeContext13 {

--- a/handshake_cache.go
+++ b/handshake_cache.go
@@ -72,67 +72,117 @@ func (h *handshakeCache) pull(rules ...handshakeCachePullRule) []*handshakeCache
 }
 
 // fullPullMap pulls all handshakes between rules[0] to rules[len(rules)-1] as map.
-//
-//nolint:cyclop
 func (h *handshakeCache) fullPullMap(
 	startSeq int,
 	cipherSuite CipherSuite,
 	rules ...handshakeCachePullRule,
 ) (int, map[handshake.Type]handshake.Message, bool) {
+	seq, msgs, _, ok := h.fullPullMapItems(startSeq, cipherSuite, rules...)
+
+	return seq, msgs, ok
+}
+
+func (h *handshakeCache) fullPullMapItems(
+	startSeq int,
+	cipherSuite CipherSuite,
+	rules ...handshakeCachePullRule,
+) (int, map[handshake.Type]handshake.Message, []*handshakeCacheItem, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	ci := make(map[handshake.Type]*handshakeCacheItem)
-	for _, rule := range rules {
-		var item *handshakeCacheItem
-		for _, c := range h.cache {
-			if c.typ == rule.typ && c.isClient == rule.isClient && c.epoch == rule.epoch {
-				switch {
-				case item == nil:
-					item = c
-				case item.messageSequence < c.messageSequence:
-					item = c
-				}
-			}
-		}
-		if !rule.optional && item == nil {
-			// Missing mandatory message.
-			return startSeq, nil, false
-		}
-		ci[rule.typ] = item
+	ci, ok := h.pullLastCacheItems(rules)
+	if !ok {
+		return startSeq, nil, nil, false
 	}
-	out := make(map[handshake.Type]handshake.Message)
-	seq := startSeq
-	ok := false
-	for _, r := range rules {
-		typ := r.typ
-		i := ci[typ]
-		if i == nil {
+
+	return fullPullMapCacheItems(startSeq, cipherSuite, rules, ci)
+}
+
+func (h *handshakeCache) pullLastCacheItems(rules []handshakeCachePullRule) ([]*handshakeCacheItem, bool) {
+	items := make([]*handshakeCacheItem, len(rules))
+	for i, rule := range rules {
+		items[i] = h.lastCacheItemForRule(rule)
+		if !rule.optional && items[i] == nil {
+			return nil, false
+		}
+	}
+
+	return items, true
+}
+
+func (h *handshakeCache) lastCacheItemForRule(rule handshakeCachePullRule) *handshakeCacheItem {
+	var last *handshakeCacheItem
+	for _, c := range h.cache {
+		if !cacheItemMatchesRule(c, rule) {
 			continue
 		}
-		var keyExchangeAlgorithm CipherSuiteKeyExchangeAlgorithm
-		if cipherSuite != nil {
-			keyExchangeAlgorithm = cipherSuite.KeyExchangeAlgorithm()
+		if last == nil || last.messageSequence < c.messageSequence {
+			last = c
 		}
-		rawHandshake := &handshake.Handshake{
-			KeyExchangeAlgorithm: keyExchangeAlgorithm,
+	}
+
+	return last
+}
+
+func cacheItemMatchesRule(item *handshakeCacheItem, rule handshakeCachePullRule) bool {
+	return item.typ == rule.typ && item.isClient == rule.isClient && item.epoch == rule.epoch
+}
+
+func fullPullMapCacheItems(
+	startSeq int,
+	cipherSuite CipherSuite,
+	rules []handshakeCachePullRule,
+	ci []*handshakeCacheItem,
+) (int, map[handshake.Type]handshake.Message, []*handshakeCacheItem, bool) {
+	out := make(map[handshake.Type]handshake.Message)
+	items := make([]*handshakeCacheItem, 0, len(rules))
+	seq := startSeq
+	keyExchangeAlgorithm := keyExchangeAlgorithmForCipherSuite(cipherSuite)
+	for i, r := range rules {
+		typ := r.typ
+		item := ci[i]
+		if item == nil {
+			continue
 		}
-		if err := rawHandshake.Unmarshal(i.data); err != nil {
-			return startSeq, nil, false
+		rawHandshake, ok := unmarshalCachedHandshake(item, keyExchangeAlgorithm)
+		if !ok {
+			return startSeq, nil, nil, false
 		}
 		if uint16(seq) != rawHandshake.Header.MessageSequence { //nolint:gosec // G115
 			// There is a gap. Some messages are not arrived.
-			return startSeq, nil, false
+			return startSeq, nil, nil, false
 		}
 		seq++
-		ok = true
 		out[typ] = rawHandshake.Message
+		items = append(items, item)
 	}
-	if !ok {
-		return seq, nil, false
+	if len(items) == 0 {
+		return seq, nil, nil, false
 	}
 
-	return seq, out, true
+	return seq, out, items, true
+}
+
+func keyExchangeAlgorithmForCipherSuite(cipherSuite CipherSuite) CipherSuiteKeyExchangeAlgorithm {
+	if cipherSuite == nil {
+		return 0
+	}
+
+	return cipherSuite.KeyExchangeAlgorithm()
+}
+
+func unmarshalCachedHandshake(
+	item *handshakeCacheItem,
+	keyExchangeAlgorithm CipherSuiteKeyExchangeAlgorithm,
+) (*handshake.Handshake, bool) {
+	rawHandshake := &handshake.Handshake{
+		KeyExchangeAlgorithm: keyExchangeAlgorithm,
+	}
+	if err := rawHandshake.Unmarshal(item.data); err != nil {
+		return nil, false
+	}
+
+	return rawHandshake, true
 }
 
 // pullAndMerge calls pull and then merges the results, ignoring any null entries.

--- a/handshake_cache_test.go
+++ b/handshake_cache_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandshakeCacheSinglePush(t *testing.T) {
@@ -123,6 +125,49 @@ func TestHandshakeCacheSinglePush(t *testing.T) {
 		verifyData := h.pullAndMerge(test.Rule...)
 		assert.Equal(t, test.Expected, verifyData)
 	}
+}
+
+func TestHandshakeCacheFullPullMapItemsReturnsAcceptedRawItems(t *testing.T) {
+	cipherSuiteID := uint16(TLS_AES_128_GCM_SHA256)
+	rawClientHello := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CipherSuiteIDs:     []uint16{uint16(TLS_AES_128_GCM_SHA256)},
+		CompressionMethods: defaultCompressionMethods(),
+	})
+	rawServerHello := marshalHandshakeCacheTestMessage(t, 1, &handshake.MessageServerHello{
+		Version:           protocol.Version1_2,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: defaultCompressionMethods()[0],
+	})
+
+	cache := newHandshakeCache()
+	cache.push(rawServerHello, 0, 1, handshake.TypeServerHello, false)
+	cache.push(rawClientHello, 0, 0, handshake.TypeClientHello, true)
+
+	seq, msgs, items, ok := cache.fullPullMapItems(0, nil,
+		handshakeCachePullRule{handshake.TypeClientHello, 0, true, false},
+		handshakeCachePullRule{handshake.TypeServerHello, 0, false, false},
+	)
+
+	require.True(t, ok)
+	assert.Equal(t, 2, seq)
+	require.IsType(t, &handshake.MessageClientHello{}, msgs[handshake.TypeClientHello])
+	require.IsType(t, &handshake.MessageServerHello{}, msgs[handshake.TypeServerHello])
+	require.Len(t, items, 2)
+	assert.Equal(t, rawClientHello, items[0].data)
+	assert.Equal(t, rawServerHello, items[1].data)
+}
+
+func marshalHandshakeCacheTestMessage(t *testing.T, seq uint16, message handshake.Message) []byte {
+	t.Helper()
+
+	raw, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: seq},
+		Message: message,
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
 }
 
 func TestHandshakeCacheSessionHash(t *testing.T) {

--- a/handshaker_13.go
+++ b/handshaker_13.go
@@ -358,11 +358,60 @@ func appendOutboundHandshake13(
 	h *handshake.Handshake,
 	canonical []byte,
 ) error {
+	return appendHandshake13(transcript, sender, cipherSuite, h.Header.MessageSequence, h.Message, canonical)
+}
+
+func appendInboundHandshakeCacheItems13(
+	transcript *handshakeTranscript13,
+	cipherSuite CipherSuite,
+	items []*handshakeCacheItem,
+) error {
+	if transcript == nil {
+		return nil
+	}
+
+	keyExchangeAlgorithm := keyExchangeAlgorithmForCipherSuite(cipherSuite)
+	for _, item := range items {
+		canonical, err := canonicalHandshake13(item.data)
+		if err != nil {
+			return err
+		}
+
+		h := &handshake.Handshake{
+			KeyExchangeAlgorithm: keyExchangeAlgorithm,
+		}
+		if err := h.Unmarshal(item.data); err != nil {
+			return err
+		}
+
+		if err := appendHandshake13(
+			transcript,
+			transcriptSenderForSide13(item.isClient),
+			cipherSuite,
+			h.Header.MessageSequence,
+			h.Message,
+			canonical,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func appendHandshake13(
+	transcript *handshakeTranscript13,
+	sender transcriptSender13,
+	cipherSuite CipherSuite,
+	seq uint16,
+	message handshake.Message,
+	canonical []byte,
+) error {
 	id := transcriptMessageID13{
 		sender: sender,
-		seq:    h.Header.MessageSequence,
+		seq:    seq,
 	}
-	if sh, ok := h.Message.(*handshake.MessageServerHello); ok && isHelloRetryRequest(sh) {
+	if sh, ok := message.(*handshake.MessageServerHello); ok && isHelloRetryRequest(sh) {
 		duplicate, err := transcript.hasCanonical13(id, canonical)
 		if err != nil || duplicate {
 			return err


### PR DESCRIPTION
#### Description

Resolves #851 and unblocks the work on consuming the transcript for traffic secrets and CertificateVerify, and unblocks cipher suites and other work.

also part of https://github.com/pion/dtls/issues/825 refs #727 