### PR TITLE
Only pass extensions declared length

### DIFF
--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -73,53 +73,56 @@ func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 
 	for offset := 2; offset < len(buf); {
 		bufView := buf[offset:] //nolint:gosec // offset bounded by loop condition
-		if len(bufView) < 2 {
+		if len(bufView) < 4 {
 			return nil, dtlserrors.ErrBufferTooSmall
 		}
+
+		extensionLength := int(binary.BigEndian.Uint16(bufView[2:4]))
+		extensionEnd := 4 + extensionLength
+		if extensionEnd > len(bufView) {
+			return nil, dtlserrors.ErrLengthMismatch
+		}
+		extensionData := bufView[:extensionEnd]
 
 		var err error
 		switch TypeValue(binary.BigEndian.Uint16(bufView)) {
 		case ServerNameTypeValue:
-			err = unmarshalAndAppend(bufView, &ServerName{})
+			err = unmarshalAndAppend(extensionData, &ServerName{})
 		case SupportedEllipticCurvesTypeValue:
-			err = unmarshalAndAppend(bufView, &SupportedEllipticCurves{})
+			err = unmarshalAndAppend(extensionData, &SupportedEllipticCurves{})
 		case SupportedPointFormatsTypeValue:
-			err = unmarshalAndAppend(bufView, &SupportedPointFormats{})
+			err = unmarshalAndAppend(extensionData, &SupportedPointFormats{})
 		case SupportedSignatureAlgorithmsTypeValue:
-			err = unmarshalAndAppend(bufView, &SupportedSignatureAlgorithms{})
+			err = unmarshalAndAppend(extensionData, &SupportedSignatureAlgorithms{})
 		case SignatureAlgorithmsCertTypeValue:
-			err = unmarshalAndAppend(bufView, &SignatureAlgorithmsCert{})
+			err = unmarshalAndAppend(extensionData, &SignatureAlgorithmsCert{})
 		case UseSRTPTypeValue:
-			err = unmarshalAndAppend(bufView, &UseSRTP{})
+			err = unmarshalAndAppend(extensionData, &UseSRTP{})
 		case ALPNTypeValue:
-			err = unmarshalAndAppend(bufView, &ALPN{})
+			err = unmarshalAndAppend(extensionData, &ALPN{})
 		case UseExtendedMasterSecretTypeValue:
-			err = unmarshalAndAppend(bufView, &UseExtendedMasterSecret{})
+			err = unmarshalAndAppend(extensionData, &UseExtendedMasterSecret{})
 		case RenegotiationInfoTypeValue:
-			err = unmarshalAndAppend(bufView, &RenegotiationInfo{})
+			err = unmarshalAndAppend(extensionData, &RenegotiationInfo{})
 		case ConnectionIDTypeValue:
-			err = unmarshalAndAppend(bufView, &ConnectionID{})
+			err = unmarshalAndAppend(extensionData, &ConnectionID{})
 		case SupportedVersionsTypeValue:
-			err = unmarshalAndAppend(bufView, &SupportedVersions{})
+			err = unmarshalAndAppend(extensionData, &SupportedVersions{})
 		case KeyShareTypeValue:
-			err = unmarshalAndAppend(bufView, &KeyShare{})
+			err = unmarshalAndAppend(extensionData, &KeyShare{})
 		case CookieTypeValue:
-			err = unmarshalAndAppend(bufView, &CookieExt{})
+			err = unmarshalAndAppend(extensionData, &CookieExt{})
 		case PskKeyExchangeModesTypeValue:
-			err = unmarshalAndAppend(bufView, &PskKeyExchangeModes{})
+			err = unmarshalAndAppend(extensionData, &PskKeyExchangeModes{})
 		case PreSharedKeyValue:
-			err = unmarshalAndAppend(bufView, &PreSharedKey{})
+			err = unmarshalAndAppend(extensionData, &PreSharedKey{})
 		default:
 		}
 
 		if err != nil {
 			return nil, err
 		}
-		if len(bufView) < 4 {
-			return nil, dtlserrors.ErrBufferTooSmall
-		}
-		extensionLength := binary.BigEndian.Uint16(bufView[2:])
-		offset += (4 + int(extensionLength))
+		offset += extensionEnd
 	}
 
 	return extensions, nil

--- a/pkg/protocol/extension/extension_test.go
+++ b/pkg/protocol/extension/extension_test.go
@@ -25,6 +25,50 @@ func TestExtensions(t *testing.T) {
 	})
 }
 
+func TestExtensionsUnmarshalBoundsExtensionData(t *testing.T) {
+	raw, err := Marshal([]Extension{
+		&UseExtendedMasterSecret{Supported: true},
+		&RenegotiationInfo{},
+	})
+	assert.NoError(t, err)
+
+	extensions, err := Unmarshal(raw)
+	assert.NoError(t, err)
+	assert.Len(t, extensions, 2)
+	assert.IsType(t, &UseExtendedMasterSecret{}, extensions[0])
+	assert.IsType(t, &RenegotiationInfo{}, extensions[1])
+}
+
+func TestExtensionsUnmarshalRejectsExtensionLengthOverflow(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			name: "unknown extension",
+			raw: []byte{
+				0x00, 0x04, // extensions length
+				0x12, 0x34, // unknown extension type
+				0x00, 0x01, // extension length, but no extension data remains
+			},
+		},
+		{
+			name: "known extension",
+			raw: []byte{
+				0x00, 0x04, // extensions length
+				0x00, 0x17, // extended_master_secret
+				0x00, 0x01, // extension length, but no extension data remains
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			extensions, err := Unmarshal(tt.raw)
+			assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
+			assert.Empty(t, extensions)
+		})
+	}
+}
+
 // testExtDataLength is used to check the declared length in an extension and
 // trailing bytes. It should only be called after a succesfull unmarshal.
 func testExtDataLength(t *testing.T, ext Extension, data []byte, trailing bool) {


### PR DESCRIPTION
#### Description
The extension loop calls the unmarshal with all the remaining payload which includes next extensions, and this is a foot gun because extensions can incorrectly try to read or verify the remainings.

Example https://github.com/pion/dtls/pull/806#discussion_r2866986724
