### PR TITLE
Unblock reads when conn is closed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -194,6 +194,7 @@ type Conn struct {
 	handshakeCompletedSuccessfully atomic.Bool
 	handshakeMutex                 sync.Mutex
 	handshakeDone                  chan struct{}
+	writeLock                      sync.Mutex
 
 	encryptedPackets []addrPkt
 
@@ -838,6 +839,8 @@ func (c *Conn) Read(buff []byte) (n int, err error) { //nolint:cyclop
 
 	for {
 		select {
+		case <-c.closed.Done():
+			return 0, io.EOF
 		case <-c.readDeadline.Done():
 			return 0, dtlserrors.ErrDeadlineExceeded
 		case out, ok := <-c.decrypted:
@@ -877,7 +880,10 @@ func (c *Conn) Write(payload []byte) (int, error) {
 
 	//nolint:godox
 	// TODO: check for version
-	return len(payload), c.writePackets(c.writeDeadline, []*dtlsflight.Packet{
+	ctx, cancel := c.contextWithClose(c.writeDeadline)
+	defer cancel()
+
+	return len(payload), c.writePackets(ctx, []*dtlsflight.Packet{
 		{
 			Record: &recordlayer.RecordLayer{
 				Header: recordlayer.Header{
@@ -940,55 +946,147 @@ func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
 }
 
 func (c *Conn) writePackets(ctx context.Context, pkts []*dtlsflight.Packet) error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+
+	compactedRawPackets, rAddr, err := c.prepareRawPackets(pkts)
+	if err != nil {
+		return err
+	}
+
+	for _, compactedRawPacket := range compactedRawPackets {
+		if _, err = c.nextConn.WriteToContext(ctx, compactedRawPacket, rAddr); err != nil {
+			if errors.Is(err, context.Canceled) && c.isConnectionClosed() {
+				return ErrConnClosed
+			}
+
+			return netError(err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Conn) prepareRawPackets(pkts []*dtlsflight.Packet) ([][]byte, net.Addr, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	var rawPackets [][]byte
 
 	for _, pkt := range pkts {
-		if dtlsHandshake, ok := pkt.Record.Content.(*handshake.Handshake); ok {
-			handshakeRaw, err := pkt.Record.Marshal()
-			if err != nil {
-				return err
-			}
-
-			c.log.Tracef("[handshake:%v] -> %s (epoch: %d, seq: %d)",
-				srvCliStr(c.state.IsClient), dtlsHandshake.Header.Type.String(),
-				pkt.Record.Header.Epoch, dtlsHandshake.Header.MessageSequence)
-
-			c.handshakeCache.Push(
-				handshakeRaw[recordlayer.FixedHeaderSize:],
-				pkt.Record.Header.Epoch,
-				dtlsHandshake.Header.MessageSequence,
-				dtlsHandshake.Header.Type,
-				c.state.IsClient,
-			)
-
-			rawHandshakePackets, err := c.processHandshakePacket(pkt, dtlsHandshake)
-			if err != nil {
-				return err
-			}
-			rawPackets = append(rawPackets, rawHandshakePackets...)
-		} else {
-			rawPacket, err := c.processPacket(pkt)
-			if err != nil {
-				return err
-			}
-			rawPackets = append(rawPackets, rawPacket)
+		pktRawPackets, err := c.prepareRawPacket(pkt)
+		if err != nil {
+			return nil, nil, err
 		}
+
+		rawPackets = append(rawPackets, pktRawPackets...)
 	}
 	if len(rawPackets) == 0 {
-		return nil
+		return nil, nil, nil
 	}
-	compactedRawPackets := c.compactRawPackets(rawPackets)
 
-	for _, compactedRawPackets := range compactedRawPackets {
-		if _, err := c.nextConn.WriteToContext(ctx, compactedRawPackets, c.rAddr); err != nil {
-			return netError(err)
+	return c.compactRawPackets(rawPackets), c.rAddr, nil
+}
+
+func (c *Conn) prepareRawPacket(pkt *dtlsflight.Packet) ([][]byte, error) {
+	dtlsHandshake, ok := pkt.Record.Content.(*handshake.Handshake)
+	if ok {
+		if err := c.cacheHandshakePacket(pkt, dtlsHandshake); err != nil {
+			return nil, err
 		}
+
+		return c.processHandshakePacket(pkt, dtlsHandshake)
 	}
+
+	rawPacket, err := c.processPacket(pkt)
+	if err != nil {
+		return nil, err
+	}
+
+	return [][]byte{rawPacket}, nil
+}
+
+func (c *Conn) cacheHandshakePacket(pkt *dtlsflight.Packet, dtlsHandshake *handshake.Handshake) error {
+	handshakeRaw, err := pkt.Record.Marshal()
+	if err != nil {
+		return err
+	}
+
+	c.log.Tracef("[handshake:%v] -> %s (epoch: %d, seq: %d)",
+		srvCliStr(c.state.IsClient), dtlsHandshake.Header.Type.String(),
+		pkt.Record.Header.Epoch, dtlsHandshake.Header.MessageSequence)
+
+	c.handshakeCache.Push(
+		handshakeRaw[recordlayer.FixedHeaderSize:],
+		pkt.Record.Header.Epoch,
+		dtlsHandshake.Header.MessageSequence,
+		dtlsHandshake.Header.Type,
+		c.state.IsClient,
+	)
 
 	return nil
+}
+
+type closeContext struct {
+	context.Context //nolint:containedctx
+	done            chan struct{}
+	errMu           sync.RWMutex
+	err             error
+	doneOnce        sync.Once
+}
+
+func (c *closeContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *closeContext) Err() error {
+	c.errMu.RLock()
+	err := c.err
+	c.errMu.RUnlock()
+	if err != nil {
+		return err
+	}
+
+	return c.Context.Err()
+}
+
+func (c *closeContext) close(err error) {
+	c.doneOnce.Do(func() {
+		c.errMu.Lock()
+		c.err = err
+		c.errMu.Unlock()
+		close(c.done)
+	})
+}
+
+func (c *Conn) contextWithClose(ctx context.Context) (context.Context, context.CancelFunc) {
+	closeCtx := &closeContext{
+		Context: ctx,
+		done:    make(chan struct{}),
+	}
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-c.closed.Done():
+			closeCtx.close(context.Canceled)
+		case <-ctx.Done():
+			err := ctx.Err()
+			if err == nil {
+				err = context.DeadlineExceeded
+			}
+			closeCtx.close(err)
+		case <-stop:
+		}
+	}()
+
+	var stopOnce sync.Once
+	cancel := func() {
+		stopOnce.Do(func() {
+			close(stop)
+		})
+	}
+
+	return closeCtx, cancel
 }
 
 func (c *Conn) compactRawPackets(rawPackets [][]byte) [][]byte {
@@ -2024,33 +2122,27 @@ func (c *Conn) close(byUser bool) error {
 	c.closeLock.Lock()
 	cancelHandshaker := c.cancelHandshaker
 	cancelHandshakeReader := c.cancelHandshakeReader
-	c.closeLock.Unlock()
-
-	cancelHandshaker()
-	cancelHandshakeReader()
-
-	if c.isHandshakeCompletedSuccessfully() && byUser {
-		// Discard error from notify() to return non-error on the first user call of Close()
-		// even if the underlying connection is already closed.
-		_ = c.notify(context.Background(), alert.Warning, alert.CloseNotify)
-	}
-
-	c.closeLock.Lock()
-	// Don't return ErrConnClosed at the first time of the call from user.
 	closedByUser := c.connectionClosedByUser
 	if byUser {
 		c.connectionClosedByUser = true
 	}
 	isClosed := c.isConnectionClosed()
-	c.closed.Close()
+	if !isClosed {
+		c.closed.Close()
+	}
 	c.closeLock.Unlock()
 
-	if closedByUser {
-		return ErrConnClosed
+	cancelHandshaker()
+	cancelHandshakeReader()
+
+	if closedByUser || isClosed {
+		return nil
 	}
 
-	if isClosed {
-		return nil
+	if c.isHandshakeCompletedSuccessfully() && byUser {
+		// Discard error from notify() to return non-error on user Close()
+		// even if the underlying connection is already closed.
+		_ = c.notify(context.Background(), alert.Warning, alert.CloseNotify)
 	}
 
 	return c.nextConn.Close()

--- a/conn_test.go
+++ b/conn_test.go
@@ -111,6 +111,34 @@ func TestRoutineLeakOnClose(t *testing.T) {
 	// inboundLoop routine should not be leaked.
 }
 
+func TestReadUnblocksOnClose(t *testing.T) {
+	lim := test.TimeOut(5 * time.Second)
+	defer lim.Stop()
+
+	ca, cb, err := pipeMemory()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cb.Close())
+	}()
+
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := ca.Read(buf)
+		readErr <- err
+	}()
+
+	assert.NoError(t, ca.Close())
+	assert.NoError(t, ca.Close())
+
+	select {
+	case err := <-readErr:
+		assert.ErrorIs(t, err, io.EOF)
+	case <-time.After(time.Second):
+		assert.Fail(t, "Read did not unblock after Close")
+	}
+}
+
 func TestReadWriteDeadline(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(5 * time.Second)


### PR DESCRIPTION
#### Description
I noticed that the CI sometimes fails with timeout (esp TestNetTest/pingpong) and i thought it was flaky slow CI, but i noticed the same issue locally and during interop tests. 
And by tracking the issue it turns out that conn can actually block on write if the connection is closed. This was fixed a while ago for SCTP users by doing writeDeadline https://github.com/pion/sctp/pull/465 but it doesn't fix it at DTLS side.
Did unrelated refactor to make the linter happy.
The back-port for v3: https://github.com/pion/dtls/pull/899
