### PR TITLE
Select and validate client certificates

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -35,6 +36,10 @@ type CertificateRequestInfo struct {
 	// that the server wishes the returned certificate to be signed by. An
 	// empty slice indicates that the server has no preference.
 	AcceptableCAs [][]byte
+
+	// SignatureSchemes lists the signature schemes that the server is
+	// willing to verify.
+	SignatureSchemes []tls.SignatureScheme
 }
 
 // SupportsCertificate returns nil if the provided certificate is supported by
@@ -42,6 +47,18 @@ type CertificateRequestInfo struct {
 // describing the reason for the incompatibility.
 // NOTE: original src:
 // https://github.com/golang/go/blob/29b9a328d268d53833d2cc063d1d8b4bf6852675/src/crypto/tls/common.go#L1273
-func (cri *CertificateRequestInfo) SupportsCertificate(c *tls.Certificate) error {
-	return dtlsconfig.SupportsCertificate(cri.AcceptableCAs, c)
+func (cri *CertificateRequestInfo) SupportsCertificate(certificate *tls.Certificate) error {
+	var signatureSchemes []signaturehash.Algorithm
+	if len(cri.SignatureSchemes) > 0 {
+		var err error
+		signatureSchemes, err = signaturehash.ParseSignatureSchemes(cri.SignatureSchemes, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	return (&dtlsconfig.CertificateRequestInfo{
+		AcceptableCAs:    cri.AcceptableCAs,
+		SignatureSchemes: signatureSchemes,
+	}).SupportsCertificate(certificate)
 }

--- a/conn.go
+++ b/conn.go
@@ -445,7 +445,16 @@ func adaptGetClientCertificate(
 	}
 
 	return func(info *dtlsconfig.CertificateRequestInfo) (*tls.Certificate, error) {
-		return getClientCertificate(&CertificateRequestInfo{AcceptableCAs: info.AcceptableCAs})
+		signatureSchemes := make([]tls.SignatureScheme, 0, len(info.SignatureSchemes))
+		for _, algorithm := range info.SignatureSchemes {
+			raw := algorithm.Marshal()
+			signatureSchemes = append(signatureSchemes, tls.SignatureScheme(uint16(raw[0])<<8|uint16(raw[1])))
+		}
+
+		return getClientCertificate(&CertificateRequestInfo{
+			AcceptableCAs:    info.AcceptableCAs,
+			SignatureSchemes: signatureSchemes,
+		})
 	}
 }
 

--- a/flight_test.go
+++ b/flight_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"crypto"
 	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -540,6 +542,66 @@ func testHandshakeConfig13(t *testing.T) *dtlsconfig.HandshakeConfig {
 		LocalCertSignatureSchemes:   nil,
 		LocalSRTPProtectionProfiles: nil,
 	}
+}
+
+func TestFlight13_5GenerateSelectsClientCertificateBySignatureScheme(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaCertificate, err := selfsign.SelfSign(rsaKey)
+	require.NoError(t, err)
+	ecdsaCertificate, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	ecdsaSHA256 := signaturehash.Algorithm{
+		Hash:      dtlshash.SHA256,
+		Signature: signature.ECDSA,
+	}
+	rawRequest, err := (&handshake.Handshake{
+		Message: &handshake.MessageCertificateRequest13{
+			CertificateRequestContext: []byte("request"),
+			Extensions: []extension.Extension{
+				&extension.SupportedSignatureAlgorithms{
+					SignatureHashAlgorithms: []signaturehash.Algorithm{ecdsaSHA256},
+				},
+			},
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	cache := dtlsflight.NewCache()
+	cache.Push(
+		rawRequest,
+		dtlsflight13.EpochHandshake,
+		0,
+		handshake.TypeCertificateRequest,
+		false,
+	)
+	cfg := testHandshakeConfig13(t)
+	cfg.LocalCertificates = []tls.Certificate{rsaCertificate, ecdsaCertificate}
+
+	packets, dtlsAlert, err := flight13GenerateForTest(t, Flight5, &handshakeTestContext13{
+		state: newTestState13(true),
+		cache: cache,
+		cfg:   cfg,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	require.Len(t, packets, 3)
+
+	certificateHandshake, ok := packets[0].Record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	certificateMessage, ok := certificateHandshake.Message.(*handshake.MessageCertificate13)
+	require.True(t, ok)
+	require.Len(t, certificateMessage.CertificateList, 1)
+	assert.Equal(t, ecdsaCertificate.Certificate[0], certificateMessage.CertificateList[0].CertificateData)
+
+	verifyHandshake, ok := packets[1].Record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	verifyMessage, ok := verifyHandshake.Message.(*handshake.MessageCertificateVerify)
+	require.True(t, ok)
+	assert.Equal(t, ecdsaSHA256.Hash, verifyMessage.HashAlgorithm)
+	assert.Equal(t, ecdsaSHA256.Signature, verifyMessage.SignatureAlgorithm)
+	assert.Same(t, ecdsaCertificate.PrivateKey, packets[1].CertificateVerifySigner)
 }
 
 type rawExtension struct {

--- a/internal/config/handshake.go
+++ b/internal/config/handshake.go
@@ -56,11 +56,21 @@ type ClientHelloInfo struct {
 }
 
 type CertificateRequestInfo struct {
-	AcceptableCAs [][]byte
+	AcceptableCAs    [][]byte
+	SignatureSchemes []signaturehash.Algorithm
 }
 
-func (cri *CertificateRequestInfo) SupportsCertificate(c *tls.Certificate) error {
-	return SupportsCertificate(cri.AcceptableCAs, c)
+func (cri *CertificateRequestInfo) SupportsCertificate(certificate *tls.Certificate) error {
+	if len(cri.SignatureSchemes) > 0 {
+		if _, err := signaturehash.SelectSignatureScheme13(
+			cri.SignatureSchemes,
+			certificate.PrivateKey,
+		); err != nil {
+			return err
+		}
+	}
+
+	return SupportsCertificate(cri.AcceptableCAs, certificate)
 }
 
 func SupportsCertificate(acceptableCAs [][]byte, c *tls.Certificate) error {

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -916,7 +916,9 @@ func flight5ClientCertificate(
 	cfg *dtlsconfig.HandshakeConfig,
 	request *handshake.MessageCertificateRequest13,
 ) (*tls.Certificate, error) {
-	requestInfo := &dtlsconfig.CertificateRequestInfo{}
+	requestInfo := &dtlsconfig.CertificateRequestInfo{
+		SignatureSchemes: certificateRequestSignatureSchemes(request),
+	}
 	for _, ext := range request.Extensions {
 		if authorities, ok := ext.(*extension.CertificateAuthorities); ok {
 			requestInfo.AcceptableCAs = authorities.Authorities


### PR DESCRIPTION
#### Description
consider requested signature schemes with acceptable CAs before choosing a certificate, and validate signer compatiblity.

part of #827 refs #727 