### PR TITLE
Remove 13 suffix from InitFromTrafficSecrets13

### DIFF
--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -15,7 +15,7 @@ import (
 // CipherSuiteTLS13 is the DTLS 1.3-specific cipher suite surface.
 type CipherSuiteTLS13 interface {
 	CipherSuite
-	InitFromTrafficSecrets13(clientSecret, serverSecret []byte, isClient bool) error
+	InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error
 }
 
 // TLS13CipherSuite provides behavior common to TLS 1.3 cipher suites. TLS 1.3

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -211,7 +211,7 @@ func TestTLS13CipherSuiteNewRecordProtectionSuites(t *testing.T) {
 	}
 }
 
-func TestTLS13CipherSuiteInitFromTrafficSecrets13(t *testing.T) {
+func TestTLS13CipherSuiteInitFromTrafficSecrets(t *testing.T) {
 	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			clientSuite := testCase.suite
@@ -223,8 +223,8 @@ func TestTLS13CipherSuiteInitFromTrafficSecrets13(t *testing.T) {
 			require.False(t, clientSuite.IsInitialized())
 			require.False(t, serverSuite.IsInitialized())
 
-			require.NoError(t, clientSuite.InitFromTrafficSecrets13(clientSecret, serverSecret, true))
-			require.NoError(t, serverSuite.InitFromTrafficSecrets13(clientSecret, serverSecret, false))
+			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
+			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
 
 			require.True(t, clientSuite.IsInitialized())
 			require.True(t, serverSuite.IsInitialized())

--- a/internal/ciphersuite/tls_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_aes_128_gcm_sha256.go
@@ -32,9 +32,9 @@ func (c *TLSAes128GcmSha256) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// InitFromTrafficSecrets13 initializes DTLS 1.3 record protection from the
+// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
 // negotiated client and server handshake/application traffic secrets.
-func (c *TLSAes128GcmSha256) InitFromTrafficSecrets13(clientSecret, serverSecret []byte, isClient bool) error {
+func (c *TLSAes128GcmSha256) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
 	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
 }
 

--- a/internal/ciphersuite/tls_aes_256_gcm_sha384.go
+++ b/internal/ciphersuite/tls_aes_256_gcm_sha384.go
@@ -32,9 +32,9 @@ func (c *TLSAes256GcmSha384) HashFunc() func() hash.Hash {
 	return sha512.New384
 }
 
-// InitFromTrafficSecrets13 initializes DTLS 1.3 record protection from the
+// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
 // negotiated client and server handshake/application traffic secrets.
-func (c *TLSAes256GcmSha384) InitFromTrafficSecrets13(clientSecret, serverSecret []byte, isClient bool) error {
+func (c *TLSAes256GcmSha384) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
 	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
 }
 

--- a/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
+++ b/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
@@ -32,9 +32,9 @@ func (c *TLSChacha20Poly1305Sha256) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
-// InitFromTrafficSecrets13 initializes DTLS 1.3 record protection from the
+// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
 // negotiated client and server handshake/application traffic secrets.
-func (c *TLSChacha20Poly1305Sha256) InitFromTrafficSecrets13(clientSecret, serverSecret []byte, isClient bool) error {
+func (c *TLSChacha20Poly1305Sha256) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
 	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
 }
 


### PR DESCRIPTION
#### Description
rename InitFromTrafficSecrets13 to InitFromTrafficSecrets. Since the interface itself is called `CipherSuiteTLS13`.