### PR TITLE
Validate server identity

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -176,7 +176,7 @@ type connConfigValues struct {
 
 type connConfigCallbacks struct {
 	customCipherSuites   func() []dtlsconfig.CipherSuite
-	verifyConnection     func(*dtlsstate.State) error
+	verifyConnection     func(dtlsstate.Active) error
 	getCertificate       func(*dtlsconfig.ClientHelloInfo) (*tls.Certificate, error)
 	getClientCertificate func(*dtlsconfig.CertificateRequestInfo) (*tls.Certificate, error)
 }
@@ -406,13 +406,13 @@ func adaptCustomCipherSuites(customCipherSuites func() []CipherSuite) func() []d
 	}
 }
 
-func adaptVerifyConnection(verifyConnection func(*State) error) func(*dtlsstate.State) error {
+func adaptVerifyConnection(verifyConnection func(*State) error) func(dtlsstate.Active) error {
 	if verifyConnection == nil {
 		return nil
 	}
 
-	return func(state *dtlsstate.State) error {
-		stateSnapshot, err := generateState(state)
+	return func(state dtlsstate.Active) error {
+		stateSnapshot, err := generateStateForVerifyConnection(state)
 		if err != nil {
 			return err
 		}

--- a/flight_test.go
+++ b/flight_test.go
@@ -5,8 +5,12 @@ package dtls
 
 import (
 	"context"
+	"crypto"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"hash"
 	"testing"
 	"time"
@@ -17,11 +21,15 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
+	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	dtlshash "github.com/pion/dtls/v3/pkg/crypto/hash"
 	"github.com/pion/dtls/v3/pkg/crypto/keyschedule"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	"github.com/pion/dtls/v3/pkg/crypto/signature"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
@@ -34,7 +42,12 @@ import (
 
 const tlsHandshakeHeaderLength13 = 4
 
-var testCurves13 = []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384} //nolint:gochecknoglobals
+var (
+	//nolint:gochecknoglobals
+	testCurves13                            = []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384}
+	errFlight13ConnectionCallbackRejected   = errors.New("connection callback rejected")
+	errFlight13ServerIdentityCallbackReject = errors.New("identity callback rejected")
+)
 
 type Flight = dtlsflight13.Flight
 
@@ -363,6 +376,148 @@ func (f flight13ProtectedServerFlightFixture) cacheWithFinished(rawFinished []by
 	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
 
 	return cache
+}
+
+type flight13ProtectedServerCertificateFlight struct {
+	cache                      *dtlsflight.Cache
+	certificateCanonical       []byte
+	certificateVerifyCanonical []byte
+	finishedCanonical          []byte
+}
+
+func (f flight13ProtectedServerFlightFixture) cacheWithCertificate(
+	t *testing.T,
+	certificate tls.Certificate,
+) flight13ProtectedServerCertificateFlight {
+	t.Helper()
+
+	rawCertificate := marshalCertificate13(t, 2, certificate.Certificate)
+	certificateCanonical, err := canonicalHandshake13(rawCertificate)
+	require.NoError(t, err)
+
+	signer, ok := certificate.PrivateKey.(crypto.Signer)
+	require.True(t, ok)
+	rawCertificateVerify := marshalServerCertificateVerify13(
+		t,
+		3,
+		signer,
+		f.clientHelloCanonical,
+		f.serverHelloCanonical,
+		f.encryptedExtensionsCanonical,
+		certificateCanonical,
+	)
+	certificateVerifyCanonical, err := canonicalHandshake13(rawCertificateVerify)
+	require.NoError(t, err)
+
+	f.state.CipherSuite = f.cfg.LocalCipherSuites[0]
+	f.state.KeySchedule.HandshakeTraffic = f.handshakeSecrets
+	rawFinished := marshalServerFinished13(
+		t,
+		f.state,
+		4,
+		f.clientHelloCanonical,
+		f.serverHelloCanonical,
+		f.encryptedExtensionsCanonical,
+		certificateCanonical,
+		certificateVerifyCanonical,
+	)
+	f.state.CipherSuite = nil
+	f.state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+	finishedCanonical, err := canonicalHandshake13(rawFinished)
+	require.NoError(t, err)
+
+	cache := dtlsflight.NewCache()
+	cache.Push(f.rawServerHello, f.cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
+	cache.Push(f.rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawCertificate, dtlsflight13.EpochHandshake, 2, handshake.TypeCertificate, false)
+	cache.Push(rawCertificateVerify, dtlsflight13.EpochHandshake, 3, handshake.TypeCertificateVerify, false)
+	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 4, handshake.TypeFinished, false)
+
+	return flight13ProtectedServerCertificateFlight{
+		cache:                      cache,
+		certificateCanonical:       certificateCanonical,
+		certificateVerifyCanonical: certificateVerifyCanonical,
+		finishedCanonical:          finishedCanonical,
+	}
+}
+
+func marshalCertificate13(t *testing.T, seq uint16, rawCertificates [][]byte) []byte {
+	t.Helper()
+
+	entries := make([]handshake.CertificateEntry13, 0, len(rawCertificates))
+	for _, rawCertificate := range rawCertificates {
+		entries = append(entries, handshake.CertificateEntry13{
+			CertificateData: rawCertificate,
+		})
+	}
+
+	raw, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: seq},
+		Message: &handshake.MessageCertificate13{
+			CertificateList: entries,
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func marshalServerCertificateVerify13(
+	t *testing.T,
+	seq uint16,
+	signer crypto.Signer,
+	transcriptMessages ...[]byte,
+) []byte {
+	t.Helper()
+
+	signatureBytes, err := dtlscrypto.GenerateCertificateVerify(
+		serverCertificateVerifyInput13(t, transcriptMessages...),
+		signer,
+		dtlshash.SHA256,
+		signature.ECDSA,
+	)
+	require.NoError(t, err)
+
+	raw, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: seq},
+		Message: &handshake.MessageCertificateVerify{
+			HashAlgorithm:      dtlshash.SHA256,
+			SignatureAlgorithm: signature.ECDSA,
+			Signature:          signatureBytes,
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func serverCertificateVerifyInput13(t *testing.T, transcriptMessages ...[]byte) []byte {
+	t.Helper()
+
+	transcriptHash := hashTranscript13(transcriptMessages...)
+	out := make([]byte, 64, 64+len("TLS 1.3, server CertificateVerify\x00")+len(transcriptHash))
+	for i := range out {
+		out[i] = 0x20
+	}
+	out = append(out, []byte("TLS 1.3, server CertificateVerify\x00")...)
+	out = append(out, transcriptHash...)
+
+	return out
+}
+
+func flight13RootCAsForCertificate(t *testing.T, certificate tls.Certificate) *x509.CertPool {
+	t.Helper()
+
+	leaf := certificate.Leaf
+	if leaf == nil {
+		var err error
+		leaf, err = x509.ParseCertificate(certificate.Certificate[0])
+		require.NoError(t, err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	return pool
 }
 
 func testHandshakeConfig13(t *testing.T) *dtlsconfig.HandshakeConfig {
@@ -1529,6 +1684,240 @@ func TestFlight13_3ParseRejectsInvalidServerFinished(t *testing.T) {
 			assert.Equal(t, alert.HandshakeFailure, dtlsAlert.Description)
 			assert.Zero(t, nextFlight)
 			assert.Equal(t, 1, fixture.state.HandshakeRecvSequence)
+
+			expectedTranscript := append(append([]byte(nil), fixture.clientHelloCanonical...), fixture.serverHelloCanonical...)
+			assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())
+		})
+	}
+}
+
+func TestFlight13_3ParseRunsVerifyConnectionWithoutServerCertificate(t *testing.T) {
+	fixture := newFlight13ProtectedServerFlightFixture(t)
+	var verifyConnectionCalled bool
+	fixture.cfg.VerifyConnection = adaptVerifyConnection(func(state *State) error {
+		verifyConnectionCalled = true
+		assert.Nil(t, state.PeerCertificates)
+		assert.Equal(t, fixture.cfg.LocalCipherSuites[0].ID(), state.CipherSuiteID)
+
+		return nil
+	})
+
+	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+		state:      fixture.state,
+		cache:      fixture.cacheWithFinished(fixture.rawFinished),
+		cfg:        fixture.cfg,
+		transcript: fixture.transcript,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, Flight5, nextFlight)
+	assert.True(t, verifyConnectionCalled)
+	assert.Nil(t, fixture.state.PeerCertificates)
+}
+
+func TestFlight13_3ParseRejectsVerifyConnectionErrorWithoutServerCertificate(t *testing.T) {
+	fixture := newFlight13ProtectedServerFlightFixture(t)
+	callbackErr := errFlight13ConnectionCallbackRejected
+	fixture.cfg.VerifyConnection = adaptVerifyConnection(func(*State) error {
+		return callbackErr
+	})
+
+	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+		state:      fixture.state,
+		cache:      fixture.cacheWithFinished(fixture.rawFinished),
+		cfg:        fixture.cfg,
+		transcript: fixture.transcript,
+	})
+
+	require.ErrorIs(t, err, dtlserrors.ErrCertificateVerificationFailed)
+	require.ErrorIs(t, err, callbackErr)
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
+	assert.Equal(t, alert.BadCertificate, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+	assert.Nil(t, fixture.state.PeerCertificates)
+
+	expectedTranscript := append(append([]byte(nil), fixture.clientHelloCanonical...), fixture.serverHelloCanonical...)
+	assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())
+}
+
+func TestFlight13_3ParseValidatesServerCertificate(t *testing.T) {
+	certificate, err := selfsign.GenerateSelfSignedWithDNS("server.test")
+	require.NoError(t, err)
+
+	fixture := newFlight13ProtectedServerFlightFixture(t)
+	fixture.cfg.RootCAs = flight13RootCAsForCertificate(t, certificate)
+	fixture.cfg.ServerName = "server.test"
+
+	var verifyPeerCalled bool
+	fixture.cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		verifyPeerCalled = true
+		require.Equal(t, certificate.Certificate, rawCerts)
+		require.Len(t, verifiedChains, 1)
+		require.NotEmpty(t, verifiedChains[0])
+		assert.Equal(t, certificate.Leaf.Raw, verifiedChains[0][0].Raw)
+
+		return nil
+	}
+
+	var verifyConnectionCalled bool
+	fixture.cfg.VerifyConnection = adaptVerifyConnection(func(state *State) error {
+		verifyConnectionCalled = true
+		require.Equal(t, certificate.Certificate, state.PeerCertificates)
+		assert.Equal(t, fixture.cfg.LocalCipherSuites[0].ID(), state.CipherSuiteID)
+		state.PeerCertificates[0][0] ^= 0xff
+
+		return nil
+	})
+
+	certificateFlight := fixture.cacheWithCertificate(t, certificate)
+	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+		state:      fixture.state,
+		cache:      certificateFlight.cache,
+		cfg:        fixture.cfg,
+		transcript: fixture.transcript,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, Flight5, nextFlight)
+	assert.True(t, verifyPeerCalled)
+	assert.True(t, verifyConnectionCalled)
+	assert.Equal(t, certificate.Certificate, fixture.state.PeerCertificates)
+
+	expectedTranscript := append([]byte(nil), fixture.clientHelloCanonical...)
+	for _, message := range [][]byte{
+		fixture.serverHelloCanonical,
+		fixture.encryptedExtensionsCanonical,
+		certificateFlight.certificateCanonical,
+		certificateFlight.certificateVerifyCanonical,
+		certificateFlight.finishedCanonical,
+	} {
+		expectedTranscript = append(expectedTranscript, message...)
+	}
+	assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())
+}
+
+func TestFlight13_3ParseRejectsWrongServerName(t *testing.T) {
+	certificate, err := selfsign.GenerateSelfSignedWithDNS("server.test")
+	require.NoError(t, err)
+
+	fixture := newFlight13ProtectedServerFlightFixture(t)
+	fixture.cfg.RootCAs = flight13RootCAsForCertificate(t, certificate)
+	fixture.cfg.ServerName = "wrong.test"
+	certificateFlight := fixture.cacheWithCertificate(t, certificate)
+
+	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+		state:      fixture.state,
+		cache:      certificateFlight.cache,
+		cfg:        fixture.cfg,
+		transcript: fixture.transcript,
+	})
+
+	require.ErrorIs(t, err, dtlserrors.ErrCertificateVerificationFailed)
+	var hostnameErr x509.HostnameError
+	assert.True(t, errors.As(err, &hostnameErr))
+	require.NotNil(t, dtlsAlert)
+	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
+	assert.Equal(t, alert.BadCertificate, dtlsAlert.Description)
+	assert.Zero(t, nextFlight)
+	assert.Nil(t, fixture.state.PeerCertificates)
+	assert.Equal(t, 1, fixture.state.HandshakeRecvSequence)
+
+	expectedTranscript := append(append([]byte(nil), fixture.clientHelloCanonical...), fixture.serverHelloCanonical...)
+	assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())
+}
+
+func TestFlight13_3ParseInsecureSkipVerifyStillRunsCertificateCallback(t *testing.T) {
+	certificate, err := selfsign.GenerateSelfSignedWithDNS("server.test")
+	require.NoError(t, err)
+
+	fixture := newFlight13ProtectedServerFlightFixture(t)
+	fixture.cfg.InsecureSkipVerify = true
+	fixture.cfg.ServerName = "wrong.test"
+
+	var verifyPeerCalled bool
+	fixture.cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		verifyPeerCalled = true
+		assert.Equal(t, certificate.Certificate, rawCerts)
+		assert.Nil(t, verifiedChains)
+
+		return nil
+	}
+	var verifyConnectionCalled bool
+	fixture.cfg.VerifyConnection = adaptVerifyConnection(func(state *State) error {
+		verifyConnectionCalled = true
+		assert.Equal(t, certificate.Certificate, state.PeerCertificates)
+
+		return nil
+	})
+
+	certificateFlight := fixture.cacheWithCertificate(t, certificate)
+	nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+		state:      fixture.state,
+		cache:      certificateFlight.cache,
+		cfg:        fixture.cfg,
+		transcript: fixture.transcript,
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, Flight5, nextFlight)
+	assert.True(t, verifyPeerCalled)
+	assert.True(t, verifyConnectionCalled)
+	assert.Equal(t, certificate.Certificate, fixture.state.PeerCertificates)
+}
+
+func TestFlight13_3ParseRejectsServerIdentityCallbackErrors(t *testing.T) {
+	certificate, err := selfsign.GenerateSelfSignedWithDNS("server.test")
+	require.NoError(t, err)
+	callbackErr := errFlight13ServerIdentityCallbackReject
+
+	tests := []struct {
+		name      string
+		configure func(*dtlsconfig.HandshakeConfig)
+	}{
+		{
+			name: "VerifyPeerCertificate",
+			configure: func(cfg *dtlsconfig.HandshakeConfig) {
+				cfg.VerifyPeerCertificate = func([][]byte, [][]*x509.Certificate) error {
+					return callbackErr
+				}
+			},
+		},
+		{
+			name: "VerifyConnection",
+			configure: func(cfg *dtlsconfig.HandshakeConfig) {
+				cfg.VerifyConnection = adaptVerifyConnection(func(*State) error {
+					return callbackErr
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFlight13ProtectedServerFlightFixture(t)
+			fixture.cfg.RootCAs = flight13RootCAsForCertificate(t, certificate)
+			fixture.cfg.ServerName = "server.test"
+			test.configure(fixture.cfg)
+			certificateFlight := fixture.cacheWithCertificate(t, certificate)
+
+			nextFlight, dtlsAlert, err := flight13ParseForTest(t, Flight3, context.Background(), &handshakeTestContext13{
+				state:      fixture.state,
+				cache:      certificateFlight.cache,
+				cfg:        fixture.cfg,
+				transcript: fixture.transcript,
+			})
+
+			require.ErrorIs(t, err, dtlserrors.ErrCertificateVerificationFailed)
+			require.ErrorIs(t, err, callbackErr)
+			require.NotNil(t, dtlsAlert)
+			assert.Equal(t, alert.Fatal, dtlsAlert.Level)
+			assert.Equal(t, alert.BadCertificate, dtlsAlert.Description)
+			assert.Zero(t, nextFlight)
+			assert.Nil(t, fixture.state.PeerCertificates)
 
 			expectedTranscript := append(append([]byte(nil), fixture.clientHelloCanonical...), fixture.serverHelloCanonical...)
 			assert.Equal(t, expectedTranscript, fixture.transcript.Bytes())

--- a/internal/config/handshake.go
+++ b/internal/config/handshake.go
@@ -102,7 +102,7 @@ type HandshakeConfig struct {
 	LocalCertificates             []tls.Certificate
 	InsecureSkipVerify            bool
 	VerifyPeerCertificate         func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
-	VerifyConnection              func(*internalstate.State) error
+	VerifyConnection              func(internalstate.Active) error
 	HasSessionStore               bool
 	GetSession                    func(key []byte) (id, secret []byte, err error)
 	SetSession                    func(key, id, secret []byte) error

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -54,7 +54,8 @@ var ( //nolint:gochecknoglobals,lll
 	ErrCookieMismatch                       = stderrors.New("client+server cookie does not match")       //nolint:lll
 	ErrIdentityNoPSK                        = stderrors.New("PSK Identity Hint provided but PSK is nil") //nolint:lll
 	ErrInvalidCertificate                   = errInvalidCertificate                                      //nolint:lll
-	ErrInvalidCipherSuite                   = stderrors.New("invalid or unknown cipher suite")           //nolint:lll
+	ErrCertificateVerificationFailed        = stderrors.New("certificate verification failed")
+	ErrInvalidCipherSuite                   = stderrors.New("invalid or unknown cipher suite") //nolint:lll
 	ErrInvalidClientAuthType                = stderrors.New("invalid client auth type")
 	ErrInvalidClientHello                   = stderrors.New("invalid ClientHello") //nolint:lll
 	ErrMissingClientHelloExtension          = stderrors.New("DTLS 1.3 ClientHello missing mandatory extension")

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -492,6 +492,7 @@ func protectedFlightParseFailure(err error) *flightParseFailure {
 		return newFlightParseFailure(alert.NoCertificate, err)
 	case errors.Is(err, dtlserrors.ErrKeySignatureMismatch),
 		errors.Is(err, dtlserrors.ErrInvalidCertificate),
+		errors.Is(err, dtlserrors.ErrCertificateVerificationFailed),
 		errors.Is(err, dtlserrors.ErrClientCertificateNotVerified),
 		errors.Is(err, dtlserrors.ErrInvalidCertificateOID),
 		errors.Is(err, dtlserrors.ErrInvalidCertificateSignatureAlgorithm),

--- a/internal/handshake/protected_flight13.go
+++ b/internal/handshake/protected_flight13.go
@@ -4,11 +4,20 @@
 package dtlshandshake
 
 import (
+	"bytes"
+	"crypto/x509"
+	"fmt"
+
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/internal/util"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -87,7 +96,7 @@ func (f *protectedHandshakeFlight13) process(item *dtlsflight.HandshakeCacheItem
 
 func (f *protectedHandshakeFlight13) processCertificate(
 	item *dtlsflight.HandshakeCacheItem,
-	h *handshake.Handshake,
+	parsedHandshake *handshake.Handshake,
 	certificate *handshake.MessageCertificate13,
 ) error {
 	f.hasCertificate = true
@@ -96,12 +105,12 @@ func (f *protectedHandshakeFlight13) processCertificate(
 		return dtlserrors.ErrInvalidCertificate
 	}
 
-	return f.append(item, h)
+	return f.append(item, parsedHandshake)
 }
 
 func (f *protectedHandshakeFlight13) processCertificateVerify(
 	item *dtlsflight.HandshakeCacheItem,
-	h *handshake.Handshake,
+	parsedHandshake *handshake.Handshake,
 	verify *handshake.MessageCertificateVerify,
 ) error {
 	if !f.hasCertificate {
@@ -110,14 +119,17 @@ func (f *protectedHandshakeFlight13) processCertificateVerify(
 	if err := verifyServerCertificateVerify13(f.transcript, f.cfg, verify, f.peerCertificates); err != nil {
 		return err
 	}
+	if err := f.verifyServerIdentity(); err != nil {
+		return err
+	}
 	f.hasCertificateVerify = true
 
-	return f.append(item, h)
+	return f.append(item, parsedHandshake)
 }
 
 func (f *protectedHandshakeFlight13) processFinished(
 	item *dtlsflight.HandshakeCacheItem,
-	h *handshake.Handshake,
+	parsedHandshake *handshake.Handshake,
 	finished *handshake.MessageFinished,
 ) error {
 	if f.hasCertificate && !f.hasCertificateVerify {
@@ -126,20 +138,23 @@ func (f *protectedHandshakeFlight13) processFinished(
 	if err := verifyServerFinished13(f.transcript, f.state, f.cipherSuite, finished); err != nil {
 		return err
 	}
+	if err := f.verifyConnection(); err != nil {
+		return err
+	}
 	f.hasFinished = true
 
-	return f.append(item, h)
+	return f.append(item, parsedHandshake)
 }
 
 func (f *protectedHandshakeFlight13) append(
 	item *dtlsflight.HandshakeCacheItem,
-	h *handshake.Handshake,
+	parsedHandshake *handshake.Handshake,
 ) error {
 	return appendParsedInboundHandshake13(
 		f.transcript,
 		item.IsClient,
 		f.cipherSuite,
-		h,
+		parsedHandshake,
 		item.Data,
 	)
 }
@@ -202,6 +217,132 @@ func rawCertificatesFromCertificate13(certificate *handshake.MessageCertificate1
 	}
 
 	return out
+}
+
+func (f *protectedHandshakeFlight13) verifyServerIdentity() error {
+	var chains [][]*x509.Certificate
+	var err error
+	if !f.cfg.InsecureSkipVerify {
+		certAlgs := f.cfg.LocalCertSignatureSchemes
+		if len(certAlgs) == 0 {
+			certAlgs = f.cfg.LocalSignatureSchemes
+		}
+		chains, err = dtlscrypto.VerifyServerCert(
+			f.peerCertificates, f.cfg.RootCAs, f.cfg.ServerName, certAlgs,
+		)
+		if err != nil {
+			return certificateVerificationError(err)
+		}
+	}
+	if f.cfg.VerifyPeerCertificate != nil {
+		if err = f.cfg.VerifyPeerCertificate(f.peerCertificates, chains); err != nil {
+			return certificateVerificationError(err)
+		}
+	}
+
+	return nil
+}
+
+func (f *protectedHandshakeFlight13) verifyConnection() error {
+	if f.cfg.VerifyConnection != nil {
+		if err := f.cfg.VerifyConnection(cloneState13ForVerifyConnection(f.state, f.peerCertificates)); err != nil {
+			return certificateVerificationError(err)
+		}
+	}
+
+	return nil
+}
+
+func certificateVerificationError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %w", dtlserrors.ErrCertificateVerificationFailed, err)
+}
+
+func cloneState13ForVerifyConnection(state *dtlsstate.State13, peerCertificates [][]byte) *dtlsstate.State13 {
+	common := &dtlsstate.Common{
+		PeerCertificates: util.CloneByteSlices(peerCertificates),
+		LocalVersion:     protocol.Version1_3,
+	}
+	if state == nil || state.Common == nil {
+		return &dtlsstate.State13{Common: common}
+	}
+
+	common.LocalSequenceNumber = append([]uint64(nil), state.LocalSequenceNumber...)
+	common.RemoteSequenceNumber = append([]uint64(nil), state.RemoteSequenceNumber...)
+	common.LocalRandom = state.LocalRandom
+	common.RemoteRandom = state.RemoteRandom
+	common.CipherSuite = state.CipherSuite
+	common.IdentityHint = bytes.Clone(state.IdentityHint)
+	common.SessionID = bytes.Clone(state.SessionID)
+	common.NegotiatedProtocol = state.NegotiatedProtocol
+	common.RemoteSRTPMasterKeyIdentifier = bytes.Clone(state.RemoteSRTPMasterKeyIdentifier)
+	common.RemoteConnectionID = bytes.Clone(state.RemoteConnectionID)
+	common.IsClient = state.IsClient
+	common.ServerName = state.ServerName
+	common.PeerSupportedProtocols = append([]string(nil), state.PeerSupportedProtocols...)
+	common.RemoteVersions = append([]protocol.Version(nil), state.RemoteVersions...)
+	if !state.LocalVersion.Equal(protocol.Version{}) {
+		common.LocalVersion = state.LocalVersion
+	}
+	if localEpoch, ok := state.LocalEpoch.Load().(uint16); ok {
+		common.LocalEpoch.Store(localEpoch)
+	}
+	if remoteEpoch, ok := state.RemoteEpoch.Load().(uint16); ok {
+		common.RemoteEpoch.Store(remoteEpoch)
+	}
+	if profile, ok := state.SRTPProtectionProfile.Load().(extension.SRTPProtectionProfile); ok {
+		common.SRTPProtectionProfile.Store(profile)
+	}
+	if localCID := state.GetLocalConnectionID(); localCID != nil {
+		common.SetLocalConnectionID(bytes.Clone(localCID))
+	}
+	var remoteKeyEntries *[]extension.KeyShareEntry
+	if state.RemoteKeyEntries != nil {
+		entries := append([]extension.KeyShareEntry(nil), (*state.RemoteKeyEntries)...)
+		remoteKeyEntries = &entries
+	}
+
+	return &dtlsstate.State13{
+		Common:                common,
+		KeySchedule:           cloneKeySchedule13(state.KeySchedule),
+		KeyAgreementSecret:    bytes.Clone(state.KeyAgreementSecret),
+		SelectedGroup:         state.SelectedGroup,
+		LocalKeyEntries:       append([]extension.KeyShareEntry(nil), state.LocalKeyEntries...),
+		RemoteKeyEntries:      remoteKeyEntries,
+		RemoteGroups:          append([]elliptic.Curve(nil), state.RemoteGroups...),
+		Cookie:                bytes.Clone(state.Cookie),
+		HandshakeSendSequence: state.HandshakeSendSequence,
+		HandshakeRecvSequence: state.HandshakeRecvSequence,
+		RemoteSignatureSchemes: append(
+			[]signaturehash.Algorithm(nil), state.RemoteSignatureSchemes...,
+		),
+		RemoteCertSignatureSchemes: append(
+			[]signaturehash.Algorithm(nil), state.RemoteCertSignatureSchemes...,
+		),
+	}
+}
+
+func cloneKeySchedule13(in dtlsstate.KeySchedule) dtlsstate.KeySchedule {
+	return dtlsstate.KeySchedule{
+		EarlySecret:                     bytes.Clone(in.EarlySecret),
+		HandshakeSecret:                 bytes.Clone(in.HandshakeSecret),
+		MasterSecret:                    bytes.Clone(in.MasterSecret),
+		HandshakeTraffic:                cloneTrafficSecrets13(in.HandshakeTraffic),
+		ClientApplicationTrafficSecret0: bytes.Clone(in.ClientApplicationTrafficSecret0),
+		ServerApplicationTrafficSecret0: bytes.Clone(in.ServerApplicationTrafficSecret0),
+		ExporterMasterSecret:            bytes.Clone(in.ExporterMasterSecret),
+		ResumptionMasterSecret:          bytes.Clone(in.ResumptionMasterSecret),
+	}
+}
+
+func cloneTrafficSecrets13(in dtlsstate.TrafficSecrets) dtlsstate.TrafficSecrets {
+	return dtlsstate.TrafficSecrets{
+		Client: bytes.Clone(in.Client),
+		Server: bytes.Clone(in.Server),
+	}
 }
 
 func verifyServerCertificateVerify13(

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -5,7 +5,6 @@
 package dtlshandshake
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"errors"
 	"hash"
@@ -288,7 +287,7 @@ func (t *Transcript) clone() (*Transcript, error) {
 
 	out := &Transcript{
 		newHash:           t.newHash,
-		pending:           cloneByteSlices(t.pending),
+		pending:           util.CloneByteSlices(t.pending),
 		transcript:        append([]byte(nil), t.transcript...),
 		seen:              make(map[transcriptMessageID]seenTranscriptMessage13, len(t.seen)),
 		order:             append([]transcriptMessage(nil), t.order...),
@@ -328,27 +327,9 @@ func (t *Transcript) replaceWith(src *Transcript) error {
 	return nil
 }
 
-func cloneByteSlices(in [][]byte) [][]byte {
-	if in == nil {
-		return nil
-	}
-
-	out := make([][]byte, len(in))
-	for i := range in {
-		out[i] = bytes.Clone(in[i])
-	}
-
-	return out
-}
-
 // pending returns the messages waiting for hash selection.
 func (t *Transcript) pendingMessages() [][]byte {
-	pending := make([][]byte, 0, len(t.pending))
-	for _, message := range t.pending {
-		pending = append(pending, append([]byte(nil), message...))
-	}
-
-	return pending
+	return util.CloneByteSlices(t.pending)
 }
 
 // Bytes returns the canonical transcript bytes.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -5,6 +5,7 @@
 package util // nolint:revive
 
 import (
+	"bytes"
 	"encoding/binary"
 )
 
@@ -41,4 +42,18 @@ func Max(a, b int) int {
 	}
 
 	return b
+}
+
+// CloneByteSlices returns a deep copy of in, preserving nil.
+func CloneByteSlices(in [][]byte) [][]byte {
+	if in == nil {
+		return nil
+	}
+
+	out := make([][]byte, len(in))
+	for i := range in {
+		out[i] = bytes.Clone(in[i])
+	}
+
+	return out
 }

--- a/state.go
+++ b/state.go
@@ -10,6 +10,7 @@ import (
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	dtlsutil "github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
@@ -81,6 +82,52 @@ func generateState(internalState *dtlsstate.State) (*State, error) {
 		IdentityHint:          internalState.IdentityHint,
 		SessionID:             internalState.SessionID,
 		NegotiatedProtocol:    internalState.NegotiatedProtocol,
+	}, nil
+}
+
+func generateStateForVerifyConnection(active dtlsstate.Active) (*State, error) {
+	switch state := active.(type) {
+	case *dtlsstate.State:
+		return generateState(state)
+	case *dtlsstate.State13:
+		return generateState13(state)
+	default:
+		return nil, dtlserrors.ErrInvalidProtocolVersionState
+	}
+}
+
+func generateState13(internalState *dtlsstate.State13) (*State, error) {
+	if internalState.CipherSuite == nil {
+		return nil, dtlserrors.ErrCipherSuiteNotSet
+	}
+
+	common := internalState.CommonFields()
+	if common == nil {
+		return nil, dtlserrors.ErrInvalidProtocolVersionState
+	}
+
+	epoch := common.GetLocalEpoch()
+	var sequenceNumber uint64
+	if int(epoch) < len(common.LocalSequenceNumber) {
+		sequenceNumber = atomic.LoadUint64(&common.LocalSequenceNumber[epoch])
+	}
+
+	return &State{
+		localEpoch:            common.GetLocalEpoch(),
+		remoteEpoch:           common.GetRemoteEpoch(),
+		localRandom:           common.LocalRandom,
+		remoteRandom:          common.RemoteRandom,
+		sequenceNumber:        sequenceNumber,
+		srtpProtectionProfile: common.GetSRTPProtectionProfile(),
+		localConnectionID:     bytes.Clone(common.GetLocalConnectionID()),
+		remoteConnectionID:    bytes.Clone(common.RemoteConnectionID),
+		isClient:              common.IsClient,
+		version:               protocol.Version1_3,
+		CipherSuiteID:         internalState.CipherSuite.ID(),
+		PeerCertificates:      dtlsutil.CloneByteSlices(common.PeerCertificates),
+		IdentityHint:          bytes.Clone(common.IdentityHint),
+		SessionID:             bytes.Clone(common.SessionID),
+		NegotiatedProtocol:    common.NegotiatedProtocol,
 	}, nil
 }
 


### PR DESCRIPTION
#### Description

Wire DTLS 1.3 protected Flight 4 processing into the existing peer certificate validation used by DTLS 1.2 (Many of them aren't related to WebRTC use like SNI use but they make pion/dtls more generic use).

The client now validates the server certificate after CertificateVerify succeeds and before committing the protected flight, using RootCAs, ServerName, InsecureSkipVerify, VerifyPeerCertificate, and VerifyConnection.

part of #825 #852 