### PR TITLE
Isolate extension payload unmarshal

### DIFF
--- a/pkg/protocol/extension/alpn.go
+++ b/pkg/protocol/extension/alpn.go
@@ -43,18 +43,16 @@ func (a *ALPN) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (a *ALPN) Unmarshal(data []byte) error {
-	val := cryptobyte.String(data)
-
-	var extension uint16
-	val.ReadUint16(&extension)
-	if TypeValue(extension) != a.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, a.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrLengthMismatch
-	}
+	return a.unmarshalPayload(payload)
+}
+
+func (a *ALPN) unmarshalPayload(data []byte) error {
+	extData := cryptobyte.String(data)
 
 	var protoList cryptobyte.String
 	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {

--- a/pkg/protocol/extension/certificate_auth.go
+++ b/pkg/protocol/extension/certificate_auth.go
@@ -49,16 +49,16 @@ func (c *CertificateAuthorities) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (c *CertificateAuthorities) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != c.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, c.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return c.unmarshalPayload(payload)
+}
+
+func (c *CertificateAuthorities) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	var auths cryptobyte.String
 	if extData.Empty() || !extData.ReadUint16LengthPrefixed(&auths) || auths.Empty() {

--- a/pkg/protocol/extension/connection_id.go
+++ b/pkg/protocol/extension/connection_id.go
@@ -39,17 +39,16 @@ func (c *ConnectionID) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (c *ConnectionID) Unmarshal(data []byte) error {
-	val := cryptobyte.String(data)
-	var extension uint16
-	val.ReadUint16(&extension)
-	if TypeValue(extension) != c.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, c.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return c.unmarshalPayload(payload)
+}
+
+func (c *ConnectionID) unmarshalPayload(data []byte) error {
+	extData := cryptobyte.String(data)
 
 	var cid cryptobyte.String
 	if !extData.ReadUint8LengthPrefixed(&cid) {

--- a/pkg/protocol/extension/cookie.go
+++ b/pkg/protocol/extension/cookie.go
@@ -40,16 +40,16 @@ func (c *CookieExt) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (c *CookieExt) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != c.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, c.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return c.unmarshalPayload(payload)
+}
+
+func (c *CookieExt) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	var cookie cryptobyte.String
 	if !extData.ReadUint16LengthPrefixed(&cookie) || cookie.Empty() || len(cookie) > maxCookieSize {

--- a/pkg/protocol/extension/early_data_indication.go
+++ b/pkg/protocol/extension/early_data_indication.go
@@ -42,16 +42,16 @@ func (e *EarlyDataIndication) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (e *EarlyDataIndication) Unmarshal(data []byte) error {
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != e.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, e.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return e.unmarshalPayload(payload)
+}
+
+func (e *EarlyDataIndication) unmarshalPayload(data []byte) error {
+	extData := cryptobyte.String(data)
 
 	// new_session_ticket
 	if !extData.Empty() {

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -46,6 +46,29 @@ type Extension interface {
 	TypeValue() TypeValue
 }
 
+type extensionPayloadUnmarshaller interface {
+	unmarshalPayload(data []byte) error
+}
+
+func extensionPayload(data []byte, expected TypeValue) ([]byte, error) {
+	if len(data) < 2 {
+		return nil, dtlserrors.ErrBufferTooSmall
+	}
+	if TypeValue(binary.BigEndian.Uint16(data)) != expected {
+		return nil, dtlserrors.ErrInvalidExtensionType
+	}
+	if len(data) < 4 {
+		return nil, dtlserrors.ErrBufferTooSmall
+	}
+
+	declaredLen := int(binary.BigEndian.Uint16(data[2:4]))
+	if declaredLen != len(data)-4 {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+
+	return data[4:], nil
+}
+
 // Unmarshal many extensions at once.
 func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 	switch {
@@ -62,9 +85,14 @@ func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 
 	extensions := []Extension{}
 	unmarshalAndAppend := func(data []byte, e Extension) error {
-		err := e.Unmarshal(data)
-		if err != nil {
-			return err
+		if payloadUnmarshaller, ok := e.(extensionPayloadUnmarshaller); ok {
+			if err := payloadUnmarshaller.unmarshalPayload(data[4:]); err != nil {
+				return err
+			}
+		} else {
+			if err := e.Unmarshal(data); err != nil {
+				return err
+			}
 		}
 		extensions = append(extensions, e)
 

--- a/pkg/protocol/extension/generic_signature_hash_extension.go
+++ b/pkg/protocol/extension/generic_signature_hash_extension.go
@@ -33,16 +33,16 @@ func marshalGenericSignatureHashAlgorithm(typeValue TypeValue, sigHashAlgs []sig
 // This supports hybrid encoding: detects TLS 1.3 PSS schemes
 // and handles them as full uint16, while TLS 1.2 schemes use byte-split encoding.
 func unmarshalGenericSignatureHashAlgorithm(typeValue TypeValue, data []byte, dst *[]signaturehash.Algorithm) error {
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != typeValue {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, typeValue)
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return unmarshalGenericSignatureHashAlgorithmPayload(payload, dst)
+}
+
+func unmarshalGenericSignatureHashAlgorithmPayload(data []byte, dst *[]signaturehash.Algorithm) error {
+	extData := cryptobyte.String(data)
 
 	var algData cryptobyte.String
 	if !extData.ReadUint16LengthPrefixed(&algData) || !extData.Empty() {

--- a/pkg/protocol/extension/key_share.go
+++ b/pkg/protocol/extension/key_share.go
@@ -85,16 +85,17 @@ func (k *KeyShare) Marshal() ([]byte, error) { //nolint:cyclop
 
 // Unmarshal decodes the extension.
 func (k *KeyShare) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extData cryptobyte.String
+	payload, err := extensionPayload(data, k.TypeValue())
+	if err != nil {
+		return err
+	}
 
-	var ext uint16
-	if !val.ReadUint16(&ext) || TypeValue(ext) != k.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
-	}
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return k.unmarshalPayload(payload)
+}
+
+func (k *KeyShare) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
+
 	if extData.Empty() {
 		return dtlserrors.ErrInvalidKeyShareFormat
 	}

--- a/pkg/protocol/extension/oid_filters.go
+++ b/pkg/protocol/extension/oid_filters.go
@@ -60,17 +60,16 @@ func (o *OIDFilters) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (o *OIDFilters) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != o.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, o.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return o.unmarshalPayload(payload)
+}
+
+func (o *OIDFilters) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	var filterList cryptobyte.String
 	if !extData.ReadUint16LengthPrefixed(&filterList) || !extData.Empty() {

--- a/pkg/protocol/extension/post_handshake_auth.go
+++ b/pkg/protocol/extension/post_handshake_auth.go
@@ -42,15 +42,18 @@ func (p *PostHandshakeAuth) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (p *PostHandshakeAuth) Unmarshal(data []byte) error {
-	switch {
-	case len(data) < postHandshakeAuthHeaderSize:
-		return dtlserrors.ErrBufferTooSmall
-	case data[2] != 0x00 || data[3] != 0x00:
-		return dtlserrors.ErrLengthMismatch
-	case TypeValue(binary.BigEndian.Uint16(data)) != p.TypeValue():
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, p.TypeValue())
+	if err != nil {
+		return err
 	}
 
+	return p.unmarshalPayload(payload)
+}
+
+func (p *PostHandshakeAuth) unmarshalPayload(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
 	p.Enabled = true
 
 	return nil

--- a/pkg/protocol/extension/pre_shared_key.go
+++ b/pkg/protocol/extension/pre_shared_key.go
@@ -85,16 +85,16 @@ func (p *PreSharedKey) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (p *PreSharedKey) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != p.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, p.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return p.unmarshalPayload(payload)
+}
+
+func (p *PreSharedKey) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	// ServerHello
 	if len(extData) == 2 {

--- a/pkg/protocol/extension/pre_shared_key_test.go
+++ b/pkg/protocol/extension/pre_shared_key_test.go
@@ -162,7 +162,7 @@ func TestPreSharedKey_ClientHello_MultipleIdentities_SingleBinder(t *testing.T) 
 
 	raw := []byte{
 		0x00, 0x29, // extension type
-		0x00, 0x0a, // extension length
+		0x00, 0x35, // extension length
 		0x00, 0x10, // identities length
 		0x00, 0x02, // identity length
 		0x41, 0x41, // identity
@@ -191,7 +191,7 @@ func TestPreSharedKey_ClientHello_LowBinders(t *testing.T) {
 	}
 	raw := []byte{
 		0x00, 0x29, // extension type
-		0x00, 0x0a, // extension length
+		0x00, 0x1d, // extension length
 		0x00, 0x06, // identities length
 		0x00, 0x02, // identity length
 		0x42, 0x42, // identity

--- a/pkg/protocol/extension/psk_key_exchange_modes.go
+++ b/pkg/protocol/extension/psk_key_exchange_modes.go
@@ -51,16 +51,16 @@ func (p *PskKeyExchangeModes) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (p *PskKeyExchangeModes) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extension uint16
-	if !val.ReadUint16(&extension) || TypeValue(extension) != p.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, p.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return p.unmarshalPayload(payload)
+}
+
+func (p *PskKeyExchangeModes) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	var strModes cryptobyte.String
 

--- a/pkg/protocol/extension/renegotiation_info.go
+++ b/pkg/protocol/extension/renegotiation_info.go
@@ -39,16 +39,20 @@ func (r *RenegotiationInfo) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (r *RenegotiationInfo) Unmarshal(data []byte) error {
-	switch {
-	case len(data) < renegotiationInfoHeaderSize:
-		return dtlserrors.ErrBufferTooSmall
-	case TypeValue(binary.BigEndian.Uint16(data)) != r.TypeValue():
-		return dtlserrors.ErrInvalidExtensionType
-	case binary.BigEndian.Uint16(data[2:4]) != 1:
+	payload, err := extensionPayload(data, r.TypeValue())
+	if err != nil {
+		return err
+	}
+
+	return r.unmarshalPayload(payload)
+}
+
+func (r *RenegotiationInfo) unmarshalPayload(data []byte) error {
+	if len(data) != 1 {
 		return dtlserrors.ErrLengthMismatch
 	}
 
-	r.RenegotiatedConnection = data[4]
+	r.RenegotiatedConnection = data[0]
 
 	return nil
 }

--- a/pkg/protocol/extension/server_name.go
+++ b/pkg/protocol/extension/server_name.go
@@ -44,17 +44,16 @@ func (s *ServerName) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (s *ServerName) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extension uint16
-	val.ReadUint16(&extension)
-	if TypeValue(extension) != s.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, s.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	var extData cryptobyte.String
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return s.unmarshalPayload(payload)
+}
+
+func (s *ServerName) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	var nameList cryptobyte.String
 	if !extData.ReadUint16LengthPrefixed(&nameList) || nameList.Empty() {

--- a/pkg/protocol/extension/signature_algorithms_cert.go
+++ b/pkg/protocol/extension/signature_algorithms_cert.go
@@ -41,3 +41,9 @@ func (s *SignatureAlgorithmsCert) Unmarshal(data []byte) error {
 
 	return unmarshalGenericSignatureHashAlgorithm(s.TypeValue(), data, &s.SignatureHashAlgorithms)
 }
+
+func (s *SignatureAlgorithmsCert) unmarshalPayload(data []byte) error {
+	s.SignatureHashAlgorithms = []signaturehash.Algorithm{}
+
+	return unmarshalGenericSignatureHashAlgorithmPayload(data, &s.SignatureHashAlgorithms)
+}

--- a/pkg/protocol/extension/signature_algorithms_cert_test.go
+++ b/pkg/protocol/extension/signature_algorithms_cert_test.go
@@ -165,7 +165,7 @@ func TestSignatureAlgorithmsCertUnmarshalErrors(t *testing.T) {
 	t.Run("Empty data", func(t *testing.T) {
 		ext := &SignatureAlgorithmsCert{}
 		err := ext.Unmarshal([]byte{})
-		assert.ErrorIs(t, err, dtlserrors.ErrInvalidExtensionType)
+		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
 	})
 
 	t.Run("Invalid extension type", func(t *testing.T) {
@@ -187,16 +187,16 @@ func TestSignatureAlgorithmsCertUnmarshalErrors(t *testing.T) {
 		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
 	})
 
-	t.Run("Buffer too small - missing algorithms length", func(t *testing.T) {
+	t.Run("Length mismatch - missing algorithms length", func(t *testing.T) {
 		ext := &SignatureAlgorithmsCert{}
 		err := ext.Unmarshal([]byte{
 			0x00, 0x32, // Extension type
 			0x00, 0x02, // Extension length
 		})
-		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+		assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
 	})
 
-	t.Run("Truncated algorithm list", func(t *testing.T) {
+	t.Run("Length mismatch - truncated algorithm list", func(t *testing.T) {
 		ext := &SignatureAlgorithmsCert{}
 		err := ext.Unmarshal([]byte{
 			0x00, 0x32, // Extension type
@@ -205,7 +205,7 @@ func TestSignatureAlgorithmsCertUnmarshalErrors(t *testing.T) {
 			0x04, 0x03, // SHA256, ECDSA
 			0x05, // Incomplete second algorithm
 		})
-		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+		assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
 	})
 
 	t.Run("Length mismatch - declared length too long", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestSignatureAlgorithmsCertUnmarshalErrors(t *testing.T) {
 			0x00, 0x06, // Algorithms length: 6 bytes (but only 2 bytes of data follow)
 			0x04, 0x03, // SHA256, ECDSA
 		})
-		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+		assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
 	})
 
 	t.Run("Empty extension data", func(t *testing.T) {

--- a/pkg/protocol/extension/supported_elliptic_curves.go
+++ b/pkg/protocol/extension/supported_elliptic_curves.go
@@ -48,26 +48,27 @@ func (s *SupportedEllipticCurves) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (s *SupportedEllipticCurves) Unmarshal(data []byte) error {
-	if len(data) < supportedGroupsHeaderSize {
-		return dtlserrors.ErrBufferTooSmall
+	payload, err := extensionPayload(data, s.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	declaredLength := int(binary.BigEndian.Uint16(data[2:4]))
-	groupCount := int(binary.BigEndian.Uint16(data[4:]) / 2)
+	return s.unmarshalPayload(payload)
+}
 
+func (s *SupportedEllipticCurves) unmarshalPayload(data []byte) error {
 	switch {
-	case TypeValue(binary.BigEndian.Uint16(data)) != s.TypeValue():
-		return dtlserrors.ErrInvalidExtensionType
-	case declaredLength > len(data)-4: // type + declared length = 4
+	case len(data) < 2:
+		return dtlserrors.ErrBufferTooSmall
+	case int(binary.BigEndian.Uint16(data))+2 != len(data):
 		return dtlserrors.ErrLengthMismatch
-	case supportedGroupsHeaderSize+(groupCount*2) > len(data):
-		return dtlserrors.ErrLengthMismatch
-	case groupCount*2+2 != declaredLength:
+	case binary.BigEndian.Uint16(data)%2 != 0:
 		return dtlserrors.ErrLengthMismatch
 	}
 
+	groupCount := int(binary.BigEndian.Uint16(data) / 2)
 	for i := range groupCount {
-		supportedGroupID := elliptic.Curve(binary.BigEndian.Uint16(data[(supportedGroupsHeaderSize + (i * 2)):]))
+		supportedGroupID := elliptic.Curve(binary.BigEndian.Uint16(data[2+(i*2):]))
 		if _, ok := elliptic.Curves()[supportedGroupID]; ok {
 			s.EllipticCurves = append(s.EllipticCurves, supportedGroupID)
 		}

--- a/pkg/protocol/extension/supported_point_formats.go
+++ b/pkg/protocol/extension/supported_point_formats.go
@@ -49,26 +49,25 @@ func (s *SupportedPointFormats) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (s *SupportedPointFormats) Unmarshal(data []byte) error {
-	if len(data) < supportedPointFormatsSize {
-		return dtlserrors.ErrBufferTooSmall
+	payload, err := extensionPayload(data, s.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	declaredLength := int(binary.BigEndian.Uint16(data[2:4]))
-	pointFormatCount := int(data[4])
+	return s.unmarshalPayload(payload)
+}
 
+func (s *SupportedPointFormats) unmarshalPayload(data []byte) error {
 	switch {
-	case TypeValue(binary.BigEndian.Uint16(data)) != s.TypeValue():
-		return dtlserrors.ErrInvalidExtensionType
-	case declaredLength > len(data)-4: // type + declared length = 4
-		return dtlserrors.ErrLengthMismatch
-	case supportedPointFormatsSize+pointFormatCount > len(data):
-		return dtlserrors.ErrLengthMismatch
-	case pointFormatCount+1 != declaredLength:
+	case len(data) < 1:
+		return dtlserrors.ErrBufferTooSmall
+	case int(data[0])+1 != len(data):
 		return dtlserrors.ErrLengthMismatch
 	}
 
+	pointFormatCount := int(data[0])
 	for i := range pointFormatCount {
-		p := elliptic.CurvePointFormat(data[supportedPointFormatsSize+i])
+		p := elliptic.CurvePointFormat(data[1+i])
 		switch p {
 		case elliptic.CurvePointFormatUncompressed:
 			s.PointFormats = append(s.PointFormats, p)

--- a/pkg/protocol/extension/supported_signature_algorithms.go
+++ b/pkg/protocol/extension/supported_signature_algorithms.go
@@ -35,3 +35,9 @@ func (s *SupportedSignatureAlgorithms) Unmarshal(data []byte) error {
 
 	return unmarshalGenericSignatureHashAlgorithm(s.TypeValue(), data, &s.SignatureHashAlgorithms)
 }
+
+func (s *SupportedSignatureAlgorithms) unmarshalPayload(data []byte) error {
+	s.SignatureHashAlgorithms = []signaturehash.Algorithm{}
+
+	return unmarshalGenericSignatureHashAlgorithmPayload(data, &s.SignatureHashAlgorithms)
+}

--- a/pkg/protocol/extension/supported_versions.go
+++ b/pkg/protocol/extension/supported_versions.go
@@ -79,18 +79,16 @@ func (s *SupportedVersions) Marshal() ([]byte, error) {
 // Unmarshal parses either the ClientHello list or the ServerHello/HelloRetryRequest single value.
 // Any version not recognized is discarded.
 func (s *SupportedVersions) Unmarshal(data []byte) error { //nolint:cyclop
-	val := cryptobyte.String(data)
-	var extData cryptobyte.String
-
-	var extension uint16
-	val.ReadUint16(&extension)
-	if TypeValue(extension) != s.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, s.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	if !val.ReadUint16LengthPrefixed(&extData) {
-		return dtlserrors.ErrBufferTooSmall
-	}
+	return s.unmarshalPayload(payload)
+}
+
+func (s *SupportedVersions) unmarshalPayload(data []byte) error { //nolint:cyclop
+	extData := cryptobyte.String(data)
 
 	if extData.Empty() {
 		return dtlserrors.ErrInvalidSupportedVersionsFormat

--- a/pkg/protocol/extension/use_master_secret.go
+++ b/pkg/protocol/extension/use_master_secret.go
@@ -41,15 +41,18 @@ func (u *UseExtendedMasterSecret) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (u *UseExtendedMasterSecret) Unmarshal(data []byte) error {
-	switch {
-	case len(data) < useExtendedMasterSecretHeaderSize:
-		return dtlserrors.ErrBufferTooSmall
-	case data[2] != 0x00 || data[3] != 0x00:
-		return dtlserrors.ErrLengthMismatch
-	case TypeValue(binary.BigEndian.Uint16(data)) != u.TypeValue():
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, u.TypeValue())
+	if err != nil {
+		return err
 	}
 
+	return u.unmarshalPayload(payload)
+}
+
+func (u *UseExtendedMasterSecret) unmarshalPayload(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
 	u.Supported = true
 
 	return nil

--- a/pkg/protocol/extension/use_srtp.go
+++ b/pkg/protocol/extension/use_srtp.go
@@ -63,28 +63,34 @@ func (u *UseSRTP) Marshal() ([]byte, error) {
 
 // Unmarshal populates the extension from encoded data.
 func (u *UseSRTP) Unmarshal(data []byte) error {
-	if len(data) <= useSRTPHeaderSize {
-		return dtlserrors.ErrBufferTooSmall
-	} else if TypeValue(binary.BigEndian.Uint16(data)) != u.TypeValue() {
-		return dtlserrors.ErrInvalidExtensionType
+	payload, err := extensionPayload(data, u.TypeValue())
+	if err != nil {
+		return err
 	}
 
-	profileCount := int(binary.BigEndian.Uint16(data[4:]) / 2)
-	masterKeyIdentifierIndex := supportedGroupsHeaderSize + (profileCount * 2)
-	if masterKeyIdentifierIndex+1 > len(data) {
+	return u.unmarshalPayload(payload)
+}
+
+func (u *UseSRTP) unmarshalPayload(data []byte) error {
+	if len(data) < 3 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+
+	profilesLength := int(binary.BigEndian.Uint16(data))
+	masterKeyIdentifierIndex := 2 + profilesLength
+	if profilesLength%2 != 0 || masterKeyIdentifierIndex+1 > len(data) {
 		return dtlserrors.ErrLengthMismatch
 	}
-
-	declaredLength := int(binary.BigEndian.Uint16(data[2:4]))
 
 	masterKeyIdentifierLen := int(data[masterKeyIdentifierIndex])
-	end := masterKeyIdentifierIndex + masterKeyIdentifierLen
-	if end >= len(data) || end-4 != declaredLength-1 {
+	masterKeyIdentifierEnd := masterKeyIdentifierIndex + 1 + masterKeyIdentifierLen
+	if masterKeyIdentifierEnd != len(data) {
 		return dtlserrors.ErrLengthMismatch
 	}
 
+	profileCount := profilesLength / 2
 	for i := range profileCount {
-		supportedProfile := SRTPProtectionProfile(binary.BigEndian.Uint16(data[(useSRTPHeaderSize + (i * 2)):]))
+		supportedProfile := SRTPProtectionProfile(binary.BigEndian.Uint16(data[2+(i*2):]))
 		if _, ok := srtpProtectionProfiles()[supportedProfile]; ok {
 			u.ProtectionProfiles = append(u.ProtectionProfiles, supportedProfile)
 		}
@@ -92,7 +98,7 @@ func (u *UseSRTP) Unmarshal(data []byte) error {
 
 	u.MasterKeyIdentifier = append(
 		[]byte{},
-		data[masterKeyIdentifierIndex+1:end+1]...,
+		data[masterKeyIdentifierIndex+1:masterKeyIdentifierEnd]...,
 	)
 
 	return nil


### PR DESCRIPTION
#### Description
The extensions loop reads [type][length] before it passes again to extensions unmarshal which reads [type][length] again which is redundant and can cause issues, and is a foot-gun.
This isolates payload unmarshal into a private interface with `unmarshalPayload` and calls it from the extensions, which only reads the payload.
based on #893 