### PR TITLE
Add 1.3 ciphers open

### DIFF
--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -23,6 +23,11 @@ type CipherSuiteTLS13 interface {
 		contentType protocol.ContentType,
 		plaintext []byte,
 	) (recordlayer.CiphertextRecord13, error)
+	Open(
+		header recordlayer.UnifiedHeader,
+		sequenceNumber uint64,
+		encryptedRecord []byte,
+	) (recordlayer.InnerPlaintext, error)
 }
 
 // TLS13CipherSuite provides behavior common to TLS 1.3 cipher suites. TLS 1.3
@@ -100,6 +105,27 @@ func (c *TLS13CipherSuite) Seal(
 	}
 
 	return record, nil
+}
+
+func (c *TLS13CipherSuite) Open(
+	header recordlayer.UnifiedHeader,
+	sequenceNumber uint64,
+	encryptedRecord []byte,
+) (recordlayer.InnerPlaintext, error) {
+	protection, ok := c.getRecordProtection13()
+	if !ok {
+		return recordlayer.InnerPlaintext{}, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+
+	clearHeader := header
+	if err := protection.unmaskRemoteSequenceNumber13(&clearHeader, encryptedRecord); err != nil {
+		return recordlayer.InnerPlaintext{}, err
+	}
+	if err := validateSequenceNumberLowBits13(clearHeader, sequenceNumber); err != nil {
+		return recordlayer.InnerPlaintext{}, err
+	}
+
+	return protection.open(clearHeader, sequenceNumber, encryptedRecord)
 }
 
 func (c *TLS13CipherSuite) Init(_, _, _ []byte, _ bool) error {

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -250,6 +250,18 @@ func (r *recordProtection13) maskLocalSequenceNumber13(
 	return applySequenceNumberMask13(header, mask)
 }
 
+func (r *recordProtection13) unmaskRemoteSequenceNumber13(
+	header *recordlayer.UnifiedHeader,
+	encryptedRecord []byte,
+) error {
+	mask, err := r.remote.sequenceNumberMask13(encryptedRecord)
+	if err != nil {
+		return err
+	}
+
+	return applySequenceNumberMask13(header, mask)
+}
+
 func (p recordTrafficProtection13) sequenceNumberMask13(encryptedRecord []byte) ([]byte, error) {
 	if p.sequenceNumberMask == nil {
 		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
@@ -278,6 +290,22 @@ func applySequenceNumberMask13(header *recordlayer.UnifiedHeader, mask []byte) e
 	}
 
 	header.SequenceNumber = (header.SequenceNumber ^ uint16(mask[0])) & 0x00ff
+
+	return nil
+}
+
+func validateSequenceNumberLowBits13(header recordlayer.UnifiedHeader, sequenceNumber uint64) error {
+	if header.SeqBit {
+		if uint64(header.SequenceNumber) != sequenceNumber&0xffff {
+			return dtlserrors.ErrInvalidCiphertextHeader
+		}
+
+		return nil
+	}
+
+	if uint64(header.SequenceNumber)&0xff != sequenceNumber&0xff {
+		return dtlserrors.ErrInvalidCiphertextHeader
+	}
 
 	return nil
 }

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -260,12 +260,12 @@ func TestTLS13CipherSuiteSeal(t *testing.T) {
 			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
 			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
 
+			sequenceNumber := uint64(0x0102030405061234)
 			header := recordlayer.UnifiedHeader{
-				SequenceNumber: 0xbeef,
+				SequenceNumber: uint16(sequenceNumber), //nolint:gosec // G115
 				EpochLow:       2,
 			}
-			sequenceNumber := uint64(0x0102030405061234)
-			plaintext := []byte("suite-level seal13 payload")
+			plaintext := []byte("suite-level seal payload")
 
 			record, err := clientSuite.Seal(header, sequenceNumber, protocol.ContentTypeApplicationData, plaintext)
 			require.NoError(t, err)
@@ -303,6 +303,74 @@ func TestTLS13CipherSuiteSealRejectsUninitialized(t *testing.T) {
 		[]byte("uninitialized"),
 	)
 	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
+}
+
+func TestTLS13CipherSuiteOpen(t *testing.T) {
+	for _, testCase := range recordProtection13TestCases() {
+		t.Run(testCase.name, func(t *testing.T) {
+			clientSuite := testCase.suite
+			serverSuite := newRecordProtection13TestSuite(t, testCase.name)
+
+			clientSecret := trafficSecret13(testCase.suite, 0xa8)
+			serverSecret := trafficSecret13(testCase.suite, 0xb8)
+			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
+			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+
+			sequenceNumber := uint64(0x0102030405061234)
+			plaintext := []byte("suite-level open payload")
+
+			record, err := clientSuite.Seal(
+				recordlayer.UnifiedHeader{SequenceNumber: 0xbeef, EpochLow: 2},
+				sequenceNumber,
+				protocol.ContentTypeApplicationData,
+				plaintext,
+			)
+			require.NoError(t, err)
+
+			innerPlaintext, err := serverSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+			require.NoError(t, err)
+			assert.Equal(t, plaintext, innerPlaintext.Content)
+			assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
+		})
+	}
+}
+
+func TestTLS13CipherSuiteOpenRejectsUninitialized(t *testing.T) {
+	suite := NewTLSAes128GcmSha256()
+
+	_, err := suite.Open(
+		recordlayer.UnifiedHeader{SequenceNumber: 0x1234, EpochLow: 2},
+		0x0102030405061234,
+		[]byte("uninitialized"),
+	)
+	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
+}
+
+func TestTLS13CipherSuiteOpenRejectsWrongSequenceNumberLowBits(t *testing.T) {
+	suite := NewTLSAes128GcmSha256()
+	clientSecret := trafficSecret13(suite, 0xc1)
+	serverSecret := trafficSecret13(suite, 0xd1)
+	require.NoError(t, suite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+
+	protection, err := suite.newRecordProtection(clientSecret, serverSecret)
+	require.NoError(t, err)
+
+	sequenceNumber := uint64(0x0102030405061234)
+	record, err := protection.seal(
+		recordlayer.UnifiedHeader{SequenceNumber: uint16(sequenceNumber), EpochLow: 2}, //nolint:gosec // G115
+		sequenceNumber,
+		protocol.ContentTypeApplicationData,
+		[]byte("wrong sequence number"),
+	)
+	require.NoError(t, err)
+
+	mask, err := protection.local.sequenceNumberMask13(record.EncryptedRecord)
+	require.NoError(t, err)
+	maskedHeader := record.Header
+	require.NoError(t, applySequenceNumberMask13(&maskedHeader, mask))
+
+	_, err = suite.Open(maskedHeader, sequenceNumber+1, record.EncryptedRecord)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
 }
 
 func TestRecordProtection13SealOpenSyntheticTrafficSecret(t *testing.T) {


### PR DESCRIPTION
#### Description
A small PR to add dtls 1.3 ciphers `open`.
part of https://github.com/pion/dtls/issues/777 related to https://github.com/pion/dtls/issues/755 refs #727 