### PR TITLE
Add CHACHA20_POLY1305_SHA256 1.3 record primitives

### DIFF
--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -4,28 +4,17 @@
 package ciphersuite
 
 import (
-	"crypto/sha256"
 	"fmt"
-	"hash"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
-// TLS13CipherSuite provides behavior common to TLS 1.3 cipher suites. When
-// used directly, it is metadata for suites whose record protection is not wired
-// yet.
-// this is a temporary struct to be removed when the record protection is wired.
-type TLS13CipherSuite struct {
-	id       ID
-	hashFunc func() hash.Hash
-}
-
-// NewTLSChacha20Poly1305Sha256 returns metadata for TLS_CHACHA20_POLY1305_SHA256.
-func NewTLSChacha20Poly1305Sha256() *TLS13CipherSuite {
-	return &TLS13CipherSuite{id: TLS_CHACHA20_POLY1305_SHA256, hashFunc: sha256.New}
-}
+// TLS13CipherSuite provides behavior common to TLS 1.3 cipher suites. TLS 1.3
+// cipher suites only identify the AEAD and hash; authentication and key
+// exchange are negotiated independently.
+type TLS13CipherSuite struct{}
 
 func (c *TLS13CipherSuite) CertificateType() clientcertificate.Type {
 	return 0
@@ -37,18 +26,6 @@ func (c *TLS13CipherSuite) KeyExchangeAlgorithm() KeyExchangeAlgorithm {
 
 func (c *TLS13CipherSuite) ECC() bool {
 	return true
-}
-
-func (c *TLS13CipherSuite) ID() ID {
-	return c.id
-}
-
-func (c *TLS13CipherSuite) String() string {
-	return c.ID().String()
-}
-
-func (c *TLS13CipherSuite) HashFunc() func() hash.Hash {
-	return c.hashFunc
 }
 
 func (c *TLS13CipherSuite) AuthenticationType() AuthenticationType {
@@ -69,8 +46,4 @@ func (c *TLS13CipherSuite) Encrypt(_ *recordlayer.RecordLayer, _ []byte) ([]byte
 
 func (c *TLS13CipherSuite) Decrypt(_ recordlayer.Header, _ []byte) ([]byte, error) {
 	return nil, fmt.Errorf("%w, unable to decrypt", dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
-}
-
-func (c *TLS13CipherSuite) newRecordProtection(_, _ []byte) (*recordProtection13, error) {
-	return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 }

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/keyschedule"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
+	"golang.org/x/crypto/chacha20"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const (
@@ -26,9 +28,17 @@ const (
 	tls13AES256GCMKeyLen = 32
 	tls13AESGCMTagLen    = 16
 
+	tls13ChaCha20Poly1305KeyLen = chacha20poly1305.KeySize
+	tls13ChaCha20Poly1305TagLen = chacha20poly1305.Overhead
+	tls13ChaCha20BlockLen       = 64
+
+	tls13SequenceNumberMaskSampleLen = 16
+
 	maxDTLSPlaintextRecordLen13  = 1 << 14
 	maxDTLSCiphertextRecordLen13 = maxDTLSPlaintextRecordLen13 + 256
 )
+
+type recordSequenceNumberMaskFunc13 func(sequenceNumberKey, encryptedRecord []byte) ([]byte, error)
 
 type recordTrafficKeys13 struct {
 	key               []byte
@@ -37,9 +47,10 @@ type recordTrafficKeys13 struct {
 }
 
 type recordTrafficProtection13 struct {
-	aead              cipher.AEAD
-	iv                []byte
-	sequenceNumberKey []byte
+	aead               cipher.AEAD
+	iv                 []byte
+	sequenceNumberKey  []byte
+	sequenceNumberMask recordSequenceNumberMaskFunc13
 }
 
 type recordProtection13 struct {
@@ -103,9 +114,52 @@ func newAESGCMRecordTrafficProtection13(
 	}
 
 	return recordTrafficProtection13{
-		aead:              aead,
-		iv:                keys.iv,
-		sequenceNumberKey: keys.sequenceNumberKey,
+		aead:               aead,
+		iv:                 keys.iv,
+		sequenceNumberKey:  keys.sequenceNumberKey,
+		sequenceNumberMask: recordSequenceNumberMaskAES13,
+	}, nil
+}
+
+func newChaCha20Poly1305RecordProtection13(
+	hashFunc func() hash.Hash,
+	localTrafficSecret, remoteTrafficSecret []byte,
+) (*recordProtection13, error) {
+	local, err := newChaCha20Poly1305RecordTrafficProtection13(hashFunc, localTrafficSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	remote, err := newChaCha20Poly1305RecordTrafficProtection13(hashFunc, remoteTrafficSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &recordProtection13{
+		local:  local,
+		remote: remote,
+	}, nil
+}
+
+func newChaCha20Poly1305RecordTrafficProtection13(
+	hashFunc func() hash.Hash,
+	trafficSecret []byte,
+) (recordTrafficProtection13, error) {
+	keys, err := deriveRecordTrafficKeys13(hashFunc, trafficSecret, tls13ChaCha20Poly1305KeyLen)
+	if err != nil {
+		return recordTrafficProtection13{}, err
+	}
+
+	aead, err := chacha20poly1305.New(keys.key)
+	if err != nil {
+		return recordTrafficProtection13{}, err
+	}
+
+	return recordTrafficProtection13{
+		aead:               aead,
+		iv:                 keys.iv,
+		sequenceNumberKey:  keys.sequenceNumberKey,
+		sequenceNumberMask: recordSequenceNumberMaskChaCha20Poly1305TLS13,
 	}, nil
 }
 
@@ -181,11 +235,15 @@ func (r *recordProtection13) open(
 }
 
 func (r *recordProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
-	return recordSequenceNumberMaskAES13(r.local.sequenceNumberKey, encryptedRecord)
+	if r.local.sequenceNumberMask == nil {
+		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+
+	return r.local.sequenceNumberMask(r.local.sequenceNumberKey, encryptedRecord)
 }
 
 func recordSequenceNumberMaskAES13(sequenceNumberKey, encryptedRecord []byte) ([]byte, error) {
-	if len(encryptedRecord) < aes.BlockSize {
+	if len(encryptedRecord) < tls13SequenceNumberMaskSampleLen {
 		return nil, dtlserrors.ErrBufferTooSmall
 	}
 
@@ -196,6 +254,23 @@ func recordSequenceNumberMaskAES13(sequenceNumberKey, encryptedRecord []byte) ([
 
 	mask := make([]byte, aes.BlockSize)
 	block.Encrypt(mask, encryptedRecord[:aes.BlockSize])
+
+	return mask, nil
+}
+
+func recordSequenceNumberMaskChaCha20Poly1305TLS13(sequenceNumberKey, encryptedRecord []byte) ([]byte, error) {
+	if len(encryptedRecord) < tls13SequenceNumberMaskSampleLen {
+		return nil, dtlserrors.ErrBufferTooSmall
+	}
+
+	chacha, err := chacha20.NewUnauthenticatedCipher(sequenceNumberKey, encryptedRecord[4:16])
+	if err != nil {
+		return nil, err
+	}
+
+	chacha.SetCounter(binary.LittleEndian.Uint32(encryptedRecord[:4]))
+	mask := make([]byte, tls13ChaCha20BlockLen)
+	chacha.XORKeyStream(mask, mask)
 
 	return mask, nil
 }

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -6,6 +6,8 @@ package ciphersuite
 import (
 	"bytes"
 	"crypto/aes"
+	"encoding/binary"
+	"encoding/hex"
 	"testing"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -14,12 +16,15 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/chacha20"
 )
 
-type aesGCMRecordProtection13TestCase struct {
-	name   string
-	suite  tls13RecordProtectionSuite
-	keyLen int
+type recordProtection13TestCase struct {
+	name                       string
+	suite                      tls13RecordProtectionSuite
+	keyLen                     int
+	tagLen                     int
+	expectedSequenceNumberMask func(t *testing.T, sequenceNumberKey, encryptedRecord []byte) []byte
 }
 
 type tls13RecordProtectionSuite interface {
@@ -27,19 +32,55 @@ type tls13RecordProtectionSuite interface {
 	newRecordProtection(localTrafficSecret, remoteTrafficSecret []byte) (*recordProtection13, error)
 }
 
-func aesGCMRecordProtection13TestCases() []aesGCMRecordProtection13TestCase {
-	return []aesGCMRecordProtection13TestCase{
+func recordProtection13TestCases() []recordProtection13TestCase {
+	return []recordProtection13TestCase{
 		{
-			name:   "TLS_AES_128_GCM_SHA256",
-			suite:  NewTLSAes128GcmSha256(),
-			keyLen: tls13AES128GCMKeyLen,
+			name:                       "TLS_AES_128_GCM_SHA256",
+			suite:                      NewTLSAes128GcmSha256(),
+			keyLen:                     tls13AES128GCMKeyLen,
+			tagLen:                     tls13AESGCMTagLen,
+			expectedSequenceNumberMask: expectedAESSequenceNumberMask13,
 		},
 		{
-			name:   "TLS_AES_256_GCM_SHA384",
-			suite:  NewTLSAes256GcmSha384(),
-			keyLen: tls13AES256GCMKeyLen,
+			name:                       "TLS_AES_256_GCM_SHA384",
+			suite:                      NewTLSAes256GcmSha384(),
+			keyLen:                     tls13AES256GCMKeyLen,
+			tagLen:                     tls13AESGCMTagLen,
+			expectedSequenceNumberMask: expectedAESSequenceNumberMask13,
+		},
+		{
+			name:                       "TLS_CHACHA20_POLY1305_SHA256",
+			suite:                      NewTLSChacha20Poly1305Sha256(),
+			keyLen:                     tls13ChaCha20Poly1305KeyLen,
+			tagLen:                     tls13ChaCha20Poly1305TagLen,
+			expectedSequenceNumberMask: expectedChaCha20SequenceNumberMask13,
 		},
 	}
+}
+
+func expectedAESSequenceNumberMask13(t *testing.T, sequenceNumberKey, encryptedRecord []byte) []byte {
+	t.Helper()
+
+	block, err := aes.NewCipher(sequenceNumberKey)
+	require.NoError(t, err)
+
+	expectedMask := make([]byte, aes.BlockSize)
+	block.Encrypt(expectedMask, encryptedRecord[:aes.BlockSize])
+
+	return expectedMask
+}
+
+func expectedChaCha20SequenceNumberMask13(t *testing.T, sequenceNumberKey, encryptedRecord []byte) []byte {
+	t.Helper()
+
+	chacha, err := chacha20.NewUnauthenticatedCipher(sequenceNumberKey, encryptedRecord[4:16])
+	require.NoError(t, err)
+	chacha.SetCounter(binary.LittleEndian.Uint32(encryptedRecord[:4]))
+
+	expectedMask := make([]byte, tls13ChaCha20BlockLen)
+	chacha.XORKeyStream(expectedMask, expectedMask)
+
+	return expectedMask
 }
 
 func trafficSecret13(suite tls13RecordProtectionSuite, fill byte) []byte {
@@ -48,8 +89,8 @@ func trafficSecret13(suite tls13RecordProtectionSuite, fill byte) []byte {
 	return bytes.Repeat([]byte{fill}, hashFunc().Size())
 }
 
-func TestDeriveRecordTrafficKeys13AESGCMSuites(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+func TestDeriveRecordTrafficKeys13Suites(t *testing.T) {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			hashFunc := testCase.suite.HashFunc()
 			trafficSecret := trafficSecret13(testCase.suite, 0x3c)
@@ -96,8 +137,8 @@ func TestDeriveRecordTrafficKeys13AESGCMSuites(t *testing.T) {
 	}
 }
 
-func TestTLS13CipherSuiteNewRecordProtectionAESGCMSuites(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+func TestTLS13CipherSuiteNewRecordProtectionSuites(t *testing.T) {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0x5a)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0x6b)
@@ -108,7 +149,7 @@ func TestTLS13CipherSuiteNewRecordProtectionAESGCMSuites(t *testing.T) {
 			require.NotNil(t, protection.remote.aead)
 
 			assert.Equal(t, tls13AEADWriteIVLen, protection.local.aead.NonceSize())
-			assert.Equal(t, tls13AESGCMTagLen, protection.local.aead.Overhead())
+			assert.Equal(t, testCase.tagLen, protection.local.aead.Overhead())
 			require.Len(t, protection.local.iv, tls13AEADWriteIVLen)
 			require.Len(t, protection.remote.iv, tls13AEADWriteIVLen)
 			require.Len(t, protection.local.sequenceNumberKey, testCase.keyLen)
@@ -116,7 +157,7 @@ func TestTLS13CipherSuiteNewRecordProtectionAESGCMSuites(t *testing.T) {
 			assert.NotEqual(t, protection.local.iv, protection.remote.iv)
 			assert.NotEqual(t, protection.local.sequenceNumberKey, protection.remote.sequenceNumberKey)
 
-			plaintext := []byte("dtls13 aes-gcm")
+			plaintext := []byte("dtls13 record protection")
 			additionalData := []byte("synthetic aad")
 			nonce := append([]byte(nil), protection.local.iv...)
 
@@ -130,15 +171,8 @@ func TestTLS13CipherSuiteNewRecordProtectionAESGCMSuites(t *testing.T) {
 	}
 }
 
-func TestTLS13CipherSuiteNewRecordProtectionRejectsChaCha20Poly1305(t *testing.T) {
-	suite := NewTLSChacha20Poly1305Sha256()
-
-	_, err := suite.newRecordProtection(trafficSecret13(suite, 0x5a), trafficSecret13(suite, 0x6b))
-	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
-}
-
 func TestRecordProtection13SealOpenSyntheticTrafficSecret(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xa6)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xb6)
@@ -160,7 +194,7 @@ func TestRecordProtection13SealOpenSyntheticTrafficSecret(t *testing.T) {
 			require.Equal(t, uint16(len(record.EncryptedRecord)), record.Header.Length) //nolint:gosec
 			require.True(t, record.Header.LengthBit)
 			require.True(t, record.Header.SeqBit)
-			require.Len(t, record.EncryptedRecord, len(plaintext)+1+tls13AESGCMTagLen)
+			require.Len(t, record.EncryptedRecord, len(plaintext)+1+testCase.tagLen)
 
 			innerPlaintext, err := peerProtection.open(record.Header, sequenceNumber, record.EncryptedRecord)
 			require.NoError(t, err)
@@ -196,7 +230,7 @@ func TestRecordProtection13SealRejectsOversizedPlaintext(t *testing.T) {
 }
 
 func TestRecordProtection13OpenRejectsWrongAdditionalData(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xb7)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xc7)
@@ -221,7 +255,7 @@ func TestRecordProtection13OpenRejectsWrongAdditionalData(t *testing.T) {
 }
 
 func TestRecordProtection13OpenRejectsWrongSequenceNumber(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xbe)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xce)
@@ -245,7 +279,7 @@ func TestRecordProtection13OpenRejectsWrongSequenceNumber(t *testing.T) {
 }
 
 func TestRecordProtection13SequenceNumberMaskSyntheticTrafficSecret(t *testing.T) {
-	for _, testCase := range aesGCMRecordProtection13TestCases() {
+	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			protection, err := testCase.suite.newRecordProtection(
 				trafficSecret13(testCase.suite, 0xc8),
@@ -263,12 +297,8 @@ func TestRecordProtection13SequenceNumberMaskSyntheticTrafficSecret(t *testing.T
 
 			mask, err := protection.sequenceNumberMask(record.EncryptedRecord)
 			require.NoError(t, err)
-			require.Len(t, mask, aes.BlockSize)
+			expectedMask := testCase.expectedSequenceNumberMask(t, protection.local.sequenceNumberKey, record.EncryptedRecord)
 
-			block, err := aes.NewCipher(protection.local.sequenceNumberKey)
-			require.NoError(t, err)
-			expectedMask := make([]byte, aes.BlockSize)
-			block.Encrypt(expectedMask, record.EncryptedRecord[:aes.BlockSize])
 			assert.Equal(t, expectedMask, mask)
 
 			rawHeader, err := record.Header.Marshal()
@@ -286,12 +316,37 @@ func TestRecordProtection13SequenceNumberMaskSyntheticTrafficSecret(t *testing.T
 }
 
 func TestRecordProtection13SequenceNumberMaskRejectsShortCiphertext(t *testing.T) {
-	suite := NewTLSAes128GcmSha256()
-	protection, err := suite.newRecordProtection(trafficSecret13(suite, 0xd9), trafficSecret13(suite, 0xda))
+	for _, testCase := range recordProtection13TestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			protection, err := testCase.suite.newRecordProtection(
+				trafficSecret13(testCase.suite, 0xd9),
+				trafficSecret13(testCase.suite, 0xda),
+			)
+			require.NoError(t, err)
+
+			_, err = protection.sequenceNumberMask(bytes.Repeat([]byte{0x01}, tls13SequenceNumberMaskSampleLen-1))
+			assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+		})
+	}
+}
+
+func TestRecordSequenceNumberMaskChaCha20RFC8439BlockVector(t *testing.T) {
+	sequenceNumberKey, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+	require.NoError(t, err)
+	encryptedRecord, err := hex.DecodeString("01000000000000090000004a00000000")
 	require.NoError(t, err)
 
-	_, err = protection.sequenceNumberMask(bytes.Repeat([]byte{0x01}, aes.BlockSize-1))
-	assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+	mask, err := recordSequenceNumberMaskChaCha20Poly1305TLS13(sequenceNumberKey, encryptedRecord)
+	require.NoError(t, err)
+
+	expected, err := hex.DecodeString(
+		"10f1e7e4d13b5915500fdd1fa32071c4" +
+			"c7d1f4c733c068030422aa9ac3d46c4e" +
+			"d2826446079faa0914c2d705d98b02a2" +
+			"b5129cd1de164eb9cbd083e8a2503c4e",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expected, mask)
 }
 
 func TestRecordNonce13(t *testing.T) {

--- a/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
+++ b/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package ciphersuite
+
+import (
+	"crypto/sha256"
+	"hash"
+)
+
+// TLSChacha20Poly1305Sha256 represents the TLS_CHACHA20_POLY1305_SHA256 CipherSuite.
+type TLSChacha20Poly1305Sha256 struct {
+	TLS13CipherSuite
+}
+
+// NewTLSChacha20Poly1305Sha256 returns the TLS_CHACHA20_POLY1305_SHA256 CipherSuite.
+func NewTLSChacha20Poly1305Sha256() *TLSChacha20Poly1305Sha256 {
+	return &TLSChacha20Poly1305Sha256{}
+}
+
+// ID returns the ID of the CipherSuite.
+func (c *TLSChacha20Poly1305Sha256) ID() ID {
+	return TLS_CHACHA20_POLY1305_SHA256
+}
+
+func (c *TLSChacha20Poly1305Sha256) String() string {
+	return "TLS_CHACHA20_POLY1305_SHA256"
+}
+
+// HashFunc returns the hashing func for this CipherSuite.
+func (c *TLSChacha20Poly1305Sha256) HashFunc() func() hash.Hash {
+	return sha256.New
+}
+
+func (c *TLSChacha20Poly1305Sha256) newRecordProtection(
+	localTrafficSecret, remoteTrafficSecret []byte,
+) (*recordProtection13, error) {
+	return newChaCha20Poly1305RecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret)
+}


### PR DESCRIPTION
#### Description
TLS_CHACHA20_POLY1305_SHA256 record primitives for dtls 1.3. we'll implement init/encrypt/decrypt as the last PR in the ciphers updates. part of #777 