### PR TITLE
Move fragment buffer to internal

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -23,6 +23,7 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight12 "github.com/pion/dtls/v3/internal/flight/flight12"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
+	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
@@ -190,11 +191,11 @@ type connSessionCallbacks struct {
 
 // Conn represents a DTLS connection.
 type Conn struct {
-	lock           sync.RWMutex      // Internal lock (must not be public)
-	nextConn       netctx.PacketConn // Embedded Conn, typically a udpconn we read/write from
-	fragmentBuffer *fragmentBuffer   // out-of-order and missing fragment handling
-	handshakeCache *dtlsflight.Cache // caching of handshake messages for verifyData generation
-	decrypted      chan any          // Decrypted Application Data or error, pull by calling `Read`
+	lock           sync.RWMutex                       // Internal lock (must not be public)
+	nextConn       netctx.PacketConn                  // Embedded Conn, typically a udpconn we read/write from
+	fragmentBuffer *dtlsfragmentbuffer.FragmentBuffer // out-of-order and missing fragment handling
+	handshakeCache *dtlsflight.Cache                  // caching of handshake messages for verifyData generation
+	decrypted      chan any                           // Decrypted Application Data or error, pull by calling `Read`
 	rAddr          net.Addr
 	state          dtlsstate.Active // active DTLS version state
 
@@ -577,7 +578,7 @@ func newConn(
 		rAddr:                   rAddr,
 		nextConn:                netctx.NewPacketConn(nextConn),
 		handshakeConfig:         handshakeConfig,
-		fragmentBuffer:          newFragmentBuffer(),
+		fragmentBuffer:          dtlsfragmentbuffer.New(),
 		handshakeCache:          dtlsflight.NewCache(),
 		maximumTransmissionUnit: configValues.maximumTransmissionUnit,
 		paddingLengthGenerator:  configValues.paddingLengthGenerator,
@@ -2090,7 +2091,7 @@ func (c *Conn) handleIncomingPacket(
 	markPacketAsValid := prepared.markPacketAsValid
 
 	c.syncFragmentBufferHandshakeSequence()
-	isHandshake, isRetransmit, err := c.fragmentBuffer.push(append([]byte{}, buf...))
+	isHandshake, isRetransmit, err := c.fragmentBuffer.Push(append([]byte{}, buf...))
 	if err != nil {
 		// Decode error must be silently discarded
 		// [RFC6347 Section-4.1.2.7]
@@ -2100,7 +2101,7 @@ func (c *Conn) handleIncomingPacket(
 	} else if isHandshake {
 		markPacketAsValid()
 
-		for out, epoch := c.fragmentBuffer.pop(); out != nil; out, epoch = c.fragmentBuffer.pop() {
+		for out, epoch := c.fragmentBuffer.Pop(); out != nil; out, epoch = c.fragmentBuffer.Pop() {
 			header := &handshake.Header{}
 			if err := header.Unmarshal(out); err != nil {
 				c.log.Debugf("%s: handshake parse failed: %s", srvCliStr(dtlsstate.CommonState(c.state).IsClient), err)
@@ -2191,7 +2192,7 @@ func (c *Conn) syncFragmentBufferHandshakeSequence() {
 		return
 	}
 
-	c.fragmentBuffer.advanceTo(uint16(handshakeRecvSequence))
+	c.fragmentBuffer.AdvanceTo(uint16(handshakeRecvSequence))
 }
 
 func (c *Conn) handshakeRecvSequence() int {

--- a/conn_test.go
+++ b/conn_test.go
@@ -29,6 +29,7 @@ import (
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
+	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/hash"
@@ -3489,7 +3490,7 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 func TestHandleIncomingPacket13QueuesHandshakeEpochBeforeProtection(t *testing.T) {
 	commonState := &dtlsstate.Common{IsClient: true, LocalVersion: protocol.Version1_3}
 	conn := &Conn{
-		fragmentBuffer:         newFragmentBuffer(),
+		fragmentBuffer:         dtlsfragmentbuffer.New(),
 		handshakeCache:         dtlsflight.NewCache(),
 		log:                    logging.NewDefaultLoggerFactory().NewLogger("dtls"),
 		replayProtectionWindow: defaultReplayProtectionWindow,
@@ -3613,20 +3614,20 @@ func TestOnConnectionAttempt(t *testing.T) {
 }
 
 func TestFragmentBuffer_Retransmission(t *testing.T) {
-	fragmentBuffer := newFragmentBuffer()
+	fragmentBuffer := dtlsfragmentbuffer.New()
 	frag := []byte{
 		0x16, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x30, 0x03, 0x00,
 		0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xfe, 0xff, 0x01, 0x01,
 	}
 
-	_, isRetransmission, err := fragmentBuffer.push(frag)
+	_, isRetransmission, err := fragmentBuffer.Push(frag)
 	assert.NoError(t, err)
 	assert.False(t, isRetransmission)
 
-	v, _ := fragmentBuffer.pop()
+	v, _ := fragmentBuffer.Pop()
 	assert.NotNil(t, v)
 
-	_, isRetransmission, err = fragmentBuffer.push(frag)
+	_, isRetransmission, err = fragmentBuffer.Push(frag)
 	assert.NoError(t, err)
 	assert.True(t, isRetransmission)
 }
@@ -4263,7 +4264,7 @@ func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuite
 	}
 
 	conn := &Conn{
-		fragmentBuffer:          newFragmentBuffer(),
+		fragmentBuffer:          dtlsfragmentbuffer.New(),
 		handshakeCache:          dtlsflight.NewCache(),
 		maximumTransmissionUnit: defaultMTU,
 		replayProtectionWindow:  defaultReplayProtectionWindow,

--- a/flight_test.go
+++ b/flight_test.go
@@ -22,6 +22,7 @@ import (
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
+	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
@@ -1376,7 +1377,7 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 	cache := dtlsflight.NewCache()
 	commonState := &dtlsstate.Common{IsClient: true, LocalVersion: protocol.Version1_3}
 	conn := &Conn{
-		fragmentBuffer:          newFragmentBuffer(),
+		fragmentBuffer:          dtlsfragmentbuffer.New(),
 		handshakeCache:          cache,
 		maximumTransmissionUnit: defaultMTU,
 		replayProtectionWindow:  defaultReplayProtectionWindow,

--- a/internal/fragmentbuffer/fragment_buffer.go
+++ b/internal/fragmentbuffer/fragment_buffer.go
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package dtls
+// Package fragmentbuffer reassembles fragmented DTLS handshake messages.
+package fragmentbuffer
 
 import (
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -28,7 +29,8 @@ type fragments struct {
 	handshakeLength  uint32
 }
 
-type fragmentBuffer struct {
+// FragmentBuffer stores and reassembles fragmented DTLS handshake messages.
+type FragmentBuffer struct {
 	// map of MessageSequenceNumbers that hold slices of fragments
 	cache map[uint16]*fragments
 
@@ -38,16 +40,18 @@ type fragmentBuffer struct {
 	totalFragmentCount int
 }
 
-func newFragmentBuffer() *fragmentBuffer {
-	return &fragmentBuffer{cache: map[uint16]*fragments{}}
+// New creates an empty FragmentBuffer.
+func New() *FragmentBuffer {
+	return &FragmentBuffer{cache: map[uint16]*fragments{}}
 }
 
 // current total size of buffer.
-func (f *fragmentBuffer) size() int {
+func (f *FragmentBuffer) size() int {
 	return f.totalBufferSize
 }
 
-func (f *fragmentBuffer) advanceTo(messageSequence uint16) {
+// AdvanceTo discards fragments for message sequences before messageSequence.
+func (f *FragmentBuffer) AdvanceTo(messageSequence uint16) {
 	if messageSequence <= f.currentMessageSequenceNumber {
 		return
 	}
@@ -64,10 +68,10 @@ func (f *fragmentBuffer) advanceTo(messageSequence uint16) {
 	f.currentMessageSequenceNumber = messageSequence
 }
 
-// Attempts to push a DTLS packet to the fragmentBuffer
+// Push attempts to add a DTLS packet to the fragment buffer.
 // when it returns true it means the fragmentBuffer has inserted and the buffer shouldn't be handled
 // when an error returns it is fatal, and the DTLS connection should be stopped.
-func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err error) { //nolint:cyclop
+func (f *FragmentBuffer) Push(buf []byte) (isHandshake, isRetransmit bool, err error) {
 	if f.size()+len(buf) >= fragmentBufferMaxSize || f.totalFragmentCount >= fragmentBufferMaxCount {
 		return false, false, dtlserrors.ErrFragmentBufferOverflow
 	}
@@ -82,8 +86,20 @@ func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err e
 		return false, false, nil
 	}
 
-	frag := new(fragment)
-	for buf = buf[recordlayer.FixedHeaderSize:]; len(buf) != 0; frag = new(fragment) { //nolint:gosec // G602
+	headerSize := recordLayerHeader.Size()
+	if len(buf) < headerSize {
+		return false, false, dtlserrors.ErrBufferTooSmall
+	}
+
+	return f.pushHandshakeFragments(recordLayerHeader, buf[headerSize:])
+}
+
+func (f *FragmentBuffer) pushHandshakeFragments(
+	recordLayerHeader recordlayer.Header,
+	buf []byte,
+) (isHandshake, isRetransmit bool, err error) {
+	for len(buf) != 0 {
+		frag := new(fragment)
 		if err := frag.handshakeHeader.Unmarshal(buf); err != nil {
 			return false, false, err
 		}
@@ -126,7 +142,8 @@ func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err e
 	return true, isRetransmit, nil
 }
 
-func (f *fragmentBuffer) pop() (content []byte, epoch uint16) {
+// Pop returns the next complete handshake message and its record epoch.
+func (f *FragmentBuffer) Pop() (content []byte, epoch uint16) {
 	frags, ok := f.cache[f.currentMessageSequenceNumber]
 	if !ok {
 		return nil, 0

--- a/internal/fragmentbuffer/fragment_buffer_test.go
+++ b/internal/fragmentbuffer/fragment_buffer_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package dtls
+package fragmentbuffer
 
 import (
 	"testing"
@@ -139,29 +139,29 @@ func TestFragmentBuffer(t *testing.T) {
 			Epoch:    0,
 		},
 	} {
-		fragmentBuffer := newFragmentBuffer()
+		fragmentBuffer := New()
 		for _, frag := range test.In {
-			status, _, err := fragmentBuffer.push(frag)
+			status, _, err := fragmentBuffer.Push(frag)
 			assert.NoError(t, err)
 			assert.Truef(t, status, "fragmentBuffer didn't accept fragments for '%s'", test.Name)
 		}
 
 		for _, expected := range test.Expected {
-			out, epoch := fragmentBuffer.pop()
+			out, epoch := fragmentBuffer.Pop()
 			assert.Equalf(t, expected, out, "fragmentBuffer '%s' pop should return expected output", test.Name)
 			assert.Equalf(t, test.Epoch, epoch, "fragmentBuffer returend wrong epoch")
 		}
 
-		frag, _ := fragmentBuffer.pop()
+		frag, _ := fragmentBuffer.Pop()
 		assert.Nilf(t, frag, "fragmentBuffer '%s' pop should return nil when no more fragments are available", test.Name)
 	}
 }
 
 func TestFragmentBuffer_Overflow(t *testing.T) {
-	fragmentBuffer := newFragmentBuffer()
+	fragmentBuffer := New()
 
 	// Push a buffer that doesn't exceed size limits
-	_, _, err := fragmentBuffer.push([]byte{
+	_, _, err := fragmentBuffer.Push([]byte{
 		0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x03,
 		0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xfe, 0xff, 0x00,
 	})
@@ -169,15 +169,15 @@ func TestFragmentBuffer_Overflow(t *testing.T) {
 
 	// Allocate a buffer that exceeds cache size
 	largeBuffer := make([]byte, fragmentBufferMaxSize)
-	_, _, err = fragmentBuffer.push(largeBuffer)
+	_, _, err = fragmentBuffer.Push(largeBuffer)
 	assert.ErrorIs(t, err, dtlserrors.ErrFragmentBufferOverflow, "Pushing a large buffer should return an overflow error")
 }
 
 func TestFragmentBuffer_TooSmall(t *testing.T) {
-	fragmentBuffer := newFragmentBuffer()
+	fragmentBuffer := New()
 
 	// Push a buffer that is smaller than fragment length
-	_, _, err := fragmentBuffer.push([]byte{
+	_, _, err := fragmentBuffer.Push([]byte{
 		0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x03,
 		0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xfe, 0xff, 0x00,
 	})
@@ -186,16 +186,16 @@ func TestFragmentBuffer_TooSmall(t *testing.T) {
 }
 
 func TestFragmentBuffer_UnmarshalInvalid(t *testing.T) {
-	fragmentBuffer := newFragmentBuffer()
+	fragmentBuffer := New()
 
 	// Push a buffer with partial record layer header
-	_, _, err := fragmentBuffer.push([]byte{
+	_, _, err := fragmentBuffer.Push([]byte{
 		0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	})
 	assert.Error(t, err, "Pushing a buffer with partial record layer header should return an error")
 
 	// Push a buffer with partial handshake header
-	_, _, err = fragmentBuffer.push([]byte{
+	_, _, err = fragmentBuffer.Push([]byte{
 		0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x03,
 	})
 	assert.Error(t, err, "Pushing a buffer with partial handshake header should return an error")


### PR DESCRIPTION
#### Description
there is no reason for fragment_buffer.go to exist in /. this also does a small refactor to remove some of the nolints.