### PR TITLE
Verify flight4 finished

### DIFF
--- a/flight_test.go
+++ b/flight_test.go
@@ -5,6 +5,7 @@ package dtls
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"hash"
 	"testing"
@@ -88,6 +89,15 @@ func flight13ParseForTestWithConn(
 		flightCtx.cfg,
 		func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
 			return dtlshandshake.AppendVerifiedInboundHandshakeCacheItems(flightCtx.transcript, cipherSuite, items)
+		},
+		func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+			return dtlshandshake.VerifyAndAppendProtectedHandshakeCacheItems13(
+				flightCtx.transcript,
+				flightCtx.state,
+				flightCtx.cfg,
+				cipherSuite,
+				items,
+			)
 		},
 		func(state *dtlsstate.State13) error {
 			return dtlshandshake.DeriveAndStoreHandshakeTrafficSecrets(state, flightCtx.transcript)
@@ -214,6 +224,145 @@ func deriveHandshakeTrafficSecrets13(
 	}
 
 	return dtlsstate.TrafficSecrets{Client: clientSecret, Server: serverSecret}, nil
+}
+
+func finishedVerifyData13(
+	t *testing.T,
+	hashFunc func() hash.Hash,
+	baseKey, transcriptHash []byte,
+) []byte {
+	t.Helper()
+
+	finishedKey, err := keyschedule.HkdfExpandLabel(hashFunc, baseKey, "finished", nil, hashFunc().Size())
+	require.NoError(t, err)
+
+	mac := hmac.New(hashFunc, finishedKey)
+	_, err = mac.Write(transcriptHash)
+	require.NoError(t, err)
+
+	return mac.Sum(nil)
+}
+
+func marshalFinished13(t *testing.T, seq uint16, verifyData []byte) []byte {
+	t.Helper()
+
+	raw, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: seq},
+		Message: &handshake.MessageFinished{VerifyData: verifyData},
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func marshalServerFinished13(
+	t *testing.T,
+	state *dtlsstate.State13,
+	seq uint16,
+	transcriptMessages ...[]byte,
+) []byte {
+	t.Helper()
+
+	verifyData := finishedVerifyData13(
+		t,
+		state.CipherSuite.HashFunc(),
+		state.KeySchedule.HandshakeTraffic.Server,
+		hashTranscript13(transcriptMessages...),
+	)
+
+	return marshalFinished13(t, seq, verifyData)
+}
+
+type flight13ProtectedServerFlightFixture struct {
+	cfg                          *dtlsconfig.HandshakeConfig
+	state                        *dtlsstate.State13
+	transcript                   *dtlshandshake.Transcript
+	clientHelloCanonical         []byte
+	serverHelloCanonical         []byte
+	encryptedExtensionsCanonical []byte
+	rawServerHello               []byte
+	rawEncryptedExtensions       []byte
+	rawFinished                  []byte
+	handshakeSecrets             dtlsstate.TrafficSecrets
+}
+
+func newFlight13ProtectedServerFlightFixture(t *testing.T) flight13ProtectedServerFlightFixture {
+	t.Helper()
+
+	cfg := testHandshakeConfig13(t)
+	state := newTestState13(true)
+	transcript := dtlshandshake.NewTranscript()
+	clientHello, _, err := flight13GenerateForTest(t, Flight1, &handshakeTestContext13{state: state, cfg: cfg})
+	require.NoError(t, err)
+	appended, err := dtlshandshake.AppendClientHelloInitialFlights(transcript, clientHello)
+	require.NoError(t, err)
+	require.True(t, appended)
+	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello[0])
+
+	group := cfg.EllipticCurves[0]
+	serverKeypair, err := elliptic.GenerateKeypair(group)
+	require.NoError(t, err)
+	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
+		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
+	}, []extension.Extension{
+		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	})
+	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
+	require.NoError(t, err)
+
+	rawEncryptedExtensions, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageEncryptedExtensions{},
+	}).Marshal()
+	require.NoError(t, err)
+	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
+	require.NoError(t, err)
+
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	keyAgreementSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	handshakeSecrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		keyAgreementSecret,
+		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = handshakeSecrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		2,
+		clientHelloCanonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+
+	return flight13ProtectedServerFlightFixture{
+		cfg:                          cfg,
+		state:                        state,
+		transcript:                   transcript,
+		clientHelloCanonical:         clientHelloCanonical,
+		serverHelloCanonical:         serverHelloCanonical,
+		encryptedExtensionsCanonical: encryptedExtensionsCanonical,
+		rawServerHello:               rawServerHello,
+		rawEncryptedExtensions:       rawEncryptedExtensions,
+		rawFinished:                  rawFinished,
+		handshakeSecrets:             handshakeSecrets,
+	}
+}
+
+func (f flight13ProtectedServerFlightFixture) cacheWithFinished(rawFinished []byte) *dtlsflight.Cache {
+	cache := dtlsflight.NewCache()
+	cache.Push(f.rawServerHello, f.cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
+	cache.Push(f.rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
+
+	return cache
 }
 
 func testHandshakeConfig13(t *testing.T) *dtlsconfig.HandshakeConfig {
@@ -869,7 +1018,32 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
+	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
+	require.NoError(t, err)
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	expected, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	expectedSecrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		expected,
+		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = expectedSecrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		2,
+		clientHelloCanonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
 	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state:      state,
 		cache:      cache,
@@ -891,17 +1065,8 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	require.Len(t, *state.RemoteKeyEntries, 1)
 	assert.Equal(t, group, (*state.RemoteKeyEntries)[0].Group)
 
-	clientKeypair := state.LocalKeypairs[group]
-	require.NotNil(t, clientKeypair)
-	expected, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
-	require.NoError(t, err)
 	assert.Equal(t, expected, state.KeyAgreementSecret)
 	assert.NotEmpty(t, state.KeyAgreementSecret)
-	transcriptHash := hashTranscript13(clientHelloCanonical, serverHelloCanonical)
-	expectedSecrets, err := deriveHandshakeTrafficSecrets13(
-		state.CipherSuite.HashFunc(), expected, transcriptHash,
-	)
-	require.NoError(t, err)
 	assert.Equal(t, expectedSecrets, state.KeySchedule.HandshakeTraffic)
 	assert.NotEqual(t, state.KeySchedule.HandshakeTraffic.Client, state.KeySchedule.HandshakeTraffic.Server)
 	assert.True(t, state.CipherSuite.IsInitialized())
@@ -926,11 +1091,38 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
 		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
+	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello[0])
+	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
+	require.NoError(t, err)
 	rawEncryptedExtensions, err := (&handshake.Handshake{
 		Header:  handshake.Header{MessageSequence: 1},
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
+	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
+	require.NoError(t, err)
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	keyAgreementSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	secrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		keyAgreementSecret,
+		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = secrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		2,
+		clientHelloCanonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
 
 	cache := dtlsflight.NewCache()
 	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
@@ -941,6 +1133,7 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 			assert.True(t, state.CipherSuite.IsInitialized())
 			assert.Equal(t, dtlsflight13.EpochHandshake, state.GetRemoteEpoch())
 			cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+			cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
 
 			return nil
 		},
@@ -958,7 +1151,7 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 	require.Nil(t, dtlsAlert)
 	assert.True(t, drained)
 	assert.Equal(t, Flight5, nextFlight)
-	assert.Equal(t, 2, state.HandshakeRecvSequence)
+	assert.Equal(t, 3, state.HandshakeRecvSequence)
 }
 
 func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T) {
@@ -1015,10 +1208,30 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 		Message: &handshake.MessageEncryptedExtensions{},
 	}).Marshal()
 	require.NoError(t, err)
-	protectedRecord := sealTestProtectedHandshakeRecord(t, peerCipherSuite, rawEncryptedExtensions)
-	protectedRaw, err := protectedRecord.Marshal()
+	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
 	require.NoError(t, err)
-	conn.encryptedPackets = []addrPkt{{data: protectedRaw}}
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = secrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		2,
+		clientHelloCanonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+
+	protectedEncryptedExtensions := sealTestProtectedHandshakeRecordWithSequence(
+		t, peerCipherSuite, rawEncryptedExtensions, 0,
+	)
+	protectedEncryptedExtensionsRaw, err := protectedEncryptedExtensions.Marshal()
+	require.NoError(t, err)
+	protectedFinished := sealTestProtectedHandshakeRecordWithSequence(t, peerCipherSuite, rawFinished, 1)
+	protectedFinishedRaw, err := protectedFinished.Marshal()
+	require.NoError(t, err)
+	conn.encryptedPackets = []addrPkt{{data: protectedEncryptedExtensionsRaw}, {data: protectedFinishedRaw}}
 
 	nextFlight, dtlsAlert, err := flight13ParseForTestWithConn(
 		t, Flight3, context.Background(), adaptFlightConn(conn), &handshakeTestContext13{
@@ -1031,7 +1244,7 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, Flight5, nextFlight)
-	assert.Equal(t, 2, state.HandshakeRecvSequence)
+	assert.Equal(t, 3, state.HandshakeRecvSequence)
 
 	items := cache.Pull(dtlsflight.HandshakeCachePullRule{
 		Typ:      handshake.TypeEncryptedExtensions,
@@ -1082,6 +1295,31 @@ func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
 	require.NoError(t, err)
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	keyAgreementSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	secrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		keyAgreementSecret,
+		hashTranscript13(clientHelloCanonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = secrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		2,
+		clientHelloCanonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	finishedCanonical, err := canonicalHandshake13(rawFinished)
+	require.NoError(t, err)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
 	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight1, context.Background(), &handshakeTestContext13{
 		state:      state,
 		cache:      cache,
@@ -1092,8 +1330,8 @@ func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, Flight5, nextFlight)
-	expectedTranscript := append(append(append([]byte(nil), clientHelloCanonical...), serverHelloCanonical...),
-		encryptedExtensionsCanonical...)
+	expectedTranscript := append(append(append(append([]byte(nil), clientHelloCanonical...), serverHelloCanonical...),
+		encryptedExtensionsCanonical...), finishedCanonical...)
 	assert.Equal(t, expectedTranscript, transcript.Bytes())
 }
 
@@ -1173,6 +1411,36 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 	encryptedExtensionsCanonical, err := canonicalHandshake13(rawEncryptedExtensions)
 	require.NoError(t, err)
 
+	clientHello1Hash := hashTranscript13(clientHello1Canonical)
+	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
+	clientKeypair := state.LocalKeypairs[group]
+	require.NotNil(t, clientKeypair)
+	keyAgreementSecret, err := prf.PreMasterSecret(clientKeypair.PublicKey, serverKeypair.PrivateKey, group)
+	require.NoError(t, err)
+	secrets, err := deriveHandshakeTrafficSecrets13(
+		cfg.LocalCipherSuites[0].HashFunc(),
+		keyAgreementSecret,
+		hashTranscript13(messageHash, helloRetryRequestCanonical, clientHello2Canonical, serverHelloCanonical),
+	)
+	require.NoError(t, err)
+	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.KeySchedule.HandshakeTraffic = secrets
+	rawFinished := marshalServerFinished13(
+		t,
+		state,
+		3,
+		messageHash,
+		helloRetryRequestCanonical,
+		clientHello2Canonical,
+		serverHelloCanonical,
+		encryptedExtensionsCanonical,
+	)
+	finishedCanonical, err := canonicalHandshake13(rawFinished)
+	require.NoError(t, err)
+	state.CipherSuite = nil
+	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 3, handshake.TypeFinished, false)
+
 	nextFlight, dtlsAlert, err = flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
 		state:      state,
 		cache:      cache,
@@ -1183,11 +1451,89 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, Flight5, nextFlight)
 
-	clientHello1Hash := hashTranscript13(clientHello1Canonical)
-	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
 	expectedTranscript := append(append(append(append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...),
 		clientHello2Canonical...), serverHelloCanonical...), encryptedExtensionsCanonical...)
+	expectedTranscript = append(expectedTranscript, finishedCanonical...)
 	assert.Equal(t, expectedTranscript, transcript.Bytes())
+}
+
+func TestFlight13_3ParseRejectsInvalidServerFinished(t *testing.T) {
+	tests := []struct {
+		name     string
+		finished func(t *testing.T, f flight13ProtectedServerFlightFixture) []byte
+	}{
+		{
+			name: "tampered Finished",
+			finished: func(t *testing.T, f flight13ProtectedServerFlightFixture) []byte {
+				t.Helper()
+
+				raw := append([]byte(nil), f.rawFinished...)
+				raw[len(raw)-1] ^= 0xff
+
+				return raw
+			},
+		},
+		{
+			name: "wrong transcript",
+			finished: func(t *testing.T, f flight13ProtectedServerFlightFixture) []byte {
+				t.Helper()
+
+				verifyData := finishedVerifyData13(
+					t,
+					f.cfg.LocalCipherSuites[0].HashFunc(),
+					f.handshakeSecrets.Server,
+					hashTranscript13(f.clientHelloCanonical, f.serverHelloCanonical),
+				)
+
+				return marshalFinished13(t, 2, verifyData)
+			},
+		},
+		{
+			name: "wrong handshake traffic secret",
+			finished: func(t *testing.T, f flight13ProtectedServerFlightFixture) []byte {
+				t.Helper()
+
+				wrongSecret := append([]byte(nil), f.handshakeSecrets.Server...)
+				wrongSecret[0] ^= 0xff
+				verifyData := finishedVerifyData13(
+					t,
+					f.cfg.LocalCipherSuites[0].HashFunc(),
+					wrongSecret,
+					hashTranscript13(
+						f.clientHelloCanonical,
+						f.serverHelloCanonical,
+						f.encryptedExtensionsCanonical,
+					),
+				)
+
+				return marshalFinished13(t, 2, verifyData)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFlight13ProtectedServerFlightFixture(t)
+			cache := fixture.cacheWithFinished(test.finished(t, fixture))
+
+			nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+				state:      fixture.state,
+				cache:      cache,
+				cfg:        fixture.cfg,
+				transcript: fixture.transcript,
+			})
+
+			require.ErrorIs(t, err, dtlserrors.ErrVerifyDataMismatch)
+			require.NotNil(t, dtlsAlert)
+			assert.Equal(t, alert.Fatal, dtlsAlert.Level)
+			assert.Equal(t, alert.HandshakeFailure, dtlsAlert.Description)
+			assert.Zero(t, nextFlight)
+			assert.Equal(t, 1, fixture.state.HandshakeRecvSequence)
+
+			expectedTranscript := append(append([]byte(nil), fixture.clientHelloCanonical...), fixture.serverHelloCanonical...)
+			assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())
+		})
+	}
 }
 
 func TestFlight13_3ParseKeepsReadingWithoutServerHello(t *testing.T) {

--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -42,6 +42,8 @@ type Generator func(
 
 type InboundHandshakeHandler func(dtlsconfig.CipherSuite, []*dtlsflight.HandshakeCacheItem) error
 
+type ProtectedHandshakeHandler func(dtlsconfig.CipherSuite, []*dtlsflight.HandshakeCacheItem) error
+
 type HandshakeTrafficSecretDeriver func(*dtlsstate.State13) error
 
 type HandshakeRecordProtectionInitializer func(*dtlsstate.State13) error
@@ -51,6 +53,7 @@ type handshakeContext struct {
 	cache                                *dtlsflight.Cache
 	cfg                                  *dtlsconfig.HandshakeConfig
 	inboundHandshakeHandler              InboundHandshakeHandler
+	protectedHandshakeHandler            ProtectedHandshakeHandler
 	handshakeTrafficSecretDeriver        HandshakeTrafficSecretDeriver
 	handshakeRecordProtectionInitializer HandshakeRecordProtectionInitializer
 }
@@ -107,6 +110,7 @@ func Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 	inboundHandshakeHandler InboundHandshakeHandler,
+	protectedHandshakeHandler ProtectedHandshakeHandler,
 	handshakeTrafficSecretDeriver HandshakeTrafficSecretDeriver,
 	handshakeRecordProtectionInitializer HandshakeRecordProtectionInitializer,
 ) (Flight, *alert.Alert, error, bool) {
@@ -120,6 +124,7 @@ func Parse(
 		cache:                                cache,
 		cfg:                                  cfg,
 		inboundHandshakeHandler:              inboundHandshakeHandler,
+		protectedHandshakeHandler:            protectedHandshakeHandler,
 		handshakeTrafficSecretDeriver:        handshakeTrafficSecretDeriver,
 		handshakeRecordProtectionInitializer: handshakeRecordProtectionInitializer,
 	})

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -384,6 +384,9 @@ func flight3PullProtectedFlight(
 ) (int, []*dtlsflight.HandshakeCacheItem, bool, *flightParseFailure) {
 	rules := []dtlsflight.HandshakeCachePullRule{
 		{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false, Optional: false},
+		{Typ: handshake.TypeCertificateRequest, Epoch: EpochHandshake, IsClient: false, Optional: true},
+		{Typ: handshake.TypeCertificate, Epoch: EpochHandshake, IsClient: false, Optional: true},
+		{Typ: handshake.TypeCertificateVerify, Epoch: EpochHandshake, IsClient: false, Optional: true},
 		{Typ: handshake.TypeFinished, Epoch: EpochHandshake, IsClient: false, Optional: false},
 	}
 	pulled := flightCtx.cache.Pull(rules...)
@@ -452,6 +455,12 @@ func unmarshalFlight3ProtectedHandshakeMessage(typ handshake.Type, body []byte) 
 	switch typ {
 	case handshake.TypeEncryptedExtensions:
 		msg = &handshake.MessageEncryptedExtensions{}
+	case handshake.TypeCertificateRequest:
+		msg = &handshake.MessageCertificateRequest13{}
+	case handshake.TypeCertificate:
+		msg = &handshake.MessageCertificate13{}
+	case handshake.TypeCertificateVerify:
+		msg = &handshake.MessageCertificateVerify{}
 	case handshake.TypeFinished:
 		msg = &handshake.MessageFinished{}
 	default:
@@ -476,11 +485,23 @@ func handleFlight3ProtectedHandshake(
 }
 
 func protectedFlightParseFailure(err error) *flightParseFailure {
-	if errors.Is(err, dtlserrors.ErrVerifyDataMismatch) {
+	switch {
+	case errors.Is(err, dtlserrors.ErrVerifyDataMismatch):
 		return newFlightParseFailure(alert.HandshakeFailure, err)
+	case errors.Is(err, dtlserrors.ErrCertificateVerifyNoCertificate):
+		return newFlightParseFailure(alert.NoCertificate, err)
+	case errors.Is(err, dtlserrors.ErrKeySignatureMismatch),
+		errors.Is(err, dtlserrors.ErrInvalidCertificate),
+		errors.Is(err, dtlserrors.ErrClientCertificateNotVerified),
+		errors.Is(err, dtlserrors.ErrInvalidCertificateOID),
+		errors.Is(err, dtlserrors.ErrInvalidCertificateSignatureAlgorithm),
+		errors.Is(err, dtlserrors.ErrNotAcceptableCertificateChain):
+		return newFlightParseFailure(alert.BadCertificate, err)
+	case errors.Is(err, dtlserrors.ErrNoAvailableSignatureSchemes):
+		return newFlightParseFailure(alert.InsufficientSecurity, err)
+	default:
+		return newFlightParseFailure(alert.InternalError, err)
 	}
-
-	return newFlightParseFailure(alert.InternalError, err)
 }
 
 func handleFlight3InboundHandshake(

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -227,10 +227,14 @@ func flight3Parse(
 		return 0, failure.alert, failure.err
 	}
 
-	seq, ok, failure := flight3PullEncryptedExtensions(flightCtx, serverHelloSeq)
+	seq, items, ok, failure := flight3PullProtectedFlight(flightCtx, serverHelloSeq)
 	if !ok {
 		return 0, nil, nil
 	}
+	if failure != nil {
+		return 0, failure.alert, failure.err
+	}
+	failure = handleFlight3ProtectedHandshake(flightCtx, items)
 	if failure != nil {
 		return 0, failure.alert, failure.err
 	}
@@ -374,27 +378,109 @@ func initializeFlight3HandshakeProtection(
 	return nil
 }
 
-func flight3PullEncryptedExtensions(
+func flight3PullProtectedFlight(
 	flightCtx *handshakeContext,
 	serverHelloSeq int,
-) (int, bool, *flightParseFailure) {
-	seq, msgs, items, ok := flightCtx.cache.FullPullMapItems(
-		serverHelloSeq, flightCtx.state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false, Optional: false}, //nolint:lll
-	)
-	if !ok {
-		return 0, false, nil
+) (int, []*dtlsflight.HandshakeCacheItem, bool, *flightParseFailure) {
+	rules := []dtlsflight.HandshakeCachePullRule{
+		{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false, Optional: false},
+		{Typ: handshake.TypeFinished, Epoch: EpochHandshake, IsClient: false, Optional: false},
+	}
+	pulled := flightCtx.cache.Pull(rules...)
+	if pulled[0] == nil || pulled[len(pulled)-1] == nil {
+		return 0, nil, false, nil
 	}
 
-	_, ok = msgs[handshake.TypeEncryptedExtensions].(*handshake.MessageEncryptedExtensions)
-	if !ok {
-		return 0, true, newFlightParseFailure(alert.InternalError, nil)
-	}
-	if failure := handleFlight3InboundHandshake(flightCtx, items); failure != nil {
-		return 0, true, failure
+	seq := serverHelloSeq
+	items := make([]*dtlsflight.HandshakeCacheItem, 0, len(pulled))
+	for i, item := range pulled {
+		if item == nil {
+			continue
+		}
+		if failure := validateFlight3ProtectedHandshakeItem(
+			item,
+			rules[i].Typ,
+			uint16(seq), //nolint:gosec // G115
+		); failure != nil {
+			if failure.err == nil {
+				return 0, nil, false, nil
+			}
+
+			return 0, nil, true, failure
+		}
+		seq++
+		items = append(items, item)
 	}
 
-	return seq, true, nil
+	return seq, items, true, nil
+}
+
+func validateFlight3ProtectedHandshakeItem(
+	item *dtlsflight.HandshakeCacheItem,
+	expectedType handshake.Type,
+	expectedSequence uint16,
+) *flightParseFailure {
+	if item.MessageSequence != expectedSequence {
+		return &flightParseFailure{}
+	}
+	if item.Typ != expectedType {
+		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+	}
+
+	header := &handshake.Header{}
+	if err := header.Unmarshal(item.Data); err != nil {
+		return newFlightParseFailure(alert.DecodeError, err)
+	}
+	if header.Type != expectedType || header.MessageSequence != expectedSequence {
+		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+	}
+	if header.FragmentOffset != 0 ||
+		header.FragmentLength != header.Length ||
+		len(item.Data) != handshake.HeaderLength+int(header.Length) {
+		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+	}
+
+	if err := unmarshalFlight3ProtectedHandshakeMessage(expectedType, item.Data[handshake.HeaderLength:]); err != nil {
+		return newFlightParseFailure(alert.DecodeError, err)
+	}
+
+	return nil
+}
+
+func unmarshalFlight3ProtectedHandshakeMessage(typ handshake.Type, body []byte) error {
+	var msg handshake.Message
+	switch typ {
+	case handshake.TypeEncryptedExtensions:
+		msg = &handshake.MessageEncryptedExtensions{}
+	case handshake.TypeFinished:
+		msg = &handshake.MessageFinished{}
+	default:
+		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+
+	return msg.Unmarshal(body)
+}
+
+func handleFlight3ProtectedHandshake(
+	flightCtx *handshakeContext,
+	items []*dtlsflight.HandshakeCacheItem,
+) *flightParseFailure {
+	if flightCtx.protectedHandshakeHandler == nil {
+		return newFlightParseFailure(alert.InternalError, dtlserrors.ErrHandshakeTranscriptHashNotSelected)
+	}
+	if err := flightCtx.protectedHandshakeHandler(flightCtx.state.CipherSuite, items); err != nil {
+		return protectedFlightParseFailure(err)
+	}
+
+	return nil
+}
+
+func protectedFlightParseFailure(err error) *flightParseFailure {
+	if errors.Is(err, dtlserrors.ErrVerifyDataMismatch) {
+		return newFlightParseFailure(alert.HandshakeFailure, err)
+	}
+
+	return newFlightParseFailure(alert.InternalError, err)
 }
 
 func handleFlight3InboundHandshake(

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -405,6 +405,15 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
 					return AppendVerifiedInboundHandshakeCacheItems(s.transcript, cipherSuite, items)
 				},
+				func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+					return VerifyAndAppendProtectedHandshakeCacheItems13(
+						s.transcript,
+						s.state,
+						s.cfg,
+						cipherSuite,
+						items,
+					)
+				},
 				func(state *dtlsstate.State13) error {
 					return DeriveAndStoreHandshakeTrafficSecrets(state, s.transcript)
 				},

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -438,11 +438,11 @@ func TestHandshakeFSM13WaitParsesProtectedEncryptedExtensions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StatePreparing, nextState)
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
-	assert.Equal(t, 2, fixture.clientState.HandshakeRecvSequence)
+	assert.Equal(t, 3, fixture.clientState.HandshakeRecvSequence)
 	assert.True(t, fixture.clientState.CipherSuite.IsInitialized())
 	assert.Equal(t, dtlsflight13.EpochHandshake, fixture.clientState.GetRemoteEpoch())
 	assertFlight13RecvDoneClosed(t, recvState)
-	assertFlight13ClientTranscriptThroughEncryptedExtensions(t, fsm.transcript)
+	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
 }
 
 func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T) {
@@ -468,9 +468,9 @@ func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, StatePreparing, nextState)
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
-	assert.Equal(t, 2, fixture.clientState.HandshakeRecvSequence)
+	assert.Equal(t, 3, fixture.clientState.HandshakeRecvSequence)
 	assertFlight13RecvDoneClosed(t, recvState)
-	assertFlight13ClientTranscriptThroughEncryptedExtensions(t, fsm.transcript)
+	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
 }
 
 func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Packet) []byte {
@@ -524,19 +524,21 @@ func newNoHRRFlight13Fixture(t *testing.T) noHRRFlight13Fixture {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	require.True(t, ok)
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	require.Equal(t, dtlsflight13.Flight4, nextFlight)
 
-	serverFlight4, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight4, &handshakeContext13{
-		state: serverState,
-		cache: serverCache,
-		cfg:   cfg,
-	})
+	serverTranscript := NewTranscript()
+	require.NoError(t, AppendOutboundHandshakeFlight(serverTranscript, true, nil, clientHello))
+	serverFSM, err := newFSM13(serverState, serverCache, cfg, dtlsflight13.Flight4, nil, serverTranscript)
 	require.NoError(t, err)
-	require.Nil(t, dtlsAlert)
+	nextState, err := serverFSM.prepare(context.Background(), &flightTestConn{})
+	require.NoError(t, err)
+	require.Equal(t, StateSending, nextState)
+	serverFlight4 := serverFSM.flights
 	require.Len(t, serverFlight4, 3)
 	setFlight13HandshakeSequence(t, serverFlight4[0], 0)
 	setFlight13HandshakeSequence(t, serverFlight4[1], 1)
@@ -617,14 +619,15 @@ func assertFlight13RecvDoneClosed(t *testing.T, state RecvHandshakeState) {
 	}
 }
 
-func assertFlight13ClientTranscriptThroughEncryptedExtensions(t *testing.T, transcript *Transcript) {
+func assertFlight13ClientTranscriptThroughServerFinished(t *testing.T, transcript *Transcript) {
 	t.Helper()
 
-	require.Len(t, transcript.messageOrder(), 3)
+	require.Len(t, transcript.messageOrder(), 4)
 	assert.Equal(t, []transcriptMessage{
 		{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 0}, Type: handshake.TypeClientHello},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 0}, Type: handshake.TypeServerHello},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 1}, Type: handshake.TypeEncryptedExtensions},
+		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 2}, Type: handshake.TypeFinished},
 	}, transcript.messageOrder())
 }
 

--- a/internal/handshake/protected_flight13.go
+++ b/internal/handshake/protected_flight13.go
@@ -7,6 +7,7 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
@@ -16,7 +17,7 @@ import (
 func VerifyAndAppendProtectedHandshakeCacheItems13(
 	transcript *Transcript,
 	state *dtlsstate.State13,
-	_ *dtlsconfig.HandshakeConfig,
+	cfg *dtlsconfig.HandshakeConfig,
 	cipherSuite dtlsconfig.CipherSuite,
 	items []*dtlsflight.HandshakeCacheItem,
 ) error {
@@ -32,6 +33,7 @@ func VerifyAndAppendProtectedHandshakeCacheItems13(
 	flight := protectedHandshakeFlight13{
 		transcript:  working,
 		state:       state,
+		cfg:         cfg,
 		cipherSuite: cipherSuite,
 	}
 	for _, item := range items {
@@ -43,15 +45,26 @@ func VerifyAndAppendProtectedHandshakeCacheItems13(
 		return dtlserrors.ErrVerifyDataMismatch
 	}
 
-	return transcript.replaceWith(working)
+	if err := transcript.replaceWith(working); err != nil {
+		return err
+	}
+	if flight.hasCertificate {
+		state.PeerCertificates = flight.peerCertificates
+	}
+
+	return nil
 }
 
 type protectedHandshakeFlight13 struct {
 	transcript  *Transcript
 	state       *dtlsstate.State13
+	cfg         *dtlsconfig.HandshakeConfig
 	cipherSuite dtlsconfig.CipherSuite
 
-	hasFinished bool
+	peerCertificates     [][]byte
+	hasCertificate       bool
+	hasCertificateVerify bool
+	hasFinished          bool
 }
 
 func (f *protectedHandshakeFlight13) process(item *dtlsflight.HandshakeCacheItem) error {
@@ -60,12 +73,46 @@ func (f *protectedHandshakeFlight13) process(item *dtlsflight.HandshakeCacheItem
 		return err
 	}
 
-	finished, ok := hs.Message.(*handshake.MessageFinished)
-	if ok {
-		return f.processFinished(item, hs, finished)
+	switch msg := hs.Message.(type) {
+	case *handshake.MessageCertificate13:
+		return f.processCertificate(item, hs, msg)
+	case *handshake.MessageCertificateVerify:
+		return f.processCertificateVerify(item, hs, msg)
+	case *handshake.MessageFinished:
+		return f.processFinished(item, hs, msg)
+	default:
+		return f.append(item, hs)
+	}
+}
+
+func (f *protectedHandshakeFlight13) processCertificate(
+	item *dtlsflight.HandshakeCacheItem,
+	h *handshake.Handshake,
+	certificate *handshake.MessageCertificate13,
+) error {
+	f.hasCertificate = true
+	f.peerCertificates = rawCertificatesFromCertificate13(certificate)
+	if len(f.peerCertificates) == 0 {
+		return dtlserrors.ErrInvalidCertificate
 	}
 
-	return f.append(item, hs)
+	return f.append(item, h)
+}
+
+func (f *protectedHandshakeFlight13) processCertificateVerify(
+	item *dtlsflight.HandshakeCacheItem,
+	h *handshake.Handshake,
+	verify *handshake.MessageCertificateVerify,
+) error {
+	if !f.hasCertificate {
+		return dtlserrors.ErrCertificateVerifyNoCertificate
+	}
+	if err := verifyServerCertificateVerify13(f.transcript, f.cfg, verify, f.peerCertificates); err != nil {
+		return err
+	}
+	f.hasCertificateVerify = true
+
+	return f.append(item, h)
 }
 
 func (f *protectedHandshakeFlight13) processFinished(
@@ -73,6 +120,9 @@ func (f *protectedHandshakeFlight13) processFinished(
 	h *handshake.Handshake,
 	finished *handshake.MessageFinished,
 ) error {
+	if f.hasCertificate && !f.hasCertificateVerify {
+		return dtlserrors.ErrClientCertificateNotVerified
+	}
 	if err := verifyServerFinished13(f.transcript, f.state, f.cipherSuite, finished); err != nil {
 		return err
 	}
@@ -127,6 +177,12 @@ func protectedHandshakeMessage13(typ handshake.Type, body []byte) (handshake.Mes
 	switch typ {
 	case handshake.TypeEncryptedExtensions:
 		msg = &handshake.MessageEncryptedExtensions{}
+	case handshake.TypeCertificateRequest:
+		msg = &handshake.MessageCertificateRequest13{}
+	case handshake.TypeCertificate:
+		msg = &handshake.MessageCertificate13{}
+	case handshake.TypeCertificateVerify:
+		msg = &handshake.MessageCertificateVerify{}
 	case handshake.TypeFinished:
 		msg = &handshake.MessageFinished{}
 	default:
@@ -137,6 +193,50 @@ func protectedHandshakeMessage13(typ handshake.Type, body []byte) (handshake.Mes
 	}
 
 	return msg, nil
+}
+
+func rawCertificatesFromCertificate13(certificate *handshake.MessageCertificate13) [][]byte {
+	out := make([][]byte, 0, len(certificate.CertificateList))
+	for _, entry := range certificate.CertificateList {
+		out = append(out, append([]byte(nil), entry.CertificateData...))
+	}
+
+	return out
+}
+
+func verifyServerCertificateVerify13(
+	transcript *Transcript,
+	cfg *dtlsconfig.HandshakeConfig,
+	verify *handshake.MessageCertificateVerify,
+	peerCertificates [][]byte,
+) error {
+	if cfg == nil {
+		return dtlserrors.ErrNoAvailableSignatureSchemes
+	}
+	var validSignatureScheme bool
+	for _, alg := range cfg.LocalSignatureSchemes {
+		if alg.Hash == verify.HashAlgorithm && alg.Signature == verify.SignatureAlgorithm {
+			validSignatureScheme = true
+
+			break
+		}
+	}
+	if !validSignatureScheme {
+		return dtlserrors.ErrNoAvailableSignatureSchemes
+	}
+
+	input, err := CertificateVerifyInputFromTranscript(false, transcript)
+	if err != nil {
+		return err
+	}
+
+	return dtlscrypto.VerifyCertificateVerify(
+		input,
+		verify.HashAlgorithm,
+		verify.SignatureAlgorithm,
+		verify.Signature,
+		peerCertificates,
+	)
 }
 
 func verifyServerFinished13(

--- a/internal/handshake/protected_flight13.go
+++ b/internal/handshake/protected_flight13.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtlshandshake
+
+import (
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+)
+
+// VerifyAndAppendProtectedHandshakeCacheItems13 verifies a DTLS 1.3 protected
+// server flight and commits it to the transcript only after Finished verifies.
+func VerifyAndAppendProtectedHandshakeCacheItems13(
+	transcript *Transcript,
+	state *dtlsstate.State13,
+	_ *dtlsconfig.HandshakeConfig,
+	cipherSuite dtlsconfig.CipherSuite,
+	items []*dtlsflight.HandshakeCacheItem,
+) error {
+	if transcript == nil {
+		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+
+	working, err := transcript.clone()
+	if err != nil {
+		return err
+	}
+
+	flight := protectedHandshakeFlight13{
+		transcript:  working,
+		state:       state,
+		cipherSuite: cipherSuite,
+	}
+	for _, item := range items {
+		if err := flight.process(item); err != nil {
+			return err
+		}
+	}
+	if !flight.hasFinished {
+		return dtlserrors.ErrVerifyDataMismatch
+	}
+
+	return transcript.replaceWith(working)
+}
+
+type protectedHandshakeFlight13 struct {
+	transcript  *Transcript
+	state       *dtlsstate.State13
+	cipherSuite dtlsconfig.CipherSuite
+
+	hasFinished bool
+}
+
+func (f *protectedHandshakeFlight13) process(item *dtlsflight.HandshakeCacheItem) error {
+	hs, err := parseProtectedHandshakeCacheItem13(item)
+	if err != nil {
+		return err
+	}
+
+	finished, ok := hs.Message.(*handshake.MessageFinished)
+	if ok {
+		return f.processFinished(item, hs, finished)
+	}
+
+	return f.append(item, hs)
+}
+
+func (f *protectedHandshakeFlight13) processFinished(
+	item *dtlsflight.HandshakeCacheItem,
+	h *handshake.Handshake,
+	finished *handshake.MessageFinished,
+) error {
+	if err := verifyServerFinished13(f.transcript, f.state, f.cipherSuite, finished); err != nil {
+		return err
+	}
+	f.hasFinished = true
+
+	return f.append(item, h)
+}
+
+func (f *protectedHandshakeFlight13) append(
+	item *dtlsflight.HandshakeCacheItem,
+	h *handshake.Handshake,
+) error {
+	return appendParsedInboundHandshake13(
+		f.transcript,
+		item.IsClient,
+		f.cipherSuite,
+		h,
+		item.Data,
+	)
+}
+
+func parseProtectedHandshakeCacheItem13(item *dtlsflight.HandshakeCacheItem) (*handshake.Handshake, error) {
+	if item == nil {
+		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+
+	header := &handshake.Header{}
+	if err := header.Unmarshal(item.Data); err != nil {
+		return nil, err
+	}
+	if header.Type != item.Typ ||
+		header.MessageSequence != item.MessageSequence ||
+		header.FragmentOffset != 0 ||
+		header.FragmentLength != header.Length ||
+		len(item.Data) != handshake.HeaderLength+int(header.Length) {
+		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+
+	msg, err := protectedHandshakeMessage13(header.Type, item.Data[handshake.HeaderLength:])
+	if err != nil {
+		return nil, err
+	}
+
+	return &handshake.Handshake{
+		Header:  *header,
+		Message: msg,
+	}, nil
+}
+
+func protectedHandshakeMessage13(typ handshake.Type, body []byte) (handshake.Message, error) {
+	var msg handshake.Message
+	switch typ {
+	case handshake.TypeEncryptedExtensions:
+		msg = &handshake.MessageEncryptedExtensions{}
+	case handshake.TypeFinished:
+		msg = &handshake.MessageFinished{}
+	default:
+		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+	if err := msg.Unmarshal(body); err != nil {
+		return nil, err
+	}
+
+	return msg, nil
+}
+
+func verifyServerFinished13(
+	transcript *Transcript,
+	state *dtlsstate.State13,
+	cipherSuite dtlsconfig.CipherSuite,
+	finished *handshake.MessageFinished,
+) error {
+	if state == nil || cipherSuite == nil {
+		return dtlserrors.ErrCipherSuiteNotSet
+	}
+
+	baseKey, err := ServerHandshakeFinishedBaseKey(state)
+	if err != nil {
+		return err
+	}
+
+	return VerifyFinishedDataFromTranscript(
+		cipherSuite.HashFunc(),
+		baseKey,
+		transcript,
+		finished.VerifyData,
+	)
+}
+
+func appendParsedInboundHandshake13(
+	transcript *Transcript,
+	isClient bool,
+	cipherSuite dtlsconfig.CipherSuite,
+	hs *handshake.Handshake,
+	raw []byte,
+) error {
+	canonical, err := canonicalHandshake(raw)
+	if err != nil {
+		return err
+	}
+
+	return appendHandshake13(
+		transcript,
+		transcriptSenderForSide13(isClient),
+		cipherSuite,
+		hs.Header.MessageSequence,
+		hs.Message,
+		canonical,
+	)
+}

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -5,9 +5,11 @@
 package dtlshandshake
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"hash"
+	"maps"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/internal/util"
@@ -277,6 +279,66 @@ func (t *Transcript) hasCanonical(id transcriptMessageID, message []byte) (bool,
 	}
 
 	return false, dtlserrors.ErrHandshakeTranscriptMessageChanged
+}
+
+func (t *Transcript) clone() (*Transcript, error) {
+	if t == nil {
+		return nil, dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+
+	out := &Transcript{
+		newHash:           t.newHash,
+		pending:           cloneByteSlices(t.pending),
+		transcript:        append([]byte(nil), t.transcript...),
+		seen:              make(map[transcriptMessageID]seenTranscriptMessage13, len(t.seen)),
+		order:             append([]transcriptMessage(nil), t.order...),
+		helloRetryApplied: t.helloRetryApplied,
+	}
+	maps.Copy(out.seen, t.seen)
+	if t.h == nil {
+		return out, nil
+	}
+
+	if out.newHash == nil {
+		return nil, dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+	out.h = out.newHash()
+	if out.h == nil {
+		return nil, dtlserrors.ErrHandshakeTranscriptHashNotSelected
+	}
+	if _, err := out.h.Write(out.transcript); err != nil {
+		return nil, err
+	}
+	out.pending = nil
+
+	return out, nil
+}
+
+func (t *Transcript) replaceWith(src *Transcript) error {
+	if t == nil || src == nil {
+		return nil
+	}
+
+	clone, err := src.clone()
+	if err != nil {
+		return err
+	}
+	*t = *clone
+
+	return nil
+}
+
+func cloneByteSlices(in [][]byte) [][]byte {
+	if in == nil {
+		return nil
+	}
+
+	out := make([][]byte, len(in))
+	for i := range in {
+		out[i] = bytes.Clone(in[i])
+	}
+
+	return out
 }
 
 // pending returns the messages waiting for hash selection.


### PR DESCRIPTION
#### Description
This is in two commits rather than 2 PRs because they are kinda related and I needed to test them both at once.
this Extend client protected-flight parsing to add:
1. optional CertificateRequest;
2. server Certificate, if require.
3. server CertificateVerify, if certificate auth.
4. server Finished.
5. Verify server Finished before committing it to authenticated transcript. 

Note: We don't record or use CertificateRequest state yet. or Install application keys after server fished. or handle when server certificate is required (Ig not really related to webrtc use but we'll do it anyways).
And we don't verify optional rootCA or ServerName etc yet.

part of  #827  #852   refs #727 