### PR TITLE
Rename 1.3 preMasterSecret to keyAgreementSecret

### DIFF
--- a/flight_test.go
+++ b/flight_test.go
@@ -185,7 +185,7 @@ func hashTranscript13(messages ...[]byte) []byte {
 
 func deriveHandshakeTrafficSecrets13(
 	hashFunc func() hash.Hash,
-	preMasterSecret, transcriptHash []byte,
+	keyAgreementSecret, transcriptHash []byte,
 ) (dtlsstate.TrafficSecrets, error) {
 	hashSize := hashFunc().Size()
 	zeroSecret := make([]byte, hashSize)
@@ -199,7 +199,7 @@ func deriveHandshakeTrafficSecrets13(
 		return dtlsstate.TrafficSecrets{}, err
 	}
 
-	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, preMasterSecret)
+	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, keyAgreementSecret)
 	if err != nil {
 		return dtlsstate.TrafficSecrets{}, err
 	}
@@ -999,11 +999,11 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 
 	clientKeypair := state.LocalKeypairs[group]
 	require.NotNil(t, clientKeypair)
-	preMasterSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	keyAgreementSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
 	require.NoError(t, err)
 	secrets, err := deriveHandshakeTrafficSecrets13(
 		cfg.LocalCipherSuites[0].HashFunc(),
-		preMasterSecret,
+		keyAgreementSecret,
 		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
 	)
 	require.NoError(t, err)

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -330,11 +330,11 @@ func applyFlight3ServerKeyShare(
 		return newFlightParseFailure(alert.IllegalParameter, dtlserrors.ErrServerKeyShareUnknownGroup)
 	}
 
-	preMasterSecret, err := prf.PreMasterSecret(serverShare.KeyExchange, localKeypair.PrivateKey, serverShare.Group)
+	keyAgreementSecret, err := prf.PreMasterSecret(serverShare.KeyExchange, localKeypair.PrivateKey, serverShare.Group)
 	if err != nil {
 		return newFlightParseFailure(alert.InternalError, err)
 	}
-	flightCtx.state.KeyAgreementSecret = preMasterSecret
+	flightCtx.state.KeyAgreementSecret = keyAgreementSecret
 	flightCtx.state.SelectedGroup = serverShare.Group
 	flightCtx.state.RemoteKeyEntries = &[]extension.KeyShareEntry{*serverShare}
 

--- a/internal/flight/flight13/flighthandlers_server.go
+++ b/internal/flight/flight13/flighthandlers_server.go
@@ -373,7 +373,7 @@ func generateClientKeyShareSecret(
 		state.LocalKeypair = keypair
 	}
 
-	preMasterSecret, err := prf.PreMasterSecret(
+	keyAgreementSecret, err := prf.PreMasterSecret(
 		selectedEntry.KeyExchange,
 		state.LocalKeypair.PrivateKey,
 		state.SelectedGroup,
@@ -381,7 +381,7 @@ func generateClientKeyShareSecret(
 	if err != nil {
 		return newClientHelloExtensionFailure(alert.IllegalParameter, err)
 	}
-	state.KeyAgreementSecret = preMasterSecret
+	state.KeyAgreementSecret = keyAgreementSecret
 
 	return nil
 }

--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -27,13 +27,13 @@ const (
 // handshake traffic secrets from the ECDHE secret and transcript hash.
 func deriveHandshakeTrafficSecrets(
 	hashFunc func() hash.Hash,
-	preMasterSecret, transcriptHash []byte,
+	keyAgreementSecret, transcriptHash []byte,
 ) (dtlsstate.HandshakeTrafficSecrets, error) {
 	hashSize, err := hashSize13(hashFunc)
 	if err != nil {
 		return dtlsstate.HandshakeTrafficSecrets{}, err
 	}
-	if len(preMasterSecret) == 0 || len(transcriptHash) != hashSize {
+	if len(keyAgreementSecret) == 0 || len(transcriptHash) != hashSize {
 		return dtlsstate.HandshakeTrafficSecrets{}, dtlserrors.ErrLengthMismatch
 	}
 
@@ -48,7 +48,7 @@ func deriveHandshakeTrafficSecrets(
 		return dtlsstate.HandshakeTrafficSecrets{}, err
 	}
 
-	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, preMasterSecret)
+	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, keyAgreementSecret)
 	if err != nil {
 		return dtlsstate.HandshakeTrafficSecrets{}, err
 	}

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -338,19 +338,19 @@ func TestHandshakeTranscript13HelloRetryRequestErrors(t *testing.T) {
 }
 
 func TestDeriveHandshakeTrafficSecrets13NoHRRAndHRR(t *testing.T) {
-	preMasterSecret := bytes.Repeat([]byte{0x42}, sha256.Size)
+	keyAgreementSecret := bytes.Repeat([]byte{0x42}, sha256.Size)
 
 	clientHello := canonicalTranscriptHandshake13(handshake.TypeClientHello, []byte{0x01})
 	serverHello := canonicalTranscriptHandshake13(handshake.TypeServerHello, []byte{0x02})
 	noHRRTranscriptHash := hashTranscript13(clientHello, serverHello)
 
-	noHRRSecrets, err := deriveHandshakeTrafficSecrets(sha256.New, preMasterSecret, noHRRTranscriptHash)
+	noHRRSecrets, err := deriveHandshakeTrafficSecrets(sha256.New, keyAgreementSecret, noHRRTranscriptHash)
 	require.NoError(t, err)
 	require.Len(t, noHRRSecrets.Client, sha256.Size)
 	require.Len(t, noHRRSecrets.Server, sha256.Size)
 	assert.NotEqual(t, noHRRSecrets.Client, noHRRSecrets.Server)
 
-	again, err := deriveHandshakeTrafficSecrets(sha256.New, preMasterSecret, noHRRTranscriptHash)
+	again, err := deriveHandshakeTrafficSecrets(sha256.New, keyAgreementSecret, noHRRTranscriptHash)
 	require.NoError(t, err)
 	assert.Equal(t, noHRRSecrets, again)
 
@@ -361,12 +361,12 @@ func TestDeriveHandshakeTrafficSecrets13NoHRRAndHRR(t *testing.T) {
 	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, hashTranscript13(clientHello1))
 	hrrTranscriptHash := hashTranscript13(messageHash, helloRetryRequest, clientHello2, serverHello2)
 
-	hrrSecrets, err := deriveHandshakeTrafficSecrets(sha256.New, preMasterSecret, hrrTranscriptHash)
+	hrrSecrets, err := deriveHandshakeTrafficSecrets(sha256.New, keyAgreementSecret, hrrTranscriptHash)
 	require.NoError(t, err)
 	assert.NotEqual(t, noHRRSecrets.Client, hrrSecrets.Client)
 	assert.NotEqual(t, noHRRSecrets.Server, hrrSecrets.Server)
 
-	changedSecret := append([]byte(nil), preMasterSecret...)
+	changedSecret := append([]byte(nil), keyAgreementSecret...)
 	changedSecret[0] ^= 0xff
 	changedSecrets, err := deriveHandshakeTrafficSecrets(sha256.New, changedSecret, noHRRTranscriptHash)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Description
preMasterSecret is DTLS/TLS 1.2 term. and doesn't make sense as a name for keyAgreementSecret now we have separate 1.2 and 1.3 states
