### PR TITLE
Move crypto test to internal/handshakecrypto

### DIFF
--- a/internal/handshakecrypto/crypto_test.go
+++ b/internal/handshakecrypto/crypto_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package dtls
+package handshakecrypto_test
 
 import (
 	"crypto/rand"


### PR DESCRIPTION
#### Description
move crypt_test.go from / to internal/handshakecrypto since the code itself is now in internal.