### PR TITLE
Move trasncript ownership to FSM

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -72,12 +72,11 @@ type addrPkt struct {
 	data  []byte
 }
 type handshakeStart struct {
-	flight12     dtlsflight12.Flight
-	flight13     dtlsflight13.Flight
-	fsmState     handshakeState
-	flights      []*dtlsflight.Packet
-	transcript13 *dtlshandshake.Transcript
-	postSetup    func(context.Context)
+	flight12  dtlsflight12.Flight
+	flight13  dtlsflight13.Flight
+	fsmState  handshakeState
+	flights   []*dtlsflight.Packet
+	postSetup func(context.Context)
 }
 
 type (
@@ -666,8 +665,9 @@ func (c *Conn) HandshakeContext(ctx context.Context) error { //nolint:cyclop
 // - DTLS 1.3 only
 // - Dual-stack (this mode sends or read handshake messages without starting a FSM)
 //
-// In dual-stack client mode, flights holds the already-sent ClientHello and
-// transcript13 carries the same ClientHello into the DTLS 1.3 FSM.
+// In dual-stack client mode, flights holds the already-sent ClientHello. If
+// DTLS 1.3 is selected, the DTLS 1.3 FSM imports those packets into its
+// transcript.
 // nolint:cyclop
 func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error) {
 	switch {
@@ -706,7 +706,7 @@ func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error
 	// Dual-stack
 	// This mode sends or read handshake messages to decide version without starting a FSM
 	case c.state.IsClient:
-		initialFlights, initialTranscript13, err := c.negotiateVersionClient(ctx)
+		initialFlights, err := c.negotiateVersionClient(ctx)
 		if err != nil {
 			return handshakeStart{}, err
 		}
@@ -716,12 +716,11 @@ func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error
 		}
 
 		return handshakeStart{
-			flight12:     dtlsflight12.Flight1,
-			flight13:     dtlsflight13.Flight1,
-			fsmState:     handshakeWaiting,
-			flights:      initialFlights,
-			transcript13: initialTranscript13,
-			postSetup:    primer,
+			flight12:  dtlsflight12.Flight1,
+			flight13:  dtlsflight13.Flight1,
+			fsmState:  handshakeWaiting,
+			flights:   initialFlights,
+			postSetup: primer,
 		}, nil
 	default:
 		err := c.negotiateVersionServer(ctx)
@@ -1589,11 +1588,10 @@ func (c *Conn) negotiateVersionServer(ctx context.Context) error {
 }
 
 //nolint:cyclop
-func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet, *dtlshandshake.Transcript, error) {
-	transcript := dtlshandshake.NewTranscript()
+func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet, error) {
 	gen, _, ok := dtlsflight13.GetGenerator(dtlsflight13.Flight1)
 	if !ok {
-		return nil, nil, dtlserrors.ErrFlightUnimplemented13
+		return nil, dtlserrors.ErrFlightUnimplemented13
 	}
 	pkts, dtlsAlert, err := gen(adaptFlightConn(c), &c.state, c.handshakeCache, c.handshakeConfig)
 	if dtlsAlert != nil {
@@ -1602,27 +1600,25 @@ func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet
 		}
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	c.stampHandshakeSequence(pkts)
-	if appended, err := dtlshandshake.AppendClientHelloInitialFlights(transcript, pkts); err != nil {
-		return nil, nil, err
-	} else if !appended {
-		return nil, nil, dtlserrors.ErrHandshakeTranscriptMissingClientHello
+	if err := dtlshandshake.ValidateClientHelloInitialFlights(pkts); err != nil {
+		return nil, err
 	}
 	if err := c.writePackets(ctx, pkts); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	for {
 		if err := c.readAndBufferNoFSM(ctx); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if ok, err := c.pickVersionFromServerResponse(); err != nil {
-			return nil, nil, err
+			return nil, err
 		} else if ok {
-			return pkts, transcript, nil
+			return pkts, nil
 		}
 		// ServerHello or HelloVerifyRequest not yet (fully) received; keep reading.
 	}
@@ -1858,7 +1854,6 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 			c.handshakeConfig,
 			start.flight13,
 			start.flights,
-			start.transcript13,
 		)
 		if err != nil {
 			return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -3734,6 +3734,54 @@ func TestDTLSDualStackClient(t *testing.T) {
 	testDTLSDualStack(t, clientOpts, serverOpts)
 }
 
+func TestDTLSDualStackClientRejectsNonClientHelloBeforeWrite(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(time.Second * 5).Stop()
+
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	var writes atomic.Int32
+	caCount := &connWithCallback{
+		Conn: ca,
+		onWrite: func([]byte) {
+			writes.Add(1)
+		},
+	}
+
+	cipherSuiteID := uint16(ciphersuite.TLS_AES_128_GCM_SHA256)
+	client, err := ClientWithOptions(
+		dtlsnet.PacketConnFromConn(caCount),
+		caCount.RemoteAddr(),
+		WithInsecureSkipVerify(true),
+		WithMinVersion(protocol.Version1_2),
+		WithMaxVersion(protocol.Version1_3),
+		WithClientHelloMessageHook(func(handshake.MessageClientHello) handshake.Message {
+			return &handshake.MessageServerHello{
+				Version:           protocol.Version1_2,
+				CipherSuiteID:     &cipherSuiteID,
+				CompressionMethod: defaultCompressionMethods()[0],
+			}
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err = client.HandshakeContext(ctx)
+	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)
+	assert.Equal(t, int32(0), writes.Load())
+}
+
 // WIP! Tests if the dual stack mode server managed to negotiate a version successfully.
 func TestDTLSDualStackServer(t *testing.T) {
 	defer test.CheckRoutines(t)()

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -84,9 +84,8 @@ func NewFSM13(
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight13.Flight,
 	initialFlights []*dtlsflight.Packet,
-	initialTranscript *Transcript,
 ) (FSM, error) {
-	return newFSM13(state, cache, cfg, initialFlight, initialFlights, initialTranscript)
+	return newFSM13(state, cache, cfg, initialFlight, initialFlights, nil)
 }
 
 func newFSM13(
@@ -119,7 +118,7 @@ func newFSM13(
 	return fsm, nil
 }
 
-// seedTranscriptFromInitialFlights handles the dual-stack ClientHello generated
+// seedTranscriptFromInitialFlights imports the dual-stack ClientHello generated
 // before the DTLS 1.3 FSM exists.
 func (s *fsm13) seedTranscriptFromInitialFlights() error {
 	if !s.state.IsClient {
@@ -161,6 +160,20 @@ func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflig
 	}
 
 	return appended, nil
+}
+
+// ValidateClientHelloInitialFlights verifies that the dual-stack initial flight
+// contains a canonical ClientHello before it is written.
+func ValidateClientHelloInitialFlights(flights []*dtlsflight.Packet) error {
+	appended, err := AppendClientHelloInitialFlights(NewTranscript(), flights)
+	if err != nil {
+		return err
+	}
+	if !appended {
+		return dtlserrors.ErrHandshakeTranscriptMissingClientHello
+	}
+
+	return nil
 }
 
 func canonicalClientHelloInitialFlight13(p *dtlsflight.Packet) (uint16, []byte, bool, error) {

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -109,12 +109,10 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 		return &ch
 	}
 
-	transcript := NewTranscript()
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext13{
-		state:      state,
-		cache:      cache,
-		cfg:        cfg,
-		transcript: transcript,
+		state: state,
+		cache: cache,
+		cfg:   cfg,
 	})
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
@@ -126,14 +124,10 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 	content.Header.MessageSequence = messageSequence
 
 	expected := canonicalPacketHandshake13(t, pkts[0])
-	appended, err := AppendClientHelloInitialFlights(transcript, pkts)
-	require.NoError(t, err)
-	require.True(t, appended)
 
-	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, pkts, transcript)
+	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, pkts, nil)
 	require.NoError(t, err)
 	require.NotNil(t, fsm.transcript)
-	require.Same(t, transcript, fsm.transcript)
 	require.Len(t, fsm.transcript.pendingMessages(), 1)
 	require.Len(t, fsm.transcript.messageOrder(), 1)
 
@@ -150,21 +144,19 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 	state := &dtlsstate.State{IsClient: true, LocalVersion: protocol.Version1_3}
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
-	transcript := NewTranscript()
 
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext13{
-		state:      state,
-		cache:      cache,
-		cfg:        cfg,
-		transcript: transcript,
+		state: state,
+		cache: cache,
+		cfg:   cfg,
 	})
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 
-	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, pkts, transcript)
+	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, pkts, nil)
 	require.NoError(t, err)
 
-	transcript = fsm.transcript
+	transcript := fsm.transcript
 	before := append([]byte(nil), transcript.Bytes()...)
 	require.Len(t, transcript.pendingMessages(), 1)
 
@@ -188,7 +180,7 @@ func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 
 	fsm, err := newFSM13(
-		state, cache, cfg, dtlsflight13.Flight1, []*dtlsflight.Packet{}, NewTranscript(),
+		state, cache, cfg, dtlsflight13.Flight1, []*dtlsflight.Packet{}, nil,
 	)
 	require.Nil(t, fsm)
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)


### PR DESCRIPTION
#### Description
Currently conn creates the transcript and seeds initial client hello, then passes it to FSM. Which later can call seedTranscriptFromInitialFlights -> AppendClientHelloInitialFlights. This is currently only safe because transcript checks for duplicated appedns, but it's a bad design.
This moves transcript ownership to FSM.