### PR TITLE
Hook protected records into cache

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2062,6 +2062,7 @@ func (c *Conn) handleIncomingPacket(
 	header := prepared.header
 	markPacketAsValid := prepared.markPacketAsValid
 
+	c.syncFragmentBufferHandshakeSequence()
 	isHandshake, isRetransmit, err := c.fragmentBuffer.push(append([]byte{}, buf...))
 	if err != nil {
 		// Decode error must be silently discarded
@@ -2153,6 +2154,15 @@ func (c *Conn) handleIncomingPacket(
 	}
 
 	return false, false, nil, nil
+}
+
+func (c *Conn) syncFragmentBufferHandshakeSequence() {
+	if c.fragmentBuffer == nil || c.state.HandshakeRecvSequence <= 0 ||
+		c.state.HandshakeRecvSequence > int(^uint16(0)) {
+		return
+	}
+
+	c.fragmentBuffer.advanceTo(uint16(c.state.HandshakeRecvSequence)) //nolint:gosec // G115 checked above.
 }
 
 func (c *Conn) recvHandshake() <-chan dtlshandshake.RecvHandshakeState {

--- a/conn_test.go
+++ b/conn_test.go
@@ -4038,9 +4038,11 @@ func TestOpenCiphertextRecordFailsWithTamperedCiphertext(t *testing.T) {
 	assert.ErrorIs(t, err, dtlserrors.ErrDecryptPacket)
 }
 
-func TestOpenCiphertextRecordDispatchesInnerHandshake(t *testing.T) {
+func TestDTLS13DecryptedEncryptedExtensionsIsCached(t *testing.T) {
 	conn, peerCipherSuite := newTestConnWithReadProtection(t)
-	record := sealTestProtectedHandshakeRecord(t, peerCipherSuite, encryptedExtensionsHandshake(t))
+	conn.state.HandshakeRecvSequence = 1
+	expectedPlaintext := encryptedExtensionsHandshakeWithSequence(t, 1)
+	record := sealTestProtectedHandshakeRecord(t, peerCipherSuite, expectedPlaintext)
 	rawPacket, err := record.Marshal()
 	assert.NoError(t, err)
 
@@ -4050,15 +4052,36 @@ func TestOpenCiphertextRecordDispatchesInnerHandshake(t *testing.T) {
 	assert.True(t, isHandshake)
 	assert.False(t, isRetransmit)
 
-	_, messages, ok := conn.handshakeCache.FullPullMap(0, conn.state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{
-			Typ:      handshake.TypeEncryptedExtensions,
-			Epoch:    dtlsflight13.EpochHandshake,
-			IsClient: false,
-		},
-	)
+	items := conn.handshakeCache.Pull(dtlsflight.HandshakeCachePullRule{
+		Typ:      handshake.TypeEncryptedExtensions,
+		Epoch:    dtlsflight13.EpochHandshake,
+		IsClient: false,
+	})
+	if assert.Len(t, items, 1) && assert.NotNil(t, items[0]) {
+		assert.Equal(t, dtlsflight13.EpochHandshake, items[0].Epoch)
+		assert.Equal(t, uint16(1), items[0].MessageSequence)
+		assert.Equal(t, expectedPlaintext, items[0].Data)
+	}
+}
+
+func TestDTLS13ProtectedHandshakeRecordKeepsEpochAndSequence(t *testing.T) {
+	conn, peerCipherSuite := newTestConnWithReadProtection(t)
+	const sequenceNumber = uint64(0x1002a)
+	conn.updateRemoteSequenceNumber(dtlsflight13.EpochHandshake, 0x10005)
+	expectedPlaintext := encryptedExtensionsHandshakeWithSequence(t, 0)
+	record := sealTestProtectedHandshakeRecordWithSequence(t, peerCipherSuite, expectedPlaintext, sequenceNumber)
+	rawPacket, err := record.Marshal()
+	assert.NoError(t, err)
+
+	prepared, ok := conn.prepareIncomingPacket(rawPacket, nil, true)
 	assert.True(t, ok)
-	assert.IsType(t, &handshake.MessageEncryptedExtensions{}, messages[handshake.TypeEncryptedExtensions])
+	if assert.NotNil(t, prepared.header) {
+		assert.Equal(t, protocol.ContentTypeHandshake, prepared.header.ContentType)
+		assert.Equal(t, dtlsflight13.EpochHandshake, prepared.header.Epoch)
+		assert.Equal(t, sequenceNumber, prepared.header.SequenceNumber)
+		assert.Equal(t, uint16(len(expectedPlaintext)), prepared.header.ContentLen) //nolint:gosec
+		assert.Equal(t, appendProtectedRecordHeader(t, prepared.header, expectedPlaintext), prepared.buf)
+	}
 }
 
 func newTestConnWithWriteProtection(t *testing.T) (*Conn, ciphersuite.CipherSuiteTLS13) {
@@ -4114,7 +4137,14 @@ func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuite
 func encryptedExtensionsHandshake(t *testing.T) []byte {
 	t.Helper()
 
+	return encryptedExtensionsHandshakeWithSequence(t, 0)
+}
+
+func encryptedExtensionsHandshakeWithSequence(t *testing.T, messageSequence uint16) []byte {
+	t.Helper()
+
 	raw, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: messageSequence},
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	assert.NoError(t, err)
@@ -4129,17 +4159,37 @@ func sealTestProtectedHandshakeRecord(
 ) recordlayer.CiphertextRecord13 {
 	t.Helper()
 
+	return sealTestProtectedHandshakeRecordWithSequence(t, cipherSuite, plaintext, 0)
+}
+
+func sealTestProtectedHandshakeRecordWithSequence(
+	t *testing.T,
+	cipherSuite ciphersuite.CipherSuiteTLS13,
+	plaintext []byte,
+	sequenceNumber uint64,
+) recordlayer.CiphertextRecord13 {
+	t.Helper()
+
 	record, err := cipherSuite.Seal(
 		recordlayer.UnifiedHeader{
 			EpochLow: uint8(dtlsflight13.EpochHandshake & recordlayer.TwoLowBitsMask),
 		},
-		0,
+		sequenceNumber,
 		protocol.ContentTypeHandshake,
 		plaintext,
 	)
 	assert.NoError(t, err)
 
 	return record
+}
+
+func appendProtectedRecordHeader(t *testing.T, header *recordlayer.Header, content []byte) []byte {
+	t.Helper()
+
+	headerRaw, err := header.Marshal()
+	assert.NoError(t, err)
+
+	return append(headerRaw, content...)
 }
 
 func openTestProtectedRecord(

--- a/flight_test.go
+++ b/flight_test.go
@@ -958,6 +958,86 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 	assert.Equal(t, 2, state.HandshakeRecvSequence)
 }
 
+func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cache := dtlsflight.NewCache()
+	conn := &Conn{
+		fragmentBuffer:          newFragmentBuffer(),
+		handshakeCache:          cache,
+		maximumTransmissionUnit: defaultMTU,
+		replayProtectionWindow:  defaultReplayProtectionWindow,
+		log:                     logging.NewDefaultLoggerFactory().NewLogger("dtls"),
+		state:                   dtlsstate.State{IsClient: true},
+	}
+	state := &conn.state
+	transcript := dtlshandshake.NewTranscript()
+
+	clientHello, _, err := flight13GenerateForTest(t, Flight1, &handshakeTestContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+	appended, err := dtlshandshake.AppendClientHelloInitialFlights(transcript, clientHello)
+	require.NoError(t, err)
+	require.True(t, appended)
+	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello[0])
+
+	group := cfg.EllipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
+		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
+	}, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
+	require.NoError(t, err)
+	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
+
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	preMasterSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	secrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		preMasterSecret,
+		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	peerCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
+	require.NoError(t, peerCipherSuite.InitFromTrafficSecrets(secrets.Client, secrets.Server, false))
+
+	rawEncryptedExtensions, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageEncryptedExtensions{},
+	}).Marshal()
+	require.NoError(t, err)
+	protectedRecord := sealTestProtectedHandshakeRecord(t, peerCipherSuite, rawEncryptedExtensions)
+	protectedRaw, err := protectedRecord.Marshal()
+	require.NoError(t, err)
+	conn.encryptedPackets = []addrPkt{{data: protectedRaw}}
+
+	nextFlight, dtlsAlert, err := flight13ParseForTestWithConn(
+		t, Flight3, context.Background(), adaptFlightConn(conn), &handshakeTestContext13{
+			state:      state,
+			cache:      cache,
+			cfg:        cfg,
+			transcript: transcript,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, Flight5, nextFlight)
+	assert.Equal(t, 2, state.HandshakeRecvSequence)
+
+	items := cache.Pull(dtlsflight.HandshakeCachePullRule{
+		Typ:      handshake.TypeEncryptedExtensions,
+		Epoch:    dtlsflight13.EpochHandshake,
+		IsClient: false,
+	})
+	if assert.Len(t, items, 1) && assert.NotNil(t, items[0]) {
+		assert.Equal(t, rawEncryptedExtensions, items[0].Data)
+	}
+}
+
 func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := &dtlsstate.State{}

--- a/fragment_buffer.go
+++ b/fragment_buffer.go
@@ -47,6 +47,23 @@ func (f *fragmentBuffer) size() int {
 	return f.totalBufferSize
 }
 
+func (f *fragmentBuffer) advanceTo(messageSequence uint16) {
+	if messageSequence <= f.currentMessageSequenceNumber {
+		return
+	}
+
+	for cachedSequence, cachedFragments := range f.cache {
+		if cachedSequence >= messageSequence {
+			continue
+		}
+		f.totalBufferSize -= int(cachedFragments.fragmentsLength)
+		f.totalFragmentCount -= len(cachedFragments.fragmentByOffset)
+		delete(f.cache, cachedSequence)
+	}
+
+	f.currentMessageSequenceNumber = messageSequence
+}
+
 // Attempts to push a DTLS packet to the fragmentBuffer
 // when it returns true it means the fragmentBuffer has inserted and the buffer shouldn't be handled
 // when an error returns it is fatal, and the DTLS connection should be stopped.

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -222,7 +222,7 @@ func flight3Parse(
 	if failure != nil {
 		return 0, failure.alert, failure.err
 	}
-	failure = initializeFlight3HandshakeProtection(ctx, conn, flightCtx, items)
+	failure = initializeFlight3HandshakeProtection(ctx, conn, flightCtx, serverHelloSeq, items)
 	if failure != nil {
 		return 0, failure.alert, failure.err
 	}
@@ -345,11 +345,13 @@ func initializeFlight3HandshakeProtection(
 	ctx context.Context,
 	conn dtlsflight.Conn,
 	flightCtx *handshakeContext,
+	serverHelloSeq int,
 	items []*dtlsflight.HandshakeCacheItem,
 ) *flightParseFailure {
 	if failure := handleFlight3InboundHandshake(flightCtx, items); failure != nil {
 		return failure
 	}
+	flightCtx.state.HandshakeRecvSequence = serverHelloSeq
 	if flightCtx.handshakeTrafficSecretDeriver != nil {
 		if err := flightCtx.handshakeTrafficSecretDeriver(flightCtx.state); err != nil {
 			return newFlightParseFailure(alert.InternalError, err)


### PR DESCRIPTION
#### Description
a small change to route decrypted handshake records into handshake cache
part of #825, Refs #852, Refs #755 refs #727 
