### PR TITLE
Remove the 13 suffix

### DIFF
--- a/handshake_transcript_13.go
+++ b/handshake_transcript_13.go
@@ -179,7 +179,7 @@ func (t *handshakeTranscript13) sumWithSuffix(suffix []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-func (t *handshakeTranscript13) hasInitialClientHello13() bool {
+func (t *handshakeTranscript13) hasInitialClientHello() bool {
 	return len(t.order) == 1 &&
 		t.order[0].id.sender == transcriptClient13 &&
 		t.order[0].typ == handshake.TypeClientHello
@@ -189,7 +189,7 @@ func (t *handshakeTranscript13) applyHelloRetryRequest() error {
 	if t.h == nil {
 		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
 	}
-	if t.helloRetryApplied || !t.hasInitialClientHello13() {
+	if t.helloRetryApplied || !t.hasInitialClientHello() {
 		return dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid
 	}
 

--- a/handshaker_13.go
+++ b/handshaker_13.go
@@ -454,7 +454,7 @@ func appendHandshake13(
 		seq:    seq,
 	}
 	if sh, ok := message.(*handshake.MessageServerHello); ok && dtlsflight13.IsHelloRetryRequest(sh) {
-		duplicate, err := transcript.hasCanonical13(id, canonical)
+		duplicate, err := transcript.hasCanonical(id, canonical)
 		if err != nil || duplicate {
 			return err
 		}
@@ -470,7 +470,7 @@ func appendHandshake13(
 	return transcript.appendCanonical(id, canonical)
 }
 
-func (t *handshakeTranscript13) hasCanonical13(id transcriptMessageID13, message []byte) (bool, error) {
+func (t *handshakeTranscript13) hasCanonical(id transcriptMessageID13, message []byte) (bool, error) {
 	if err := validateCanonicalHandshake13(message); err != nil {
 		return false, err
 	}

--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -100,7 +100,7 @@ func (c *TLS13CipherSuite) Seal(
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
-	if err = protection.maskLocalSequenceNumber13(&record.Header, record.EncryptedRecord); err != nil {
+	if err = protection.maskLocalSequenceNumber(&record.Header, record.EncryptedRecord); err != nil {
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
@@ -118,7 +118,7 @@ func (c *TLS13CipherSuite) Open(
 	}
 
 	clearHeader := header
-	if err := protection.unmaskRemoteSequenceNumber13(&clearHeader, encryptedRecord); err != nil {
+	if err := protection.unmaskRemoteSequenceNumber(&clearHeader, encryptedRecord); err != nil {
 		return recordlayer.InnerPlaintext{}, err
 	}
 	if err := validateSequenceNumberLowBits13(clearHeader, sequenceNumber); err != nil {

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -47,10 +47,10 @@ type recordTrafficKeys13 struct {
 }
 
 type recordTrafficProtection13 struct {
-	aead               cipher.AEAD
-	iv                 []byte
-	sequenceNumberKey  []byte
-	sequenceNumberMask recordSequenceNumberMaskFunc13
+	aead                 cipher.AEAD
+	iv                   []byte
+	sequenceNumberKey    []byte
+	sequenceNumberMaskFn recordSequenceNumberMaskFunc13
 }
 
 type recordProtection13 struct {
@@ -114,10 +114,10 @@ func newAESGCMRecordTrafficProtection13(
 	}
 
 	return recordTrafficProtection13{
-		aead:               aead,
-		iv:                 keys.iv,
-		sequenceNumberKey:  keys.sequenceNumberKey,
-		sequenceNumberMask: recordSequenceNumberMaskAES13,
+		aead:                 aead,
+		iv:                   keys.iv,
+		sequenceNumberKey:    keys.sequenceNumberKey,
+		sequenceNumberMaskFn: recordSequenceNumberMaskAES13,
 	}, nil
 }
 
@@ -156,10 +156,10 @@ func newChaCha20Poly1305RecordTrafficProtection13(
 	}
 
 	return recordTrafficProtection13{
-		aead:               aead,
-		iv:                 keys.iv,
-		sequenceNumberKey:  keys.sequenceNumberKey,
-		sequenceNumberMask: recordSequenceNumberMaskChaCha20Poly1305TLS13,
+		aead:                 aead,
+		iv:                   keys.iv,
+		sequenceNumberKey:    keys.sequenceNumberKey,
+		sequenceNumberMaskFn: recordSequenceNumberMaskChaCha20Poly1305TLS13,
 	}, nil
 }
 
@@ -235,14 +235,14 @@ func (r *recordProtection13) open(
 }
 
 func (r *recordProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
-	return r.local.sequenceNumberMask13(encryptedRecord)
+	return r.local.sequenceNumberMask(encryptedRecord)
 }
 
-func (r *recordProtection13) maskLocalSequenceNumber13(
+func (r *recordProtection13) maskLocalSequenceNumber(
 	header *recordlayer.UnifiedHeader,
 	encryptedRecord []byte,
 ) error {
-	mask, err := r.local.sequenceNumberMask13(encryptedRecord)
+	mask, err := r.local.sequenceNumberMask(encryptedRecord)
 	if err != nil {
 		return err
 	}
@@ -250,11 +250,11 @@ func (r *recordProtection13) maskLocalSequenceNumber13(
 	return applySequenceNumberMask13(header, mask)
 }
 
-func (r *recordProtection13) unmaskRemoteSequenceNumber13(
+func (r *recordProtection13) unmaskRemoteSequenceNumber(
 	header *recordlayer.UnifiedHeader,
 	encryptedRecord []byte,
 ) error {
-	mask, err := r.remote.sequenceNumberMask13(encryptedRecord)
+	mask, err := r.remote.sequenceNumberMask(encryptedRecord)
 	if err != nil {
 		return err
 	}
@@ -262,12 +262,12 @@ func (r *recordProtection13) unmaskRemoteSequenceNumber13(
 	return applySequenceNumberMask13(header, mask)
 }
 
-func (p recordTrafficProtection13) sequenceNumberMask13(encryptedRecord []byte) ([]byte, error) {
-	if p.sequenceNumberMask == nil {
+func (p recordTrafficProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
+	if p.sequenceNumberMaskFn == nil {
 		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 	}
 
-	return p.sequenceNumberMask(p.sequenceNumberKey, encryptedRecord)
+	return p.sequenceNumberMaskFn(p.sequenceNumberKey, encryptedRecord)
 }
 
 func applySequenceNumberMask13(header *recordlayer.UnifiedHeader, mask []byte) error {

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -275,7 +275,7 @@ func TestTLS13CipherSuiteSeal(t *testing.T) {
 			require.Equal(t, uint16(len(record.EncryptedRecord)), record.Header.Length) //nolint:gosec
 
 			serverProtection := requireRecordProtection13(t, serverSuite)
-			mask, err := serverProtection.remote.sequenceNumberMask13(record.EncryptedRecord)
+			mask, err := serverProtection.remote.sequenceNumberMask(record.EncryptedRecord)
 			require.NoError(t, err)
 			expectedHeaderSequenceNumber := uint16(sequenceNumber & 0xffff) //nolint:gosec // G115
 			expectedMaskedSequenceNumber := expectedHeaderSequenceNumber ^ (uint16(mask[0])<<8 | uint16(mask[1]))
@@ -364,7 +364,7 @@ func TestTLS13CipherSuiteOpenRejectsWrongSequenceNumberLowBits(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	mask, err := protection.local.sequenceNumberMask13(record.EncryptedRecord)
+	mask, err := protection.local.sequenceNumberMask(record.EncryptedRecord)
 	require.NoError(t, err)
 	maskedHeader := record.Header
 	require.NoError(t, applySequenceNumberMask13(&maskedHeader, mask))


### PR DESCRIPTION
#### Description
It doesn't make sense now to keep the 13 suffix for 1.3 dtls helpers now the code is closer to the final shape and closer to production ready, and that all the DTLS 1.3 interfaces already have it.