### PR TITLE
Wait for clientErr before closing the server connection

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -3053,8 +3053,8 @@ func TestMultipleServerCertificates(t *testing.T) {
 				WithCertificates(fooCert, barCert),
 			}, false)
 			assert.NoError(t, err)
-			assert.NoError(t, s.Close())
 			assert.NoError(t, <-clientErr)
+			assert.NoError(t, s.Close())
 			assert.NoError(t, (<-client).Close())
 		})
 	}


### PR DESCRIPTION
#### Description
Fixes a racy test that breaks the CI all the time.
