### PR TITLE
Derive handshake master secret

### DIFF
--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -13,15 +13,20 @@ import (
 )
 
 const (
-	clientHandshakeTrafficLabel13 = "c hs traffic"
-	serverHandshakeTrafficLabel13 = "s hs traffic"
-	derivedSecretLabel13          = "derived"
-	finishedLabel13               = "finished"
+	clientHandshakeTrafficLabel = "c hs traffic"
+	serverHandshakeTrafficLabel = "s hs traffic"
+	derivedSecretLabel          = "derived"
+	finishedLabel               = "finished"
 
 	serverCertificateVerifyContext13 = "TLS 1.3, server CertificateVerify\x00"
 	clientCertificateVerifyContext13 = "TLS 1.3, client CertificateVerify\x00"
 	certificateVerifyPaddingLen13    = 64
 )
+
+type handshakeKeySchedule struct {
+	HandshakeTrafficSecrets dtlsstate.TrafficSecrets
+	MasterSecret            []byte
+}
 
 // deriveHandshakeTrafficSecrets derives the DTLS 1.3 client and server
 // handshake traffic secrets from the ECDHE secret and transcript hash.
@@ -29,56 +34,120 @@ func deriveHandshakeTrafficSecrets(
 	hashFunc func() hash.Hash,
 	keyAgreementSecret, transcriptHash []byte,
 ) (dtlsstate.HandshakeTrafficSecrets, error) {
-	hashSize, err := hashSize13(hashFunc)
+	secrets, err := deriveHandshakeKeySchedule(hashFunc, keyAgreementSecret, transcriptHash)
 	if err != nil {
 		return dtlsstate.HandshakeTrafficSecrets{}, err
 	}
+
+	return secrets.HandshakeTrafficSecrets, nil
+}
+
+func deriveHandshakeKeySchedule(
+	hashFunc func() hash.Hash,
+	keyAgreementSecret, transcriptHash []byte,
+) (handshakeKeySchedule, error) {
+	hashSize, err := hashSize13(hashFunc)
+	if err != nil {
+		return handshakeKeySchedule{}, err
+	}
 	if len(keyAgreementSecret) == 0 || len(transcriptHash) != hashSize {
-		return dtlsstate.HandshakeTrafficSecrets{}, dtlserrors.ErrLengthMismatch
+		return handshakeKeySchedule{}, dtlserrors.ErrLengthMismatch
+	}
+
+	handshakeSecret, err := deriveHandshakeSecret(hashFunc, keyAgreementSecret)
+	if err != nil {
+		return handshakeKeySchedule{}, err
+	}
+
+	clientSecret, err := deriveTrafficSecret(
+		hashFunc,
+		handshakeSecret,
+		clientHandshakeTrafficLabel,
+		transcriptHash,
+	)
+	if err != nil {
+		return handshakeKeySchedule{}, err
+	}
+
+	serverSecret, err := deriveTrafficSecret(
+		hashFunc,
+		handshakeSecret,
+		serverHandshakeTrafficLabel,
+		transcriptHash,
+	)
+	if err != nil {
+		return handshakeKeySchedule{}, err
+	}
+
+	masterSecret, err := deriveMasterSecret(hashFunc, handshakeSecret)
+	if err != nil {
+		return handshakeKeySchedule{}, err
+	}
+
+	return handshakeKeySchedule{
+		HandshakeTrafficSecrets: dtlsstate.TrafficSecrets{
+			Client: clientSecret,
+			Server: serverSecret,
+		},
+		MasterSecret: masterSecret,
+	}, nil
+}
+
+func deriveHandshakeSecret(hashFunc func() hash.Hash, keyAgreementSecret []byte) ([]byte, error) {
+	hashSize, err := hashSize13(hashFunc)
+	if err != nil {
+		return nil, err
+	}
+	if len(keyAgreementSecret) == 0 {
+		return nil, dtlserrors.ErrLengthMismatch
 	}
 
 	zeroSecret := make([]byte, hashSize)
 	earlySecret, err := keyschedule.HkdfExtract(hashFunc, nil, zeroSecret)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return nil, err
 	}
 
-	derivedSecret, err := keyschedule.DeriveSecret(hashFunc, earlySecret, derivedSecretLabel13, nil)
+	derivedSecret, err := keyschedule.DeriveSecret(hashFunc, earlySecret, derivedSecretLabel, nil)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return nil, err
 	}
 
-	handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedSecret, keyAgreementSecret)
+	return keyschedule.HkdfExtract(hashFunc, derivedSecret, keyAgreementSecret)
+}
+
+func deriveMasterSecret(hashFunc func() hash.Hash, handshakeSecret []byte) ([]byte, error) {
+	hashSize, err := hashSize13(hashFunc)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return nil, err
+	}
+	if len(handshakeSecret) != hashSize {
+		return nil, dtlserrors.ErrLengthMismatch
 	}
 
-	clientSecret, err := keyschedule.HkdfExpandLabel(
-		hashFunc,
-		handshakeSecret,
-		clientHandshakeTrafficLabel13,
-		transcriptHash,
-		hashSize,
-	)
+	derivedSecret, err := keyschedule.DeriveSecret(hashFunc, handshakeSecret, derivedSecretLabel, nil)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return nil, err
 	}
 
-	serverSecret, err := keyschedule.HkdfExpandLabel(
-		hashFunc,
-		handshakeSecret,
-		serverHandshakeTrafficLabel13,
-		transcriptHash,
-		hashSize,
-	)
+	return keyschedule.HkdfExtract(hashFunc, derivedSecret, make([]byte, hashSize))
+}
+
+func deriveTrafficSecret(
+	hashFunc func() hash.Hash,
+	baseSecret []byte,
+	label string,
+	transcriptHash []byte,
+) ([]byte, error) {
+	hashSize, err := hashSize13(hashFunc)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return nil, err
+	}
+	if len(baseSecret) != hashSize || len(transcriptHash) != hashSize {
+		return nil, dtlserrors.ErrLengthMismatch
 	}
 
-	return dtlsstate.HandshakeTrafficSecrets{
-		Client: clientSecret,
-		Server: serverSecret,
-	}, nil
+	return keyschedule.HkdfExpandLabel(hashFunc, baseSecret, label, transcriptHash, hashSize)
 }
 
 // DeriveAndStoreHandshakeTrafficSecrets derives DTLS 1.3 handshake traffic
@@ -99,7 +168,7 @@ func DeriveAndStoreHandshakeTrafficSecrets(state *dtlsstate.State13, transcript 
 		return err
 	}
 
-	secrets, err := deriveHandshakeTrafficSecrets(
+	secrets, err := deriveHandshakeKeySchedule(
 		state.CipherSuite.HashFunc(),
 		state.KeyAgreementSecret,
 		transcriptHash,
@@ -107,7 +176,8 @@ func DeriveAndStoreHandshakeTrafficSecrets(state *dtlsstate.State13, transcript 
 	if err != nil {
 		return err
 	}
-	state.KeySchedule.HandshakeTraffic = secrets
+	state.KeySchedule.HandshakeTraffic = secrets.HandshakeTrafficSecrets
+	state.KeySchedule.MasterSecret = secrets.MasterSecret
 
 	return nil
 }
@@ -164,7 +234,7 @@ func finishedKey(hashFunc func() hash.Hash, baseKey []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return keyschedule.HkdfExpandLabel(hashFunc, baseKey, finishedLabel13, nil, hashSize)
+	return keyschedule.HkdfExpandLabel(hashFunc, baseKey, finishedLabel, nil, hashSize)
 }
 
 // FinishedVerifyDataFromTranscript returns verify_data for the current

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/sha512"
 	"testing"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
@@ -17,6 +18,7 @@ import (
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	dtlshash "github.com/pion/dtls/v3/pkg/crypto/hash"
+	"github.com/pion/dtls/v3/pkg/crypto/keyschedule"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	"github.com/pion/dtls/v3/pkg/crypto/signature"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -375,6 +377,123 @@ func TestDeriveHandshakeTrafficSecrets13NoHRRAndHRR(t *testing.T) {
 	assert.NotEqual(t, noHRRSecrets.Server, changedSecrets.Server)
 }
 
+func TestDeriveTrafficSecrets13KeySchedule(t *testing.T) {
+	tests := []struct {
+		name        string
+		cipherSuite ciphersuite.ID
+		hashSize    int
+		secretByte  byte
+		hashByte    byte
+	}{
+		{
+			name:        "sha256",
+			cipherSuite: ciphersuite.TLS_AES_128_GCM_SHA256,
+			hashSize:    sha256.Size,
+			secretByte:  0x31,
+			hashByte:    0x41,
+		},
+		{
+			name:        "chacha20_sha256",
+			cipherSuite: ciphersuite.TLS_CHACHA20_POLY1305_SHA256,
+			hashSize:    sha256.Size,
+			secretByte:  0x33,
+			hashByte:    0x43,
+		},
+		{
+			name:        "sha384",
+			cipherSuite: ciphersuite.TLS_AES_256_GCM_SHA384,
+			hashSize:    sha512.Size384,
+			secretByte:  0x32,
+			hashByte:    0x42,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cipherSuite := ciphersuite.ForID(test.cipherSuite, nil)
+			require.NotNil(t, cipherSuite)
+			hashFunc := cipherSuite.HashFunc()
+			require.Equal(t, test.hashSize, hashFunc().Size())
+
+			preMasterSecret := bytes.Repeat([]byte{test.secretByte}, test.hashSize)
+			handshakeTranscriptHash := bytes.Repeat([]byte{test.hashByte}, test.hashSize)
+			schedule, err := deriveHandshakeKeySchedule(hashFunc, preMasterSecret, handshakeTranscriptHash)
+			require.NoError(t, err)
+			require.Len(t, schedule.HandshakeTrafficSecrets.Client, test.hashSize)
+			require.Len(t, schedule.HandshakeTrafficSecrets.Server, test.hashSize)
+			require.Len(t, schedule.MasterSecret, test.hashSize)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Client, schedule.HandshakeTrafficSecrets.Server)
+
+			zeroSecret := make([]byte, test.hashSize)
+			earlySecret, err := keyschedule.HkdfExtract(hashFunc, nil, zeroSecret)
+			require.NoError(t, err)
+			derivedEarlySecret, err := keyschedule.DeriveSecret(
+				hashFunc,
+				earlySecret,
+				derivedSecretLabel,
+				nil,
+			)
+			require.NoError(t, err)
+			handshakeSecret, err := keyschedule.HkdfExtract(hashFunc, derivedEarlySecret, preMasterSecret)
+			require.NoError(t, err)
+			expectedClientHandshakeSecret, err := keyschedule.HkdfExpandLabel(
+				hashFunc,
+				handshakeSecret,
+				clientHandshakeTrafficLabel,
+				handshakeTranscriptHash,
+				test.hashSize,
+			)
+			require.NoError(t, err)
+			expectedServerHandshakeSecret, err := keyschedule.HkdfExpandLabel(
+				hashFunc,
+				handshakeSecret,
+				serverHandshakeTrafficLabel,
+				handshakeTranscriptHash,
+				test.hashSize,
+			)
+			require.NoError(t, err)
+			derivedHandshakeSecret, err := keyschedule.DeriveSecret(
+				hashFunc,
+				handshakeSecret,
+				derivedSecretLabel,
+				nil,
+			)
+			require.NoError(t, err)
+			expectedMasterSecret, err := keyschedule.HkdfExtract(hashFunc, derivedHandshakeSecret, zeroSecret)
+			require.NoError(t, err)
+			assert.Equal(t, expectedClientHandshakeSecret, schedule.HandshakeTrafficSecrets.Client)
+			assert.Equal(t, expectedServerHandshakeSecret, schedule.HandshakeTrafficSecrets.Server)
+			assert.Equal(t, expectedMasterSecret, schedule.MasterSecret)
+
+			changedHandshakeTranscriptHash := append([]byte(nil), handshakeTranscriptHash...)
+			changedHandshakeTranscriptHash[0] ^= 0xff
+			changedSchedule, err := deriveHandshakeKeySchedule(
+				hashFunc,
+				preMasterSecret,
+				changedHandshakeTranscriptHash,
+			)
+			require.NoError(t, err)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Client, changedSchedule.HandshakeTrafficSecrets.Client)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Server, changedSchedule.HandshakeTrafficSecrets.Server)
+			assert.Equal(t, schedule.MasterSecret, changedSchedule.MasterSecret)
+
+			changedPreMasterSecret := append([]byte(nil), preMasterSecret...)
+			changedPreMasterSecret[0] ^= 0xff
+			changedPreMasterSchedule, err := deriveHandshakeKeySchedule(
+				hashFunc,
+				changedPreMasterSecret,
+				handshakeTranscriptHash,
+			)
+			require.NoError(t, err)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Client,
+				changedPreMasterSchedule.HandshakeTrafficSecrets.Client)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Server,
+				changedPreMasterSchedule.HandshakeTrafficSecrets.Server)
+			assert.NotEqual(t, schedule.MasterSecret, changedPreMasterSchedule.MasterSecret)
+		})
+	}
+}
+
 func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
 	cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 	state := newTestState13(false)
@@ -396,6 +515,7 @@ func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
 	assert.Equal(t, expected, state.KeySchedule.HandshakeTraffic)
 	assert.NotEmpty(t, state.KeySchedule.HandshakeTraffic.Client)
 	assert.NotEmpty(t, state.KeySchedule.HandshakeTraffic.Server)
+	assert.NotEmpty(t, state.KeySchedule.MasterSecret)
 }
 
 func TestInitHandshakeRecordProtection13(t *testing.T) {


### PR DESCRIPTION
#### Description
this refactors handshake traffic derivation into reusable helpers, derive the dtls 1.3 master secret from the handshake secret, and store it in the new dtls 1.3 state (State13.KeySchedule) we added recently

part of #736 refs #727 