### PR TITLE
Remove outdated unused nolints

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1325,17 +1325,6 @@ func (c *Conn) maxQueueableFutureEpoch(remoteEpoch uint16) uint16 {
 	return maxEpoch
 }
 
-// nolint:unused
-func (c *Conn) handleIncomingPacket13(
-	ctx context.Context,
-	buf []byte,
-	rAddr net.Addr,
-	enqueue bool,
-) (bool, bool, *alert.Alert, error) {
-	// Placeholder function
-	return false, false, nil, nil
-}
-
 //nolint:gocognit,gocyclo,cyclop,maintidx
 func (c *Conn) handleIncomingPacket(
 	ctx context.Context,

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -109,7 +109,7 @@ func selectServerHelloCipherSuite(
 	return selectedCipherSuite, nil, nil
 }
 
-// nolint:unused,cyclop
+// nolint:cyclop
 func flight1Parse(
 	ctx context.Context,
 	conn dtlsflight.Conn,

--- a/internal/flight/flight13/flighthandlers_server.go
+++ b/internal/flight/flight13/flighthandlers_server.go
@@ -155,7 +155,7 @@ func processClientHelloStateExtension(
 	}
 }
 
-//nolint:cyclop,gocognit,gocyclo,unused
+//nolint:cyclop,gocognit,gocyclo
 func flight0Parse(
 	_ context.Context,
 	_ dtlsflight.Conn,

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -68,8 +68,8 @@ import (
 
 type fsm13 struct {
 	currentFlight      dtlsflight13.Flight
-	flights            []*dtlsflight.Packet //nolint:unused
-	retransmit         bool                 //nolint:unused
+	flights            []*dtlsflight.Packet
+	retransmit         bool
 	retransmitInterval time.Duration
 	state              *dtlsstate.State
 	cache              *dtlsflight.Cache


### PR DESCRIPTION
#### Description
remove all the nolint:unused that were added early on, before wiring flights and the rest of the code.
removes an actually unused function that doesn't make sense with the new design.