### PR TITLE
Derive application secrets

### DIFF
--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -13,10 +13,14 @@ import (
 )
 
 const (
-	clientHandshakeTrafficLabel = "c hs traffic"
-	serverHandshakeTrafficLabel = "s hs traffic"
-	derivedSecretLabel          = "derived"
-	finishedLabel               = "finished"
+	clientHandshakeTrafficLabel   = "c hs traffic"
+	serverHandshakeTrafficLabel   = "s hs traffic"
+	clientApplicationTrafficLabel = "c ap traffic"
+	serverApplicationTrafficLabel = "s ap traffic"
+	exporterMasterSecretLabel     = "exp master"
+	resumptionMasterSecretLabel   = "res master"
+	derivedSecretLabel            = "derived"
+	finishedLabel                 = "finished"
 
 	serverCertificateVerifyContext13 = "TLS 1.3, server CertificateVerify\x00"
 	clientCertificateVerifyContext13 = "TLS 1.3, client CertificateVerify\x00"
@@ -150,6 +154,53 @@ func deriveTrafficSecret(
 	return keyschedule.HkdfExpandLabel(hashFunc, baseSecret, label, transcriptHash, hashSize)
 }
 
+func deriveApplicationTrafficSecrets(
+	hashFunc func() hash.Hash,
+	masterSecret, transcriptHash []byte,
+) (dtlsstate.TrafficSecrets, error) {
+	clientSecret, err := deriveTrafficSecret(
+		hashFunc,
+		masterSecret,
+		clientApplicationTrafficLabel,
+		transcriptHash,
+	)
+	if err != nil {
+		return dtlsstate.TrafficSecrets{}, err
+	}
+
+	serverSecret, err := deriveTrafficSecret(
+		hashFunc,
+		masterSecret,
+		serverApplicationTrafficLabel,
+		transcriptHash,
+	)
+	if err != nil {
+		return dtlsstate.TrafficSecrets{}, err
+	}
+
+	return dtlsstate.TrafficSecrets{
+		Client: clientSecret,
+		Server: serverSecret,
+	}, nil
+}
+
+func deriveMasterSecretFromKeyAgreementSecret(hashFunc func() hash.Hash, keyAgreementSecret []byte) ([]byte, error) {
+	handshakeSecret, err := deriveHandshakeSecret(hashFunc, keyAgreementSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return deriveMasterSecret(hashFunc, handshakeSecret)
+}
+
+func deriveExporterMasterSecret(hashFunc func() hash.Hash, masterSecret, transcriptHash []byte) ([]byte, error) {
+	return deriveTrafficSecret(hashFunc, masterSecret, exporterMasterSecretLabel, transcriptHash)
+}
+
+func deriveResumptionMasterSecret(hashFunc func() hash.Hash, masterSecret, transcriptHash []byte) ([]byte, error) {
+	return deriveTrafficSecret(hashFunc, masterSecret, resumptionMasterSecretLabel, transcriptHash)
+}
+
 // DeriveAndStoreHandshakeTrafficSecrets derives DTLS 1.3 handshake traffic
 // secrets and stores them in state.
 func DeriveAndStoreHandshakeTrafficSecrets(state *dtlsstate.State13, transcript *Transcript) error {
@@ -180,6 +231,114 @@ func DeriveAndStoreHandshakeTrafficSecrets(state *dtlsstate.State13, transcript 
 	state.KeySchedule.MasterSecret = secrets.MasterSecret
 
 	return nil
+}
+
+// DeriveAndStoreApplicationTrafficSecrets derives DTLS 1.3 application
+// traffic and exporter master secrets from the current transcript snapshot.
+// The caller is responsible for invoking it with the transcript through server
+// Finished.
+func DeriveAndStoreApplicationTrafficSecrets(state *dtlsstate.State13, transcript *Transcript) error {
+	if state == nil || state.CipherSuite == nil {
+		return dtlserrors.ErrCipherSuiteNotSet
+	}
+	if transcript == nil {
+		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+	if err := selectHashIfReady(transcript, state.CipherSuite); err != nil {
+		return err
+	}
+
+	transcriptHash, err := transcript.SnapshotHash()
+	if err != nil {
+		return err
+	}
+
+	masterSecret, err := ensureMasterSecret(state)
+	if err != nil {
+		return err
+	}
+
+	secrets, err := deriveApplicationTrafficSecrets(
+		state.CipherSuite.HashFunc(),
+		masterSecret,
+		transcriptHash,
+	)
+	if err != nil {
+		return err
+	}
+
+	exporterMasterSecret, err := deriveExporterMasterSecret(
+		state.CipherSuite.HashFunc(),
+		masterSecret,
+		transcriptHash,
+	)
+	if err != nil {
+		return err
+	}
+
+	state.KeySchedule.ClientApplicationTrafficSecret0 = secrets.Client
+	state.KeySchedule.ServerApplicationTrafficSecret0 = secrets.Server
+	state.KeySchedule.ExporterMasterSecret = exporterMasterSecret
+
+	return nil
+}
+
+// DeriveAndStoreResumptionMasterSecret derives the DTLS 1.3 resumption master
+// secret from the current transcript snapshot. The caller is responsible for
+// invoking it with the transcript through client Finished.
+func DeriveAndStoreResumptionMasterSecret(state *dtlsstate.State13, transcript *Transcript) error {
+	if state == nil || state.CipherSuite == nil {
+		return dtlserrors.ErrCipherSuiteNotSet
+	}
+	if transcript == nil {
+		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+	if err := selectHashIfReady(transcript, state.CipherSuite); err != nil {
+		return err
+	}
+
+	transcriptHash, err := transcript.SnapshotHash()
+	if err != nil {
+		return err
+	}
+
+	masterSecret, err := ensureMasterSecret(state)
+	if err != nil {
+		return err
+	}
+
+	state.KeySchedule.ResumptionMasterSecret, err = deriveResumptionMasterSecret(
+		state.CipherSuite.HashFunc(),
+		masterSecret,
+		transcriptHash,
+	)
+
+	return err
+}
+
+func ensureMasterSecret(state *dtlsstate.State13) ([]byte, error) {
+	hashSize, err := hashSize13(state.CipherSuite.HashFunc())
+	if err != nil {
+		return nil, err
+	}
+	if len(state.KeySchedule.MasterSecret) != 0 {
+		if len(state.KeySchedule.MasterSecret) != hashSize {
+			return nil, dtlserrors.ErrLengthMismatch
+		}
+
+		return state.KeySchedule.MasterSecret, nil
+	}
+
+	masterSecret, err := deriveMasterSecretFromKeyAgreementSecret(
+		state.CipherSuite.HashFunc(),
+		state.KeyAgreementSecret,
+	)
+	if err != nil {
+		return nil, err
+	}
+	state.KeySchedule.MasterSecret = masterSecret
+
+	return masterSecret, nil
 }
 
 // CertificateVerifyInputFromTranscript returns the TLS 1.3 CertificateVerify

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -465,6 +465,73 @@ func TestDeriveTrafficSecrets13KeySchedule(t *testing.T) {
 			assert.Equal(t, expectedServerHandshakeSecret, schedule.HandshakeTrafficSecrets.Server)
 			assert.Equal(t, expectedMasterSecret, schedule.MasterSecret)
 
+			applicationTranscriptHash := bytes.Repeat([]byte{test.hashByte + 1}, test.hashSize)
+			applicationSecrets, err := deriveApplicationTrafficSecrets(
+				hashFunc,
+				schedule.MasterSecret,
+				applicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			require.Len(t, applicationSecrets.Client, test.hashSize)
+			require.Len(t, applicationSecrets.Server, test.hashSize)
+			assert.NotEqual(t, applicationSecrets.Client, applicationSecrets.Server)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Client, applicationSecrets.Client)
+			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Server, applicationSecrets.Server)
+
+			expectedClientApplicationSecret, err := keyschedule.HkdfExpandLabel(
+				hashFunc,
+				schedule.MasterSecret,
+				clientApplicationTrafficLabel,
+				applicationTranscriptHash,
+				test.hashSize,
+			)
+			require.NoError(t, err)
+			expectedServerApplicationSecret, err := keyschedule.HkdfExpandLabel(
+				hashFunc,
+				schedule.MasterSecret,
+				serverApplicationTrafficLabel,
+				applicationTranscriptHash,
+				test.hashSize,
+			)
+			require.NoError(t, err)
+			exporterMasterSecret, err := deriveExporterMasterSecret(
+				hashFunc,
+				schedule.MasterSecret,
+				applicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			expectedExporterMasterSecret, err := keyschedule.HkdfExpandLabel(
+				hashFunc,
+				schedule.MasterSecret,
+				exporterMasterSecretLabel,
+				applicationTranscriptHash,
+				test.hashSize,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, expectedClientApplicationSecret, applicationSecrets.Client)
+			assert.Equal(t, expectedServerApplicationSecret, applicationSecrets.Server)
+			assert.Equal(t, expectedExporterMasterSecret, exporterMasterSecret)
+
+			resumptionTranscriptHash := bytes.Repeat([]byte{test.hashByte + 2}, test.hashSize)
+			resumptionMasterSecret, err := deriveResumptionMasterSecret(
+				hashFunc,
+				schedule.MasterSecret,
+				resumptionTranscriptHash,
+			)
+			require.NoError(t, err)
+			require.Len(t, resumptionMasterSecret, test.hashSize)
+			assert.NotEqual(t, exporterMasterSecret, resumptionMasterSecret)
+
+			changedResumptionTranscriptHash := append([]byte(nil), resumptionTranscriptHash...)
+			changedResumptionTranscriptHash[0] ^= 0xff
+			changedResumptionMasterSecret, err := deriveResumptionMasterSecret(
+				hashFunc,
+				schedule.MasterSecret,
+				changedResumptionTranscriptHash,
+			)
+			require.NoError(t, err)
+			assert.NotEqual(t, resumptionMasterSecret, changedResumptionMasterSecret)
+
 			changedHandshakeTranscriptHash := append([]byte(nil), handshakeTranscriptHash...)
 			changedHandshakeTranscriptHash[0] ^= 0xff
 			changedSchedule, err := deriveHandshakeKeySchedule(
@@ -476,6 +543,24 @@ func TestDeriveTrafficSecrets13KeySchedule(t *testing.T) {
 			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Client, changedSchedule.HandshakeTrafficSecrets.Client)
 			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Server, changedSchedule.HandshakeTrafficSecrets.Server)
 			assert.Equal(t, schedule.MasterSecret, changedSchedule.MasterSecret)
+
+			changedApplicationTranscriptHash := append([]byte(nil), applicationTranscriptHash...)
+			changedApplicationTranscriptHash[0] ^= 0xff
+			changedApplicationSecrets, err := deriveApplicationTrafficSecrets(
+				hashFunc,
+				schedule.MasterSecret,
+				changedApplicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			changedExporterMasterSecret, err := deriveExporterMasterSecret(
+				hashFunc,
+				schedule.MasterSecret,
+				changedApplicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			assert.NotEqual(t, applicationSecrets.Client, changedApplicationSecrets.Client)
+			assert.NotEqual(t, applicationSecrets.Server, changedApplicationSecrets.Server)
+			assert.NotEqual(t, exporterMasterSecret, changedExporterMasterSecret)
 
 			changedPreMasterSecret := append([]byte(nil), preMasterSecret...)
 			changedPreMasterSecret[0] ^= 0xff
@@ -490,6 +575,29 @@ func TestDeriveTrafficSecrets13KeySchedule(t *testing.T) {
 			assert.NotEqual(t, schedule.HandshakeTrafficSecrets.Server,
 				changedPreMasterSchedule.HandshakeTrafficSecrets.Server)
 			assert.NotEqual(t, schedule.MasterSecret, changedPreMasterSchedule.MasterSecret)
+
+			changedPreMasterApplicationSecrets, err := deriveApplicationTrafficSecrets(
+				hashFunc,
+				changedPreMasterSchedule.MasterSecret,
+				applicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			changedPreMasterExporterMasterSecret, err := deriveExporterMasterSecret(
+				hashFunc,
+				changedPreMasterSchedule.MasterSecret,
+				applicationTranscriptHash,
+			)
+			require.NoError(t, err)
+			changedPreMasterResumptionMasterSecret, err := deriveResumptionMasterSecret(
+				hashFunc,
+				changedPreMasterSchedule.MasterSecret,
+				resumptionTranscriptHash,
+			)
+			require.NoError(t, err)
+			assert.NotEqual(t, applicationSecrets.Client, changedPreMasterApplicationSecrets.Client)
+			assert.NotEqual(t, applicationSecrets.Server, changedPreMasterApplicationSecrets.Server)
+			assert.NotEqual(t, exporterMasterSecret, changedPreMasterExporterMasterSecret)
+			assert.NotEqual(t, resumptionMasterSecret, changedPreMasterResumptionMasterSecret)
 		})
 	}
 }


### PR DESCRIPTION
#### Description
A small patch to add application traffic labels and derive / store client / server application traffic secret 0, also the exporter master secret from the master secret and transcript hash

part of #736 related to #827 refs #727  