### PR TITLE
Delay BasicIO test close

### DIFF
--- a/nettest_test.go
+++ b/nettest_test.go
@@ -8,6 +8,7 @@ package dtls
 import (
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,14 +16,23 @@ import (
 	"golang.org/x/net/nettest"
 )
 
+const nettestBasicIOCloseDelay = 50 * time.Millisecond
+
 func TestNetTest(t *testing.T) {
 	lim := test.TimeOut(time.Minute*1 + time.Second*10)
 	defer lim.Stop()
+
+	var makePipeCalls atomic.Int32
 
 	nettest.TestConn(t, func() (c1, c2 net.Conn, stop func(), err error) {
 		c1, c2, err = pipeMemory()
 		if err != nil {
 			return nil, nil, nil, err
+		}
+
+		if makePipeCalls.Add(1) == 1 {
+			c1 = &delayedCloseConn{Conn: c1, delay: nettestBasicIOCloseDelay}
+			c2 = &delayedCloseConn{Conn: c2, delay: nettestBasicIOCloseDelay}
 		}
 
 		var stopOnce sync.Once
@@ -35,4 +45,21 @@ func TestNetTest(t *testing.T) {
 
 		return c1, c2, stop, nil
 	})
+}
+
+type delayedCloseConn struct {
+	net.Conn
+	delay time.Duration
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (c *delayedCloseConn) Close() error {
+	c.closeOnce.Do(func() {
+		time.Sleep(c.delay)
+		c.closeErr = c.Conn.Close()
+	})
+
+	return c.closeErr
 }


### PR DESCRIPTION
#### Description
close_notify sometimes beat final data delivery, truncating BasicIO reads happens when the CI is slow. esp on x86