### PR TITLE
 fix protected-handshake epoch handling

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1307,6 +1307,24 @@ func (c *Conn) enqueueEncryptedPackets(packet addrPkt) bool {
 	return false
 }
 
+func (c *Conn) maxQueueableFutureEpoch(remoteEpoch uint16) uint16 {
+	maxEpoch := remoteEpoch + 1
+	if remoteEpoch >= dtlsflight13.EpochHandshake {
+		return maxEpoch
+	}
+	if c.state.LocalVersion.Equal(protocol.Version1_3) {
+		return dtlsflight13.EpochHandshake
+	}
+	if !c.state.LocalVersion.Equal(protocol.Version{}) {
+		return maxEpoch
+	}
+	if c.handshakeConfig != nil && c.handshakeConfig.MaxVersion.Equal(protocol.Version1_3) {
+		return dtlsflight13.EpochHandshake
+	}
+
+	return maxEpoch
+}
+
 // nolint:unused
 func (c *Conn) handleIncomingPacket13(
 	ctx context.Context,
@@ -1341,7 +1359,7 @@ func (c *Conn) handleIncomingPacket(
 	// Validate epoch
 	remoteEpoch := c.state.GetRemoteEpoch()
 	if header.Epoch > remoteEpoch {
-		if header.Epoch > remoteEpoch+1 {
+		if header.Epoch > c.maxQueueableFutureEpoch(remoteEpoch) {
 			c.log.Debugf("discarded future packet (epoch: %d, seq: %d)",
 				header.Epoch, header.SequenceNumber,
 			)

--- a/conn_test.go
+++ b/conn_test.go
@@ -28,6 +28,7 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/hash"
@@ -3423,6 +3424,44 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	assert.NoError(t, ca.Close())
 	<-done
+}
+
+func TestHandleIncomingPacket13QueuesHandshakeEpochBeforeProtection(t *testing.T) {
+	conn := &Conn{
+		fragmentBuffer:         newFragmentBuffer(),
+		handshakeCache:         dtlsflight.NewCache(),
+		log:                    logging.NewDefaultLoggerFactory().NewLogger("dtls"),
+		replayProtectionWindow: defaultReplayProtectionWindow,
+		handshakeConfig:        testVersionNegotiationHandshakeConfig13(t),
+		state:                  dtlsstate.State{IsClient: true, LocalVersion: protocol.Version1_3},
+	}
+	conn.setRemoteEpoch(0)
+
+	rawPacket, err := (&recordlayer.RecordLayer{
+		Header: recordlayer.Header{
+			Version:        protocol.Version1_2,
+			Epoch:          dtlsflight13.EpochHandshake,
+			SequenceNumber: 0,
+		},
+		Content: &handshake.Handshake{
+			Header:  handshake.Header{MessageSequence: 1},
+			Message: &handshake.MessageEncryptedExtensions{},
+		},
+	}).Marshal()
+	assert.NoError(t, err)
+
+	isHandshake, isRetransmit, dtlsAlert, err := conn.handleIncomingPacket(
+		context.Background(),
+		rawPacket,
+		nil,
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Nil(t, dtlsAlert)
+	assert.False(t, isHandshake)
+	assert.False(t, isRetransmit)
+	assert.Len(t, conn.encryptedPackets, 1)
+	assert.Equal(t, rawPacket, conn.encryptedPackets[0].data)
 }
 
 func TestHelloRandom(t *testing.T) {

--- a/flight_test.go
+++ b/flight_test.go
@@ -59,6 +59,16 @@ func flight13ParseForTest(
 	ctx context.Context,
 	flightCtx *handshakeTestContext13,
 ) (Flight, *alert.Alert, error) {
+	return flight13ParseForTestWithConn(testingT, flight, ctx, nil, flightCtx)
+}
+
+func flight13ParseForTestWithConn(
+	testingT require.TestingT,
+	flight Flight,
+	ctx context.Context,
+	conn dtlsflight.Conn,
+	flightCtx *handshakeTestContext13,
+) (Flight, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {
 		helper.Helper()
 	}
@@ -66,7 +76,7 @@ func flight13ParseForTest(
 	nextFlight, dtlsAlert, err, ok := dtlsflight13.Parse(
 		ctx,
 		flight,
-		nil,
+		conn,
 		flightCtx.state,
 		flightCtx.cache,
 		flightCtx.cfg,
@@ -81,6 +91,22 @@ func flight13ParseForTest(
 	require.True(testingT, ok)
 
 	return nextFlight, dtlsAlert, err
+}
+
+type flight13QueuedPacketConn struct {
+	handleQueuedPackets func(context.Context) error
+}
+
+func (c *flight13QueuedPacketConn) HandleQueuedPackets(ctx context.Context) error {
+	if c.handleQueuedPackets == nil {
+		return nil
+	}
+
+	return c.handleQueuedPackets(ctx)
+}
+
+func (c *flight13QueuedPacketConn) SessionKey() []byte {
+	return nil
 }
 
 func flight13GenerateForTest(
@@ -840,7 +866,7 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state:      state,
 		cache:      cache,
@@ -876,6 +902,60 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	assert.Equal(t, expectedSecrets, state.HandshakeTrafficSecrets13)
 	assert.NotEqual(t, state.HandshakeTrafficSecrets13.Client, state.HandshakeTrafficSecrets13.Server)
 	assert.True(t, state.CipherSuite.IsInitialized())
+}
+
+func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := &dtlsstate.State{IsClient: true}
+	transcript := dtlshandshake.NewTranscript()
+	clientHello, _, err := flight13GenerateForTest(t, Flight1, &handshakeTestContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+	appended, err := dtlshandshake.AppendClientHelloInitialFlights(transcript, clientHello)
+	require.NoError(t, err)
+	require.True(t, appended)
+
+	group := cfg.EllipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
+		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
+	}, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+	rawEncryptedExtensions, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageEncryptedExtensions{},
+	}).Marshal()
+	require.NoError(t, err)
+
+	cache := dtlsflight.NewCache()
+	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
+	drained := false
+	conn := &flight13QueuedPacketConn{
+		handleQueuedPackets: func(context.Context) error {
+			drained = true
+			assert.True(t, state.CipherSuite.IsInitialized())
+			assert.Equal(t, dtlsflight13.EpochHandshake, state.GetRemoteEpoch())
+			cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+
+			return nil
+		},
+	}
+
+	nextFlight, dtlsAlert, err := flight13ParseForTestWithConn(
+		t, Flight3, context.Background(), conn, &handshakeTestContext13{
+			state:      state,
+			cache:      cache,
+			cfg:        cfg,
+			transcript: transcript,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.True(t, drained)
+	assert.Equal(t, Flight5, nextFlight)
+	assert.Equal(t, 2, state.HandshakeRecvSequence)
 }
 
 func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
@@ -914,7 +994,7 @@ func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
 	require.NoError(t, err)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight1, context.Background(), &handshakeTestContext13{
@@ -1004,7 +1084,7 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 2, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 2, handshake.TypeEncryptedExtensions, false)
 	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
 	require.NoError(t, err)
 
@@ -1057,7 +1137,7 @@ func TestFlight13_3ParseRejectsSecondHelloRetryRequest(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state: state,
 		cache: cache,
@@ -1102,7 +1182,7 @@ func TestFlight13_3ParseRejectsWrongLegacyVersion(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state: state,
 		cache: cache,
@@ -1137,7 +1217,7 @@ func TestFlight13_3ParseRejectsMissingSupportedVersions(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state: state,
 		cache: cache,
@@ -1168,7 +1248,7 @@ func TestFlight13_3ParseRejectsMissingKeyShare(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state: state,
 		cache: cache,
@@ -1202,7 +1282,7 @@ func TestFlight13_3ParseRejectsUnofferedKeyShareGroup(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	cache.Push(rawEncryptedExtensions, cfg.InitialEpoch+1, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state: state,
 		cache: cache,
@@ -1934,7 +2014,7 @@ func TestFlight13_4Generate(t *testing.T) {
 
 		encryptedExtensionsHandshake, ok := pkts[1].Record.Content.(*handshake.Handshake)
 		require.True(t, ok)
-		assert.Equal(t, uint16(1), pkts[1].Record.Header.Epoch)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[1].Record.Header.Epoch)
 		assert.True(t, pkts[1].ShouldEncrypt)
 		assert.True(t, pkts[1].ResetLocalSequenceNumber)
 		encryptedExtensions, ok := encryptedExtensionsHandshake.Message.(*handshake.MessageEncryptedExtensions)
@@ -1968,6 +2048,33 @@ func TestFlight13_4Generate(t *testing.T) {
 		require.Nil(t, dtlsAlert)
 		require.Nil(t, pkts)
 	})
+}
+
+func TestFlight13ServerFlight4UsesHandshakeEpoch(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	group := cfg.EllipticCurves[0]
+	keypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+
+	state := &dtlsstate.State{
+		LocalVersion: protocol.Version1_3,
+		CipherSuite:  cfg.LocalCipherSuites[0],
+		LocalKeypair: keypair,
+		LocalRandom:  handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}},
+	}
+
+	pkts, dtlsAlert, err := flight13GenerateForTest(
+		t, Flight4, &handshakeTestContext13{state: state, cfg: cfg},
+	)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, pkts, 2)
+
+	assert.Equal(t, uint16(0), pkts[0].Record.Header.Epoch)
+	assert.False(t, pkts[0].ShouldEncrypt)
+	assert.Equal(t, dtlsflight13.EpochHandshake, pkts[1].Record.Header.Epoch)
+	assert.True(t, pkts[1].ShouldEncrypt)
+	assert.True(t, pkts[1].ResetLocalSequenceNumber)
 }
 
 func pushClientHello13(

--- a/internal/flight/flight13/flighthandler13.go
+++ b/internal/flight/flight13/flighthandler13.go
@@ -18,6 +18,13 @@ const (
 	renegotiationInfoSCSV = 0x00ff
 )
 
+const (
+	EpochInitial     uint16 = 0
+	EpochEarlyData   uint16 = 1
+	EpochHandshake   uint16 = 2
+	EpochApplication uint16 = 3
+)
+
 type flightParser13 func(
 	context.Context,
 	dtlsflight.Conn,

--- a/internal/flight/flight13/flighthandlers_client_13.go
+++ b/internal/flight/flight13/flighthandlers_client_13.go
@@ -190,10 +190,10 @@ func flight13_1Parse(
 	return Flight3, nil, nil
 }
 
-//nolint:cyclop
+//nolint:cyclop,gocognit
 func flight13_3Parse(
-	_ context.Context,
-	_ dtlsflight.Conn,
+	ctx context.Context,
+	conn dtlsflight.Conn,
 	flightCtx *handshakeContext13,
 ) (Flight, *alert.Alert, error) {
 	serverHelloSeq, msgs, items, ok := flightCtx.cache.FullPullMapItems(
@@ -279,11 +279,17 @@ func flight13_3Parse(
 		if err := flightCtx.handshakeRecordProtectionInitializer(flightCtx.state); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
+		flightCtx.state.RemoteEpoch.Store(EpochHandshake)
+		if conn != nil {
+			if err := conn.HandleQueuedPackets(ctx); err != nil {
+				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+			}
+		}
 	}
 
 	seq, msgs, items, ok := flightCtx.cache.FullPullMapItems(
 		serverHelloSeq, flightCtx.state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeEncryptedExtensions, Epoch: flightCtx.cfg.InitialEpoch + 1, IsClient: false, Optional: false}, //nolint:lll
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false, Optional: false}, //nolint:lll
 	)
 	if !ok {
 		return 0, nil, nil
@@ -310,9 +316,8 @@ func flight13_1Generate(
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 
-	var zeroEpoch uint16
-	state.LocalEpoch.Store(zeroEpoch)
-	state.RemoteEpoch.Store(zeroEpoch)
+	state.LocalEpoch.Store(EpochInitial)
+	state.RemoteEpoch.Store(EpochInitial)
 	if len(cfg.EllipticCurves) < 1 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}

--- a/internal/flight/flight13/flighthandlers_server_13.go
+++ b/internal/flight/flight13/flighthandlers_server_13.go
@@ -274,9 +274,8 @@ func flight13_0Generate(
 		}
 	}
 
-	var zeroEpoch uint16
-	state.LocalEpoch.Store(zeroEpoch)
-	state.RemoteEpoch.Store(zeroEpoch)
+	state.LocalEpoch.Store(EpochInitial)
+	state.RemoteEpoch.Store(EpochInitial)
 	if len(cfg.EllipticCurves) < 1 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
@@ -548,7 +547,7 @@ func flight13_4Generate(
 			Record: &recordlayer.RecordLayer{
 				Header: recordlayer.Header{
 					Version: protocol.Version1_2,
-					Epoch:   1,
+					Epoch:   EpochHandshake,
 				},
 				Content: &handshake.Handshake{
 					Message: &handshake.MessageEncryptedExtensions{},

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -59,7 +59,11 @@ func flight13GenerateForTest(
 	return gen(nil, flightCtx.state, flightCtx.cache, flightCtx.cfg)
 }
 
-type flightTestConn struct{}
+type flightTestConn struct {
+	localEpoch          uint16
+	setLocalEpochCalled bool
+	handleQueuedPackets func(context.Context) error
+}
 
 func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description) error {
 	return nil
@@ -73,9 +77,16 @@ func (c *flightTestConn) RecvHandshake() <-chan RecvHandshakeState {
 	return nil
 }
 
-func (c *flightTestConn) SetLocalEpoch(uint16) {}
+func (c *flightTestConn) SetLocalEpoch(epoch uint16) {
+	c.localEpoch = epoch
+	c.setLocalEpochCalled = true
+}
 
-func (c *flightTestConn) HandleQueuedPackets(context.Context) error {
+func (c *flightTestConn) HandleQueuedPackets(ctx context.Context) error {
+	if c.handleQueuedPackets != nil {
+		return c.handleQueuedPackets(ctx)
+	}
+
 	return nil
 }
 
@@ -258,7 +269,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscri
 	assert.Equal(t, 1, state.HandshakeSendSequence)
 }
 
-func TestHandshakeFSM13PrepareDerivesTrafficSecretsBeforeEncryptedExtensions(t *testing.T) {
+func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	group := cfg.EllipticCurves[0]
 	keypair, err := elliptic.GenerateKeypair(group)
@@ -279,10 +290,13 @@ func TestHandshakeFSM13PrepareDerivesTrafficSecretsBeforeEncryptedExtensions(t *
 	fsm, err := newFSM13(state, dtlsflight.NewCache(), cfg, dtlsflight13.Flight4, nil, transcript)
 	require.NoError(t, err)
 
-	nextState, err := fsm.prepare(context.Background(), &flightTestConn{})
+	conn := &flightTestConn{}
+	nextState, err := fsm.prepare(context.Background(), conn)
 	require.NoError(t, err)
 	assert.Equal(t, StateSending, nextState)
 	require.Len(t, fsm.flights, 2)
+	assert.Equal(t, dtlsflight13.EpochHandshake, fsm.flights[1].Record.Header.Epoch)
+	assert.True(t, fsm.flights[1].ShouldEncrypt)
 
 	serverHelloCanonical := canonicalPacketHandshake13(t, fsm.flights[0])
 	encryptedExtensionsCanonical := canonicalPacketHandshake13(t, fsm.flights[1])
@@ -303,6 +317,8 @@ func TestHandshakeFSM13PrepareDerivesTrafficSecretsBeforeEncryptedExtensions(t *
 	require.NoError(t, err)
 	assert.Equal(t, expectedSecrets, state.HandshakeTrafficSecrets13)
 	assert.True(t, state.CipherSuite.IsInitialized())
+	assert.True(t, conn.setLocalEpochCalled)
+	assert.Equal(t, dtlsflight13.EpochHandshake, conn.localEpoch)
 }
 
 func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Packet) []byte {


### PR DESCRIPTION
#### Description
fixes many issues with DTLS 1.3 epoch handling, and adds explicit constants for DTLS 1.3 epoch values.
#### Reference issue
Fixes #896 part of #755 important for #825