### PR TITLE
Derive handshake  secrets from transcript

### DIFF
--- a/flighthandlers_client_13.go
+++ b/flighthandlers_client_13.go
@@ -263,6 +263,9 @@ func flight13_3Parse(
 	if err := appendInboundHandshakeCacheItems13(flightCtx.transcript, flightCtx.state.CipherSuite, items); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
+	if err := deriveAndStoreHandshakeTrafficSecrets13(flightCtx.state, flightCtx.transcript); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
 	flightCtx.state.HandshakeRecvSequence = seq
 
 	return flight13_5, nil, nil

--- a/flighthandlers_client_13_test.go
+++ b/flighthandlers_client_13_test.go
@@ -629,8 +629,12 @@ func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T)
 func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := &dtlsstate.State{}
-	_, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
+	transcript := newHandshakeTranscript13()
+	clientHello, _, err := flight13_1Generate(nil, &handshakeContext13{state: state, cfg: cfg})
 	require.NoError(t, err)
+	appended, err := appendClientHelloInitialFlights13(transcript, clientHello)
+	require.NoError(t, err)
+	require.True(t, appended)
 
 	group := cfg.ellipticCurves[0]
 	serverKeypair, err := elliptic.GenerateKeypair(group)
@@ -645,9 +649,10 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	cache := newHandshakeCache()
 	cache.push(rawServerHello, cfg.initialEpoch, 0, handshake.TypeServerHello, false)
 	nextFlight, dtlsAlert, err := flight13_3Parse(context.Background(), nil, &handshakeContext13{
-		state: state,
-		cache: cache,
-		cfg:   cfg,
+		state:      state,
+		cache:      cache,
+		cfg:        cfg,
+		transcript: transcript,
 	})
 
 	require.NoError(t, err)
@@ -670,6 +675,12 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, state.PreMasterSecret)
 	assert.NotEmpty(t, state.PreMasterSecret)
+	transcriptHash, err := transcript.sum()
+	require.NoError(t, err)
+	expectedSecrets, err := deriveHandshakeTrafficSecrets13(state.CipherSuite.HashFunc(), expected, transcriptHash)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSecrets, state.HandshakeTrafficSecrets13)
+	assert.NotEqual(t, state.HandshakeTrafficSecrets13.Client, state.HandshakeTrafficSecrets13.Server)
 }
 
 func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {

--- a/handshake_transcript_13.go
+++ b/handshake_transcript_13.go
@@ -4,15 +4,29 @@
 package dtls
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"hash"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
+	"github.com/pion/dtls/v3/pkg/crypto/keyschedule"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 const tlsHandshakeHeaderLength13 = 4
+
+const (
+	clientHandshakeTrafficLabel13 = "c hs traffic"
+	serverHandshakeTrafficLabel13 = "s hs traffic"
+	derivedSecretLabel13          = "derived"
+	finishedLabel13               = "finished"
+
+	serverCertificateVerifyContext13 = "TLS 1.3, server CertificateVerify\x00"
+	clientCertificateVerifyContext13 = "TLS 1.3, client CertificateVerify\x00"
+	certificateVerifyPaddingLen13    = 64
+)
 
 type transcriptSender13 uint8
 
@@ -165,14 +179,17 @@ func (t *handshakeTranscript13) sumWithSuffix(suffix []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
+func (t *handshakeTranscript13) hasInitialClientHello13() bool {
+	return len(t.order) == 1 &&
+		t.order[0].id.sender == transcriptClient13 &&
+		t.order[0].typ == handshake.TypeClientHello
+}
+
 func (t *handshakeTranscript13) applyHelloRetryRequest() error {
 	if t.h == nil {
 		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
 	}
-	if t.helloRetryApplied ||
-		len(t.order) != 1 ||
-		t.order[0].id.sender != transcriptClient13 ||
-		t.order[0].typ != handshake.TypeClientHello {
+	if t.helloRetryApplied || !t.hasInitialClientHello13() {
 		return dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid
 	}
 
@@ -205,4 +222,193 @@ func validateCanonicalHandshake13(message []byte) error {
 	}
 
 	return nil
+}
+
+func deriveHandshakeTrafficSecrets13(
+	hashFunc func() hash.Hash,
+	preMasterSecret, transcriptHash []byte,
+) (dtlsstate.HandshakeTrafficSecrets13, error) {
+	hashSize, err := hashSize13(hashFunc)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+	if len(preMasterSecret) == 0 || len(transcriptHash) != hashSize {
+		return dtlsstate.HandshakeTrafficSecrets13{}, dtlserrors.ErrLengthMismatch
+	}
+
+	zeroSecret := make([]byte, hashSize)
+	earlySecret, err := keyschedule.HkdfExtract(hashFunc, nil, zeroSecret)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+
+	derivedSecret, err := keyschedule.DeriveSecret(hashFunc, earlySecret, derivedSecretLabel13, nil)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+
+	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, preMasterSecret)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+
+	clientSecret, err := keyschedule.HkdfExpandLabel(
+		hashFunc,
+		handshakeSecret,
+		clientHandshakeTrafficLabel13,
+		transcriptHash,
+		hashSize,
+	)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+
+	serverSecret, err := keyschedule.HkdfExpandLabel(
+		hashFunc,
+		handshakeSecret,
+		serverHandshakeTrafficLabel13,
+		transcriptHash,
+		hashSize,
+	)
+	if err != nil {
+		return dtlsstate.HandshakeTrafficSecrets13{}, err
+	}
+
+	return dtlsstate.HandshakeTrafficSecrets13{
+		Client: clientSecret,
+		Server: serverSecret,
+	}, nil
+}
+
+func deriveAndStoreHandshakeTrafficSecrets13(state *dtlsstate.State, transcript *handshakeTranscript13) error {
+	if state == nil || state.CipherSuite == nil {
+		return dtlserrors.ErrCipherSuiteNotSet
+	}
+	if transcript == nil {
+		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+	if err := selectTranscriptHashIfReady13(transcript, state.CipherSuite); err != nil {
+		return err
+	}
+
+	transcriptHash, err := transcript.sum()
+	if err != nil {
+		return err
+	}
+
+	secrets, err := deriveHandshakeTrafficSecrets13(
+		state.CipherSuite.HashFunc(),
+		state.PreMasterSecret,
+		transcriptHash,
+	)
+	if err != nil {
+		return err
+	}
+	state.HandshakeTrafficSecrets13 = secrets
+
+	return nil
+}
+
+func certificateVerifyInputFromTranscript13(
+	isClient bool,
+	transcript *handshakeTranscript13,
+) ([]byte, error) {
+	if transcript == nil {
+		return nil, dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+
+	transcriptHash, err := transcript.sum()
+	if err != nil {
+		return nil, err
+	}
+
+	return certificateVerifyInput13(isClient, transcriptHash), nil
+}
+
+func certificateVerifyInput13(isClient bool, transcriptHash []byte) []byte {
+	context := serverCertificateVerifyContext13
+	if isClient {
+		context = clientCertificateVerifyContext13
+	}
+
+	out := make([]byte, certificateVerifyPaddingLen13, certificateVerifyPaddingLen13+len(context)+len(transcriptHash))
+	for i := range out {
+		out[i] = 0x20
+	}
+	out = append(out, context...)
+	out = append(out, transcriptHash...)
+
+	return out
+}
+
+func finishedKey13(hashFunc func() hash.Hash, baseKey []byte) ([]byte, error) {
+	hashSize, err := hashSize13(hashFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyschedule.HkdfExpandLabel(hashFunc, baseKey, finishedLabel13, nil, hashSize)
+}
+
+func finishedVerifyDataFromTranscript13(
+	hashFunc func() hash.Hash,
+	baseKey []byte,
+	transcript *handshakeTranscript13,
+) ([]byte, error) {
+	if transcript == nil {
+		return nil, dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+
+	transcriptHash, err := transcript.sum()
+	if err != nil {
+		return nil, err
+	}
+
+	return finishedVerifyData13(hashFunc, baseKey, transcriptHash)
+}
+
+func finishedVerifyData13(hashFunc func() hash.Hash, baseKey, transcriptHash []byte) ([]byte, error) {
+	hashSize, err := hashSize13(hashFunc)
+	if err != nil {
+		return nil, err
+	}
+	if len(transcriptHash) != hashSize {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+
+	finishedKey, err := finishedKey13(hashFunc, baseKey)
+	if err != nil {
+		return nil, err
+	}
+
+	mac := hmac.New(hashFunc, finishedKey)
+	if _, err := mac.Write(transcriptHash); err != nil {
+		return nil, err
+	}
+
+	return mac.Sum(nil), nil
+}
+
+func verifyFinishedData13(hashFunc func() hash.Hash, baseKey, transcriptHash, verifyData []byte) error {
+	expected, err := finishedVerifyData13(hashFunc, baseKey, transcriptHash)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(expected, verifyData) {
+		return dtlserrors.ErrVerifyDataMismatch
+	}
+
+	return nil
+}
+
+func hashSize13(hashFunc func() hash.Hash) (int, error) {
+	if hashFunc == nil {
+		return 0, dtlserrors.ErrKeyScheduleMissingHashFunction
+	}
+	h := hashFunc()
+	if h == nil {
+		return 0, dtlserrors.ErrKeyScheduleMissingHashFunction
+	}
+
+	return h.Size(), nil
 }

--- a/handshake_transcript_13_test.go
+++ b/handshake_transcript_13_test.go
@@ -4,16 +4,19 @@
 package dtls
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"testing"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCanonicalHandshake13(t *testing.T) {
@@ -256,6 +259,177 @@ func TestHandshakeTranscript13HelloRetryRequestErrors(t *testing.T) {
 		err := transcript.applyHelloRetryRequest()
 		assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid)
 	})
+}
+
+func TestDeriveHandshakeTrafficSecrets13NoHRRAndHRR(t *testing.T) {
+	preMasterSecret := bytes.Repeat([]byte{0x42}, sha256.Size)
+
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+	noHRRTranscriptHash := hashTranscript13(clientHello, serverHello)
+
+	noHRRSecrets, err := deriveHandshakeTrafficSecrets13(sha256.New, preMasterSecret, noHRRTranscriptHash)
+	require.NoError(t, err)
+	require.Len(t, noHRRSecrets.Client, sha256.Size)
+	require.Len(t, noHRRSecrets.Server, sha256.Size)
+	assert.NotEqual(t, noHRRSecrets.Client, noHRRSecrets.Server)
+
+	again, err := deriveHandshakeTrafficSecrets13(sha256.New, preMasterSecret, noHRRTranscriptHash)
+	require.NoError(t, err)
+	assert.Equal(t, noHRRSecrets, again)
+
+	clientHello1 := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x03})
+	helloRetryRequest := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x04})
+	clientHello2 := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x05})
+	serverHello2 := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x06})
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, hashTranscript13(clientHello1))
+	hrrTranscriptHash := hashTranscript13(messageHash, helloRetryRequest, clientHello2, serverHello2)
+
+	hrrSecrets, err := deriveHandshakeTrafficSecrets13(sha256.New, preMasterSecret, hrrTranscriptHash)
+	require.NoError(t, err)
+	assert.NotEqual(t, noHRRSecrets.Client, hrrSecrets.Client)
+	assert.NotEqual(t, noHRRSecrets.Server, hrrSecrets.Server)
+
+	changedSecret := append([]byte(nil), preMasterSecret...)
+	changedSecret[0] ^= 0xff
+	changedSecrets, err := deriveHandshakeTrafficSecrets13(sha256.New, changedSecret, noHRRTranscriptHash)
+	require.NoError(t, err)
+	assert.NotEqual(t, noHRRSecrets.Client, changedSecrets.Client)
+	assert.NotEqual(t, noHRRSecrets.Server, changedSecrets.Server)
+}
+
+func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
+	cipherSuite := cipherSuiteForID(TLS_AES_128_GCM_SHA256, nil)
+	state := &dtlsstate.State{
+		CipherSuite:     cipherSuite,
+		PreMasterSecret: bytes.Repeat([]byte{0x11}, sha256.Size),
+	}
+
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+	transcript := newHandshakeTranscript13()
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+
+	require.NoError(t, deriveAndStoreHandshakeTrafficSecrets13(state, transcript))
+
+	transcriptHash, err := transcript.sum()
+	require.NoError(t, err)
+	expected, err := deriveHandshakeTrafficSecrets13(cipherSuite.HashFunc(), state.PreMasterSecret, transcriptHash)
+	require.NoError(t, err)
+	assert.Equal(t, expected, state.HandshakeTrafficSecrets13)
+	assert.NotEmpty(t, state.HandshakeTrafficSecrets13.Client)
+	assert.NotEmpty(t, state.HandshakeTrafficSecrets13.Server)
+}
+
+func TestCertificateVerifyInput13ServerAndClient(t *testing.T) {
+	transcriptHash := bytes.Repeat([]byte{0xa5}, sha256.Size)
+
+	serverInput := certificateVerifyInput13(false, transcriptHash)
+	clientInput := certificateVerifyInput13(true, transcriptHash)
+
+	require.Len(t, serverInput, certificateVerifyPaddingLen13+len(serverCertificateVerifyContext13)+sha256.Size)
+	assert.Equal(t, bytes.Repeat([]byte{0x20}, certificateVerifyPaddingLen13),
+		serverInput[:certificateVerifyPaddingLen13])
+	serverContextEnd := certificateVerifyPaddingLen13 + len(serverCertificateVerifyContext13)
+	serverContext := serverInput[certificateVerifyPaddingLen13:serverContextEnd]
+	assert.Equal(t, serverCertificateVerifyContext13,
+		string(serverContext))
+	assert.Equal(t, transcriptHash, serverInput[len(serverInput)-sha256.Size:])
+
+	require.Len(t, clientInput, certificateVerifyPaddingLen13+len(clientCertificateVerifyContext13)+sha256.Size)
+	clientContextEnd := certificateVerifyPaddingLen13 + len(clientCertificateVerifyContext13)
+	clientContext := clientInput[certificateVerifyPaddingLen13:clientContextEnd]
+	assert.Equal(t, clientCertificateVerifyContext13,
+		string(clientContext))
+	assert.Equal(t, transcriptHash, clientInput[len(clientInput)-sha256.Size:])
+	assert.NotEqual(t, serverInput, clientInput)
+}
+
+func TestFinishedVerifyData13(t *testing.T) {
+	baseKey := bytes.Repeat([]byte{0x11}, sha256.Size)
+	transcriptHash := bytes.Repeat([]byte{0x22}, sha256.Size)
+
+	finishedKey, err := finishedKey13(sha256.New, baseKey)
+	require.NoError(t, err)
+
+	verifyData, err := finishedVerifyData13(sha256.New, baseKey, transcriptHash)
+	require.NoError(t, err)
+	require.Len(t, verifyData, sha256.Size)
+
+	expectedMAC := hmac.New(sha256.New, finishedKey)
+	_, err = expectedMAC.Write(transcriptHash)
+	require.NoError(t, err)
+	assert.Equal(t, expectedMAC.Sum(nil), verifyData)
+	assert.NoError(t, verifyFinishedData13(sha256.New, baseKey, transcriptHash, verifyData))
+
+	changedTranscript := append([]byte(nil), transcriptHash...)
+	changedTranscript[0] ^= 0xff
+	changedVerifyData, err := finishedVerifyData13(sha256.New, baseKey, changedTranscript)
+	require.NoError(t, err)
+	assert.NotEqual(t, verifyData, changedVerifyData)
+
+	changedKey := append([]byte(nil), baseKey...)
+	changedKey[0] ^= 0xff
+	changedKeyVerifyData, err := finishedVerifyData13(sha256.New, changedKey, transcriptHash)
+	require.NoError(t, err)
+	assert.NotEqual(t, verifyData, changedKeyVerifyData)
+
+	badVerifyData := append([]byte(nil), verifyData...)
+	badVerifyData[0] ^= 0xff
+	assert.ErrorIs(t, verifyFinishedData13(sha256.New, baseKey, transcriptHash, badVerifyData),
+		dtlserrors.ErrVerifyDataMismatch)
+}
+
+func TestDTLS13TranscriptAuthenticatedHandshakeInputs(t *testing.T) {
+	cipherSuite := cipherSuiteForID(TLS_AES_128_GCM_SHA256, nil)
+	state := &dtlsstate.State{
+		CipherSuite:     cipherSuite,
+		PreMasterSecret: bytes.Repeat([]byte{0x77}, sha256.Size),
+	}
+	transcript := newHandshakeTranscript13()
+
+	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
+	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptClient13}, clientHello))
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{sender: transcriptServer13}, serverHello))
+
+	require.NoError(t, deriveAndStoreHandshakeTrafficSecrets13(state, transcript))
+	require.NotEmpty(t, state.HandshakeTrafficSecrets13.Client)
+	require.NotEmpty(t, state.HandshakeTrafficSecrets13.Server)
+
+	certificate := canonicalTranscriptHandshake13(handshake.TypeCertificate, []byte{0x03})
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{
+		sender: transcriptServer13,
+		seq:    1,
+	}, certificate))
+
+	certVerifyInput, err := certificateVerifyInputFromTranscript13(false, transcript)
+	require.NoError(t, err)
+	certVerifyTranscriptHash, err := transcript.sum()
+	require.NoError(t, err)
+	assert.Equal(t, certVerifyTranscriptHash, certVerifyInput[len(certVerifyInput)-sha256.Size:])
+
+	certVerify := canonicalTranscriptHandshake13(handshake.TypeCertificateVerify, []byte{0x04})
+	require.NoError(t, transcript.appendCanonical(transcriptMessageID13{
+		sender: transcriptServer13,
+		seq:    2,
+	}, certVerify))
+
+	verifyData, err := finishedVerifyDataFromTranscript13(
+		sha256.New,
+		state.HandshakeTrafficSecrets13.Server,
+		transcript,
+	)
+	require.NoError(t, err)
+	finishedTranscriptHash, err := transcript.sum()
+	require.NoError(t, err)
+	assert.NoError(t, verifyFinishedData13(
+		sha256.New,
+		state.HandshakeTrafficSecrets13.Server,
+		finishedTranscriptHash,
+		verifyData,
+	))
 }
 
 func FuzzCanonicalHandshake13(f *testing.F) {

--- a/handshaker_13.go
+++ b/handshaker_13.go
@@ -248,6 +248,14 @@ func (s *handshakeFSM13) prepare(ctx context.Context, conn flightConn) (handshak
 	}
 
 	s.flights = pkts
+	if err := s.commitPreparedFlights(conn); err != nil {
+		return handshakeErrored, err
+	}
+
+	return handshakeSending, nil
+}
+
+func (s *handshakeFSM13) commitPreparedFlights(conn flightConn) error {
 	epoch := s.cfg.initialEpoch
 	nextEpoch := epoch
 	for _, p := range s.flights {
@@ -260,12 +268,20 @@ func (s *handshakeFSM13) prepare(ctx context.Context, conn flightConn) (handshak
 			s.state.HandshakeSendSequence++
 		}
 	}
+	if err := appendOutboundHandshakeFlight13(
+		s.transcript,
+		s.state.IsClient,
+		s.state.CipherSuite,
+		s.flights,
+	); err != nil {
+		return err
+	}
 	if epoch != nextEpoch {
 		s.cfg.log.Tracef("[handshake13:%s] -> changeCipherSpec (epoch: %d)", srvCliStr(s.state.IsClient), nextEpoch)
 		conn.setLocalEpoch(nextEpoch)
 	}
 
-	return handshakeSending, nil
+	return nil
 }
 
 func (s *handshakeFSM13) send(ctx context.Context, c flightConn) (handshakeState, error) {

--- a/handshaker_13_test.go
+++ b/handshaker_13_test.go
@@ -129,7 +129,7 @@ func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)
 }
 
-func TestHandshakeFSM13PrepareHelloRetryRequestDoesNotRequireSeededTranscript(t *testing.T) {
+func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := &dtlsstate.State{
 		LocalVersion: protocol.Version1_3,
@@ -141,11 +141,63 @@ func TestHandshakeFSM13PrepareHelloRetryRequestDoesNotRequireSeededTranscript(t 
 	require.NoError(t, err)
 
 	nextState, err := fsm.prepare(context.Background(), nil)
-	require.NoError(t, err)
-	assert.Equal(t, handshakeSending, nextState)
+	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid)
+	assert.Equal(t, handshakeErrored, nextState)
 	require.Len(t, fsm.flights, 1)
 	assert.Empty(t, fsm.transcript.order)
 	assert.Empty(t, fsm.transcript.transcript)
+	assert.Equal(t, 1, state.HandshakeSendSequence)
+}
+
+func TestHandshakeFSM13PrepareCommitsOutboundClientHello(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &dtlsstate.State{IsClient: true, LocalVersion: protocol.Version1_3}
+	cache := newHandshakeCache()
+
+	fsm, err := newHandshakeFSM13(state, cache, cfg, flight13_1, nil, nil)
+	require.NoError(t, err)
+
+	nextState, err := fsm.prepare(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, handshakeSending, nextState)
+	require.Len(t, fsm.flights, 1)
+
+	expected := canonicalPacketHandshake13(t, fsm.flights[0])
+	require.Len(t, fsm.transcript.order, 1)
+	assert.Equal(t, transcriptMessageID13{sender: transcriptClient13, seq: 0}, fsm.transcript.order[0].id)
+	assert.Equal(t, handshake.TypeClientHello, fsm.transcript.order[0].typ)
+	assert.Equal(t, expected, fsm.transcript.transcript)
+	assert.Equal(t, 1, state.HandshakeSendSequence)
+}
+
+func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscript(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &dtlsstate.State{
+		LocalVersion: protocol.Version1_3,
+		CipherSuite:  cfg.localCipherSuites[0],
+	}
+	cache := newHandshakeCache()
+	transcript := newHandshakeTranscript13()
+	clientHello := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
+	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello)
+	require.NoError(t, appendOutboundHandshakeFlight13(transcript, true, nil, []*packet{clientHello}))
+
+	fsm, err := newHandshakeFSM13(state, cache, cfg, flight13_2, nil, transcript)
+	require.NoError(t, err)
+
+	nextState, err := fsm.prepare(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, handshakeSending, nextState)
+	require.Len(t, fsm.flights, 1)
+
+	helloRetryRequestCanonical := canonicalPacketHandshake13(t, fsm.flights[0])
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, hashTranscript13(clientHelloCanonical))
+	expectedTranscript := append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...)
+
+	assert.Equal(t, expectedTranscript, fsm.transcript.transcript)
+	require.Len(t, fsm.transcript.order, 2)
+	assert.Equal(t, transcriptMessageID13{sender: transcriptServer13, seq: 0}, fsm.transcript.order[1].id)
+	assert.Equal(t, handshake.TypeServerHello, fsm.transcript.order[1].typ)
 	assert.Equal(t, 1, state.HandshakeSendSequence)
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,6 +18,11 @@ import (
 	"github.com/pion/transport/v4/replaydetector"
 )
 
+type HandshakeTrafficSecrets13 struct {
+	Client []byte
+	Server []byte
+}
+
 type State struct {
 	LocalEpoch, RemoteEpoch   atomic.Value
 	LocalSequenceNumber       []uint64 // uint48
@@ -76,6 +81,9 @@ type State struct {
 	LocalVersion protocol.Version
 	// RemoteVersions are the DTLS versions advertised by the peer
 	RemoteVersions []protocol.Version
+	// HandshakeTrafficSecrets13 are derived from the ECDHE secret and the
+	// transcript through ServerHello. Record protection consumes them later.
+	HandshakeTrafficSecrets13 HandshakeTrafficSecrets13
 	// LocalKeyEntries are the DTLS 1.3 KeyShareEntry values generated locally
 	// and sent in the ClientHello's key_share extension.
 	LocalKeyEntries []extension.KeyShareEntry


### PR DESCRIPTION
#### Description

derives handshake traffic secrets from the post-ServerHello transcript hash. adds helpers for CertificateVerify input and Finished verify data from transcript hashes.
commits outbound DTLS 1.3 handshake messages through the prepare()


This should be the last part of transcript before we're back to cipher update.

part of #852 refs #727 
