### PR TITLE
Fix queued 1.3 packets read race

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -75,6 +75,31 @@ type addrPkt struct {
 	data  []byte
 }
 
+// packetQueueWriter owns a recyclable read buffer until a queued packet view
+// takes responsibility for keeping its backing array alive.
+type packetQueueWriter struct {
+	conn                 *Conn
+	recyclableReadBuffer *[]byte
+}
+
+func (w *packetQueueWriter) enqueue(packet addrPkt) bool {
+	if !w.conn.enqueueEncryptedPackets(packet) {
+		return false
+	}
+
+	w.recyclableReadBuffer = nil
+
+	return true
+}
+
+func (w *packetQueueWriter) releaseReadBuffer() {
+	readBuffer := w.recyclableReadBuffer
+	w.recyclableReadBuffer = nil
+	if readBuffer != nil {
+		poolReadBuffer.Put(readBuffer)
+	}
+}
+
 type incomingPacketState struct {
 	buf               []byte
 	header            *recordlayer.Header
@@ -749,7 +774,7 @@ func (c *Conn) prepareDualStackClientHandshakeStart(ctx context.Context) (handsh
 		fsmState: handshakeWaiting,
 		flights:  initialFlights,
 		postSetup: func(ctx context.Context) {
-			go c.primeHandshakeRecv(ctx)
+			c.primeHandshakeRecv(ctx)
 		},
 	}, nil
 }
@@ -1459,7 +1484,8 @@ func (c *Conn) readAndBuffer(ctx context.Context) error { //nolint:cyclop,gocogn
 	if !ok {
 		return dtlserrors.ErrFailedToAccessPoolReadBuffer
 	}
-	defer poolReadBuffer.Put(bufptr)
+	queueWriter := packetQueueWriter{conn: c, recyclableReadBuffer: bufptr}
+	defer queueWriter.releaseReadBuffer()
 
 	b := *bufptr
 	i, rAddr, err := c.nextConn.ReadFromContext(ctx, b)
@@ -1474,9 +1500,7 @@ func (c *Conn) readAndBuffer(ctx context.Context) error { //nolint:cyclop,gocogn
 
 	var hasHandshake, isRetransmit bool
 	for _, p := range pkts {
-		//nolint:godox
-		// TODO: check version
-		hs, rtx, alert, err := c.handleIncomingPacket(ctx, p, rAddr, true)
+		hs, rtx, alert, err := c.handleIncomingPacket(ctx, p, rAddr, &queueWriter)
 		if alert != nil {
 			if alertErr := c.notify(ctx, alert.Level, alert.Description); alertErr != nil {
 				if err == nil {
@@ -1499,6 +1523,7 @@ func (c *Conn) readAndBuffer(ctx context.Context) error { //nolint:cyclop,gocogn
 			isRetransmit = true
 		}
 	}
+	queueWriter.releaseReadBuffer()
 	if hasHandshake {
 		s := dtlshandshake.RecvHandshakeState{
 			Done:         make(chan struct{}),
@@ -1523,9 +1548,7 @@ func (c *Conn) handleQueuedPackets(ctx context.Context) error {
 	c.lock.Unlock()
 
 	for _, p := range pkts {
-		//nolint:godox
-		// TODO: check version
-		_, _, alert, err := c.handleIncomingPacket(ctx, p.data, p.rAddr, false) // don't re-enqueue
+		_, _, alert, err := c.handleIncomingPacket(ctx, p.data, p.rAddr, nil) // don't re-enqueue
 		if alert != nil {
 			if alertErr := c.notify(ctx, alert.Level, alert.Description); alertErr != nil {
 				if err == nil {
@@ -1549,13 +1572,16 @@ func (c *Conn) enqueueEncryptedPackets(packet addrPkt) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if len(c.encryptedPackets) < maxAppDataPacketQueueSize {
-		c.encryptedPackets = append(c.encryptedPackets, packet)
-
-		return true
+	if len(c.encryptedPackets) >= maxAppDataPacketQueueSize {
+		return false
 	}
 
-	return false
+	// Prevent an append by a queue consumer from overwriting an adjacent record
+	// that shares the same datagram backing array.
+	packet.data = packet.data[:len(packet.data):len(packet.data)]
+	c.encryptedPackets = append(c.encryptedPackets, packet)
+
+	return true
 }
 
 func (c *Conn) maxQueueableFutureEpoch(remoteEpoch uint16) uint16 {
@@ -1740,19 +1766,19 @@ func marshalInnerPlaintextRecord(
 func (c *Conn) prepareIncomingPacket(
 	buf []byte,
 	rAddr net.Addr,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) (incomingPacketState, bool) {
 	if protocol.IsDTLS13Ciphertext(protocol.ContentType(buf[0])) {
-		return c.prepareCiphertextPacket(buf, rAddr, enqueue)
+		return c.prepareCiphertextPacket(buf, rAddr, queueWriter)
 	}
 
-	return c.prepareLegacyPacket(buf, rAddr, enqueue)
+	return c.prepareLegacyPacket(buf, rAddr, queueWriter)
 }
 
 func (c *Conn) prepareCiphertextPacket(
 	buf []byte,
 	rAddr net.Addr,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) (incomingPacketState, bool) {
 	ciphertext, err := c.unmarshalCiphertextRecord(buf)
 	if err != nil {
@@ -1763,12 +1789,17 @@ func (c *Conn) prepareCiphertextPacket(
 
 	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
 	if ciphertext.Header.EpochLow != uint8(remoteEpoch&recordlayer.TwoLowBitsMask) {
-		c.handleFutureCiphertextPacket(ciphertext.Header.EpochLow, remoteEpoch, rAddr, buf, enqueue)
+		c.handleFutureCiphertextPacket(ciphertext.Header.EpochLow, remoteEpoch, rAddr, buf, queueWriter)
 
 		return incomingPacketState{}, false
 	}
 
-	if c.queueIfCipherSuiteUninitialized(rAddr, buf, enqueue, "handshake not finished, queuing ciphertext packet") {
+	if c.queueIfCipherSuiteUninitialized(
+		rAddr,
+		buf,
+		queueWriter,
+		"handshake not finished, queuing ciphertext packet",
+	) {
 		return incomingPacketState{}, false
 	}
 
@@ -1823,15 +1854,15 @@ func (c *Conn) handleFutureCiphertextPacket(
 	remoteEpoch uint16,
 	rAddr net.Addr,
 	buf []byte,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) {
 	if !c.queueableCiphertextEpoch(epochLow, remoteEpoch) {
 		c.log.Debugf("discarded future ciphertext packet (epoch low: %d)", epochLow)
 
 		return
 	}
-	if enqueue {
-		if ok := c.enqueueEncryptedPackets(addrPkt{rAddr, buf}); ok {
+	if queueWriter != nil {
+		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug("received ciphertext packet of next epoch, queuing packet")
 		}
 	}
@@ -1864,15 +1895,15 @@ func (c *Conn) protectedReplayMarker(epoch uint16, sequenceNumber uint64) (func(
 func (c *Conn) queueIfCipherSuiteUninitialized(
 	rAddr net.Addr,
 	buf []byte,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 	message string,
 ) bool {
 	common := dtlsstate.CommonState(c.state)
 	if common.CipherSuite != nil && common.CipherSuite.IsInitialized() {
 		return false
 	}
-	if enqueue {
-		if ok := c.enqueueEncryptedPackets(addrPkt{rAddr, buf}); ok {
+	if queueWriter != nil {
+		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug(message)
 		}
 	}
@@ -1883,13 +1914,13 @@ func (c *Conn) queueIfCipherSuiteUninitialized(
 func (c *Conn) prepareLegacyPacket(
 	buf []byte,
 	rAddr net.Addr,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) (incomingPacketState, bool) {
 	header, ok := c.unmarshalLegacyHeader(buf)
 	if !ok {
 		return incomingPacketState{}, false
 	}
-	if c.handleFutureLegacyPacket(header, rAddr, buf, enqueue) {
+	if c.handleFutureLegacyPacket(header, rAddr, buf, queueWriter) {
 		return incomingPacketState{}, false
 	}
 
@@ -1901,7 +1932,7 @@ func (c *Conn) prepareLegacyPacket(
 	originalCID := false
 	if header.Epoch != 0 {
 		var decryptOK bool
-		buf, originalCID, decryptOK = c.decryptLegacyPacket(header, buf, rAddr, enqueue)
+		buf, originalCID, decryptOK = c.decryptLegacyPacket(header, buf, rAddr, queueWriter)
 		if !decryptOK {
 			return incomingPacketState{}, false
 		}
@@ -1938,7 +1969,7 @@ func (c *Conn) handleFutureLegacyPacket(
 	header *recordlayer.Header,
 	rAddr net.Addr,
 	buf []byte,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) bool {
 	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
 	if header.Epoch <= remoteEpoch {
@@ -1951,8 +1982,8 @@ func (c *Conn) handleFutureLegacyPacket(
 
 		return true
 	}
-	if enqueue {
-		if ok := c.enqueueEncryptedPackets(addrPkt{rAddr, buf}); ok {
+	if queueWriter != nil {
+		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug("received packet of next epoch, queuing packet")
 		}
 	}
@@ -1983,9 +2014,14 @@ func (c *Conn) decryptLegacyPacket(
 	header *recordlayer.Header,
 	buf []byte,
 	rAddr net.Addr,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) ([]byte, bool, bool) {
-	if c.queueIfCipherSuiteUninitialized(rAddr, buf, enqueue, "handshake not finished, queuing packet") {
+	if c.queueIfCipherSuiteUninitialized(
+		rAddr,
+		buf,
+		queueWriter,
+		"handshake not finished, queuing packet",
+	) {
 		return nil, false, false
 	}
 
@@ -2076,13 +2112,13 @@ func (c *Conn) handleIncomingPacket(
 	ctx context.Context,
 	buf []byte,
 	rAddr net.Addr,
-	enqueue bool,
+	queueWriter *packetQueueWriter,
 ) (bool, bool, *alert.Alert, error) {
 	if len(buf) == 0 {
 		return false, false, nil, nil
 	}
 
-	prepared, ok := c.prepareIncomingPacket(buf, rAddr, enqueue)
+	prepared, ok := c.prepareIncomingPacket(buf, rAddr, queueWriter)
 	if !ok {
 		return false, false, nil, nil
 	}
@@ -2134,8 +2170,8 @@ func (c *Conn) handleIncomingPacket(
 	case *protocol.ChangeCipherSpec:
 		common := dtlsstate.CommonState(c.state)
 		if common.CipherSuite == nil || !common.CipherSuite.IsInitialized() {
-			if enqueue {
-				if ok := c.enqueueEncryptedPackets(addrPkt{rAddr, buf}); ok {
+			if queueWriter != nil {
+				if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 					c.log.Debugf("CipherSuite not initialized, queuing packet")
 				}
 			}
@@ -2488,7 +2524,8 @@ func (c *Conn) readAndBufferNoFSM(ctx context.Context) error { //nolint:cyclop
 	if !ok {
 		return dtlserrors.ErrFailedToAccessPoolReadBuffer
 	}
-	defer poolReadBuffer.Put(bufptr)
+	queueWriter := packetQueueWriter{conn: c, recyclableReadBuffer: bufptr}
+	defer queueWriter.releaseReadBuffer()
 
 	b := *bufptr
 	i, rAddr, err := c.nextConn.ReadFromContext(ctx, b)
@@ -2502,9 +2539,7 @@ func (c *Conn) readAndBufferNoFSM(ctx context.Context) error { //nolint:cyclop
 	}
 
 	for _, p := range pkts {
-		// nolint:godox
-		// TODO: check version
-		_, _, alert, err := c.handleIncomingPacket(ctx, p, rAddr, true)
+		_, _, alert, err := c.handleIncomingPacket(ctx, p, rAddr, &queueWriter)
 		if alert != nil {
 			if alertErr := c.notify(ctx, alert.Level, alert.Description); alertErr != nil {
 				if err == nil {
@@ -2564,10 +2599,6 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 		}
 	}()
 
-	if start.postSetup != nil {
-		start.postSetup(ctxHs)
-	}
-
 	go func() {
 		defer func() {
 			if c.isHandshakeCompletedSuccessfully() {
@@ -2580,6 +2611,9 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 			cancel()
 		}()
 		defer handshakeLoopsFinished.Done()
+		if start.postSetup != nil {
+			start.postSetup(ctxHs)
+		}
 		for {
 			if err := c.readAndBuffer(ctxRead); err != nil { //nolint:nestif
 				var alertErr *alertError

--- a/conn_test.go
+++ b/conn_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/dpipe"
+	"github.com/pion/transport/v4/netctx"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3487,6 +3488,65 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 	<-done
 }
 
+func TestPacketQueueWriterRetiresReadBufferOnlyWhenQueued(t *testing.T) {
+	readBuffer := []byte{1, 2, 3}
+	conn := &Conn{}
+	writer := packetQueueWriter{conn: conn, recyclableReadBuffer: &readBuffer}
+
+	require.True(t, writer.enqueue(addrPkt{data: readBuffer}))
+	assert.Nil(t, writer.recyclableReadBuffer)
+	require.Len(t, conn.encryptedPackets, 1)
+	assert.Same(t, &readBuffer[0], &conn.encryptedPackets[0].data[0])
+	assert.Equal(t, len(conn.encryptedPackets[0].data), cap(conn.encryptedPackets[0].data))
+
+	rejectedReadBuffer := []byte{4, 5, 6}
+	fullConn := &Conn{encryptedPackets: make([]addrPkt, maxAppDataPacketQueueSize)}
+	rejectedWriter := packetQueueWriter{conn: fullConn, recyclableReadBuffer: &rejectedReadBuffer}
+	assert.False(t, rejectedWriter.enqueue(addrPkt{data: rejectedReadBuffer}))
+	assert.Same(t, &rejectedReadBuffer, rejectedWriter.recyclableReadBuffer)
+}
+
+func TestReadAndBufferNoFSMQueuesWithoutCopy(t *testing.T) {
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		assert.NoError(t, ca.Close())
+		assert.NoError(t, cb.Close())
+	}()
+
+	conn := &Conn{
+		nextConn:       netctx.NewPacketConn(dtlsnet.PacketConnFromConn(cb)),
+		fragmentBuffer: dtlsfragmentbuffer.New(),
+		handshakeCache: dtlsflight.NewCache(),
+		log:            logging.NewDefaultLoggerFactory().NewLogger("dtls"),
+		state: &dtlsstate.State13{Common: &dtlsstate.Common{
+			LocalVersion: protocol.Version1_3,
+		}},
+	}
+	rawPacket, err := (&recordlayer.RecordLayer{
+		Header: recordlayer.Header{
+			Version: protocol.Version1_2,
+			Epoch:   dtlsflight13.EpochHandshake,
+		},
+		Content: &handshake.Handshake{
+			Header:  handshake.Header{MessageSequence: 1},
+			Message: &handshake.MessageEncryptedExtensions{},
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	writeResult := make(chan error, 1)
+	go func() {
+		_, writeErr := ca.Write(rawPacket)
+		writeResult <- writeErr
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, conn.readAndBufferNoFSM(ctx))
+	require.NoError(t, <-writeResult)
+	require.Len(t, conn.encryptedPackets, 1)
+	assert.Equal(t, rawPacket, conn.encryptedPackets[0].data)
+}
+
 func TestHandleIncomingPacket13QueuesHandshakeEpochBeforeProtection(t *testing.T) {
 	commonState := &dtlsstate.Common{IsClient: true, LocalVersion: protocol.Version1_3}
 	conn := &Conn{
@@ -3512,16 +3572,18 @@ func TestHandleIncomingPacket13QueuesHandshakeEpochBeforeProtection(t *testing.T
 	}).Marshal()
 	assert.NoError(t, err)
 
+	queueWriter := &packetQueueWriter{conn: conn, recyclableReadBuffer: &rawPacket}
 	isHandshake, isRetransmit, dtlsAlert, err := conn.handleIncomingPacket(
 		context.Background(),
 		rawPacket,
 		nil,
-		true,
+		queueWriter,
 	)
 	assert.NoError(t, err)
 	assert.Nil(t, dtlsAlert)
 	assert.False(t, isHandshake)
 	assert.False(t, isRetransmit)
+	assert.Nil(t, queueWriter.recyclableReadBuffer)
 	assert.Len(t, conn.encryptedPackets, 1)
 	assert.Equal(t, rawPacket, conn.encryptedPackets[0].data)
 }
@@ -3902,6 +3964,59 @@ func TestDTLS13RetransmittedClientFinalFlight(t *testing.T) {
 	assert.Equal(t, payload, buf)
 }
 
+func TestHandshakeCancellationWhilePostSetupBlocks(t *testing.T) {
+	defer test.CheckRoutines(t)()
+
+	ca, cb := dpipe.Pipe()
+	defer func() {
+		_ = ca.Close()
+		_ = cb.Close()
+	}()
+
+	clientCert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+	client, err := ClientWithOptions(
+		dtlsnet.PacketConnFromConn(ca),
+		ca.RemoteAddr(),
+		WithCertificates(clientCert),
+		WithInsecureSkipVerify(true),
+		WithMinVersion(protocol.Version1_3),
+		WithMaxVersion(protocol.Version1_3),
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	postSetupStarted := make(chan struct{})
+	start := client.prepareHandshakeStart13()
+	start.fsmState = handshakeWaiting
+	start.postSetup = func(ctx context.Context) {
+		close(postSetupStarted)
+		<-ctx.Done()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- client.handshake(ctx, start)
+	}()
+
+	select {
+	case <-postSetupStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "post-setup hook did not start")
+	}
+	cancel()
+
+	select {
+	case err = <-result:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		require.FailNow(t, "handshake did not observe context cancellation")
+	}
+}
+
 // WIP! Tests if the dual stack mode client managed to negotiate a version successfully.
 func TestDTLSDualStackClient(t *testing.T) {
 	defer test.CheckRoutines(t)()
@@ -4184,7 +4299,10 @@ func TestDTLS13DecryptedEncryptedExtensionsIsCached(t *testing.T) {
 	rawPacket, err := record.Marshal()
 	assert.NoError(t, err)
 
-	isHandshake, isRetransmit, dtlsAlert, err := conn.handleIncomingPacket(context.Background(), rawPacket, nil, true)
+	queueWriter := &packetQueueWriter{conn: conn}
+	isHandshake, isRetransmit, dtlsAlert, err := conn.handleIncomingPacket(
+		context.Background(), rawPacket, nil, queueWriter,
+	)
 	assert.NoError(t, err)
 	assert.Nil(t, dtlsAlert)
 	assert.True(t, isHandshake)
@@ -4211,7 +4329,7 @@ func TestDTLS13ProtectedHandshakeRecordKeepsEpochAndSequence(t *testing.T) {
 	rawPacket, err := record.Marshal()
 	assert.NoError(t, err)
 
-	prepared, ok := conn.prepareIncomingPacket(rawPacket, nil, true)
+	prepared, ok := conn.prepareIncomingPacket(rawPacket, nil, &packetQueueWriter{conn: conn})
 	assert.True(t, ok)
 	if assert.NotNil(t, prepared.header) {
 		assert.Equal(t, protocol.ContentTypeHandshake, prepared.header.ContentType)

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -77,6 +77,7 @@ type fsm13 struct {
 	cfg                *dtlsconfig.HandshakeConfig
 	transcript         *Transcript
 	closed             chan struct{}
+	pendingRecvDone    chan struct{} // keeps the reader paused across a prepare/send transition
 }
 
 func NewFSM13(
@@ -202,6 +203,8 @@ func canonicalClientHelloInitialFlight13(p *dtlsflight.Packet) (uint16, []byte, 
 }
 
 func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
+	defer s.releasePendingRecv()
+
 	return runHandshakeFSM(
 		ctx,
 		conn,
@@ -233,12 +236,17 @@ func (s *fsm13) Done() <-chan struct{} {
 	return s.closed
 }
 
-func (s *fsm13) prepare(ctx context.Context, conn Conn) (State, error) {
+func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err error) {
+	defer func() {
+		if err != nil {
+			s.releasePendingRecv()
+		}
+	}()
+
 	s.flights = nil
 	// Prepare flights
 	var (
 		dtlsAlert *alert.Alert
-		err       error
 		pkts      []*dtlsflight.Packet
 	)
 	gen, retransmit, ok := dtlsflight13.GetGenerator(s.currentFlight)
@@ -404,18 +412,24 @@ func (s *fsm13) populateOutboundFinished(p *dtlsflight.Packet) error {
 	return nil
 }
 
-func (s *fsm13) send(ctx context.Context, c Conn) (State, error) {
-	if err := c.WritePackets(ctx, s.flights); err != nil {
+func (s *fsm13) send(ctx context.Context, conn Conn) (State, error) {
+	defer s.releasePendingRecv()
+
+	if err := conn.WritePackets(ctx, s.flights); err != nil {
 		return StateErrored, err
 	}
-	if !s.state.IsClient && s.currentFlight == dtlsflight13.Flight4 {
+	if !s.state.IsClient &&
+		s.currentFlight == dtlsflight13.Flight4 &&
+		s.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake {
+		// Only the first send advances the epoch and drains packets. A timer
+		// retransmission has no receive-side rendezvous and the reader is active.
 		s.state.RemoteEpoch.Store(dtlsflight13.EpochHandshake)
-		if err := c.HandleQueuedPackets(ctx); err != nil {
+		if err := conn.HandleQueuedPackets(ctx); err != nil {
 			return StateErrored, err
 		}
 	}
 	if s.state.IsClient && s.currentFlight == dtlsflight13.Flight5 {
-		if err := s.activateApplicationRecordProtection(ctx, c); err != nil {
+		if err := s.activateApplicationRecordProtection(ctx, conn); err != nil {
 			return StateErrored, err
 		}
 
@@ -425,12 +439,30 @@ func (s *fsm13) send(ctx context.Context, c Conn) (State, error) {
 	return StateWaiting, nil
 }
 
+func (s *fsm13) transitionRequiresReaderPause(nextFlight dtlsflight13.Flight) bool {
+	if s.state.IsClient {
+		return nextFlight == dtlsflight13.Flight5
+	}
+
+	return nextFlight == dtlsflight13.Flight4 &&
+		s.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake
+}
+
 func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:gocognit,cyclop
+	retainPendingRecv := false
+	defer func() {
+		if !retainPendingRecv {
+			s.releasePendingRecv()
+		}
+	}()
+
 	retransmitTimer := time.NewTimer(s.retransmitInterval)
 	defer retransmitTimer.Stop()
 	for {
 		select {
 		case state := <-conn.RecvHandshake():
+			// Keep the reader paused while this receive state is parsed.
+			s.pendingRecvDone = state.Done
 			if !state.IsRetransmit {
 				s.retransmitInterval = s.cfg.InitialRetransmitInterval
 			}
@@ -459,7 +491,6 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				},
 				InitHandshakeRecordProtection,
 			)
-			close(state.Done)
 			if !ok {
 				if alertErr := conn.Notify(ctx, alert.Fatal, alert.InternalError); alertErr != nil {
 					return StateErrored, alertErr
@@ -478,6 +509,8 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				return StateErrored, err
 			}
 			if nextFlight == 0 {
+				s.releasePendingRecv()
+
 				break
 			}
 			if s.state.IsClient && nextFlight == dtlsflight13.Flight5 {
@@ -500,6 +533,7 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				s.currentFlight.String(),
 				nextFlight.String(),
 			)
+			retainPendingRecv = s.transitionRequiresReaderPause(nextFlight)
 			s.currentFlight = nextFlight
 
 			return StatePreparing, nil
@@ -523,6 +557,15 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 			return StateErrored, ctx.Err()
 		}
 	}
+}
+
+func (s *fsm13) releasePendingRecv() {
+	if s.pendingRecvDone == nil {
+		return
+	}
+
+	close(s.pendingRecvDone)
+	s.pendingRecvDone = nil
 }
 
 func (s *fsm13) finish(ctx context.Context, c Conn) (State, error) {

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -392,6 +392,135 @@ func TestHandshakeFSM13SendsFlight4ProtectedRecords(t *testing.T) {
 	assert.Equal(t, dtlsflight13.EpochHandshake, conn.localEpoch)
 }
 
+func TestHandshakeFSM13ServerFlight4KeepsReaderPausedThroughQueueDrain(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cfg.InsecureSkipHelloVerify = true
+	_, clientHello, _ := newFlight13ClientHelloFixture(t, cfg)
+	serverState := newTestState13(false)
+	cache := dtlsflight.NewCache()
+	fsm, err := newFSM13(serverState, cache, cfg, dtlsflight13.Flight0, nil, nil)
+	require.NoError(t, err)
+	conn := &flightTestConn{recvHandshake: make(chan RecvHandshakeState, 1)}
+
+	nextState, err := fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateSending, nextState)
+	nextState, err = fsm.send(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, nextState)
+
+	pushFlight13HandshakePacketsToCache(t, cache, clientHello, true)
+	recvState := RecvHandshakeState{Done: make(chan struct{})}
+	conn.recvHandshake <- recvState
+	nextState, err = fsm.wait(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StatePreparing, nextState)
+	require.Equal(t, dtlsflight13.Flight4, fsm.currentFlight)
+	assertFlight13RecvDoneOpen(t, recvState)
+
+	queueDrains := 0
+	conn.writePackets = func(context.Context, []*dtlsflight.Packet) error {
+		assertFlight13RecvDoneOpen(t, recvState)
+
+		return nil
+	}
+	conn.handleQueuedPackets = func(context.Context) error {
+		queueDrains++
+		assertFlight13RecvDoneOpen(t, recvState)
+
+		return nil
+	}
+	nextState, err = fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateSending, nextState)
+	assertFlight13RecvDoneOpen(t, recvState)
+	nextState, err = fsm.send(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, nextState)
+	assertFlight13RecvDoneClosed(t, recvState)
+	assert.Equal(t, 1, queueDrains)
+	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.GetRemoteEpoch())
+
+	conn.writePackets = nil
+	nextState, err = fsm.send(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, nextState)
+	assert.Equal(t, 1, queueDrains)
+	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.GetRemoteEpoch())
+}
+
+func TestHandshakeFSM13NonDrainingTransitionReleasesReaderAfterWait(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	cfg.InsecureSkipHelloVerify = false
+	_, clientHello, _ := newFlight13ClientHelloFixture(t, cfg)
+	serverState := newTestState13(false)
+	cache := dtlsflight.NewCache()
+	fsm, err := newFSM13(serverState, cache, cfg, dtlsflight13.Flight0, nil, nil)
+	require.NoError(t, err)
+	conn := &flightTestConn{recvHandshake: make(chan RecvHandshakeState, 1)}
+
+	nextState, err := fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateSending, nextState)
+	nextState, err = fsm.send(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateWaiting, nextState)
+
+	pushFlight13HandshakePacketsToCache(t, cache, clientHello, true)
+	recvState := RecvHandshakeState{Done: make(chan struct{})}
+	conn.recvHandshake <- recvState
+	nextState, err = fsm.wait(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StatePreparing, nextState)
+	require.Equal(t, dtlsflight13.Flight2, fsm.currentFlight)
+	assertFlight13RecvDoneClosed(t, recvState)
+}
+
+func TestHandshakeFSM13ReaderPauseRequiredOnlyForQueueDrainingTransitions(t *testing.T) {
+	tests := []struct {
+		name        string
+		isClient    bool
+		nextFlight  dtlsflight13.Flight
+		remoteEpoch uint16
+		expected    bool
+	}{
+		{
+			name:       "client hello retry",
+			isClient:   true,
+			nextFlight: dtlsflight13.Flight3,
+		},
+		{
+			name:       "client final flight",
+			isClient:   true,
+			nextFlight: dtlsflight13.Flight5,
+			expected:   true,
+		},
+		{
+			name:       "server hello retry",
+			nextFlight: dtlsflight13.Flight2,
+		},
+		{
+			name:       "server protected flight",
+			nextFlight: dtlsflight13.Flight4,
+			expected:   true,
+		},
+		{
+			name:        "server protected flight already activated",
+			nextFlight:  dtlsflight13.Flight4,
+			remoteEpoch: dtlsflight13.EpochHandshake,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := newTestState13(test.isClient)
+			state.RemoteEpoch.Store(test.remoteEpoch)
+			fsm := &fsm13{state: state}
+
+			assert.Equal(t, test.expected, fsm.transitionRequiresReaderPause(test.nextFlight))
+		})
+	}
+}
+
 func TestHandshakeFSM13ServerFlight4NoCertificateMVPGeneratesFinished(t *testing.T) {
 	fixture := newNoHRRFlight13Fixture(t)
 	require.Empty(t, fixture.cfg.LocalCertificates)
@@ -444,8 +573,27 @@ func TestHandshakeFSM13WaitParsesProtectedEncryptedExtensions(t *testing.T) {
 	assert.Equal(t, 3, fixture.clientState.HandshakeRecvSequence)
 	assert.True(t, fixture.clientState.CipherSuite.IsInitialized())
 	assert.Equal(t, dtlsflight13.EpochHandshake, fixture.clientState.GetRemoteEpoch())
-	assertFlight13RecvDoneClosed(t, recvState)
+	assertFlight13RecvDoneOpen(t, recvState)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
+
+	conn.writePackets = func(context.Context, []*dtlsflight.Packet) error {
+		assertFlight13RecvDoneOpen(t, recvState)
+
+		return nil
+	}
+	conn.handleQueuedPackets = func(context.Context) error {
+		assertFlight13RecvDoneOpen(t, recvState)
+
+		return nil
+	}
+	nextState, err = fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	assert.Equal(t, StateSending, nextState)
+	assertFlight13RecvDoneOpen(t, recvState)
+	nextState, err = fsm.send(context.Background(), conn)
+	require.NoError(t, err)
+	assert.Equal(t, StateFinished, nextState)
+	assertFlight13RecvDoneClosed(t, recvState)
 }
 
 func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T) {
@@ -472,8 +620,10 @@ func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T)
 	assert.Equal(t, StatePreparing, nextState)
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
 	assert.Equal(t, 3, fixture.clientState.HandshakeRecvSequence)
-	assertFlight13RecvDoneClosed(t, recvState)
+	assertFlight13RecvDoneOpen(t, recvState)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
+	fsm.releasePendingRecv()
+	assertFlight13RecvDoneClosed(t, recvState)
 }
 
 func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {
@@ -524,6 +674,44 @@ func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {
 	}, fsm.transcript.messageOrder()[4])
 	assert.True(t, conn.setLocalEpochCalled)
 	assert.Equal(t, dtlsflight13.EpochHandshake, conn.localEpoch)
+}
+
+func TestHandshakeFSM13SendErrorReleasesReader(t *testing.T) {
+	tests := []struct {
+		name     string
+		writeErr error
+		queueErr error
+	}{
+		{name: "write", writeErr: context.Canceled},
+		{name: "queue drain", queueErr: context.Canceled},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fsm := clientFSMThroughServerFlight13(t, newNoHRRFlight13Fixture(t))
+			recvState := RecvHandshakeState{Done: fsm.pendingRecvDone}
+			conn := &flightTestConn{
+				writePackets: func(context.Context, []*dtlsflight.Packet) error {
+					assertFlight13RecvDoneOpen(t, recvState)
+
+					return test.writeErr
+				},
+				handleQueuedPackets: func(context.Context) error {
+					assertFlight13RecvDoneOpen(t, recvState)
+
+					return test.queueErr
+				},
+			}
+
+			nextState, err := fsm.prepare(context.Background(), conn)
+			require.NoError(t, err)
+			require.Equal(t, StateSending, nextState)
+			assertFlight13RecvDoneOpen(t, recvState)
+			nextState, err = fsm.send(context.Background(), conn)
+			require.ErrorIs(t, err, context.Canceled)
+			assert.Equal(t, StateErrored, nextState)
+			assertFlight13RecvDoneClosed(t, recvState)
+		})
+	}
 }
 
 func TestHandshakeFSM13ClientFlight5WithCertificate(t *testing.T) {
@@ -710,6 +898,11 @@ func TestHandshakeFSM13ServerVerifiesClientFinishedAndCompletes(t *testing.T) {
 	serverFSM := serverFSMForClientFlight13(t, fixture, clientFSM.flights, 1)
 	conn := &flightTestConn{recvHandshake: make(chan RecvHandshakeState, 1)}
 	recvState := RecvHandshakeState{Done: make(chan struct{})}
+	conn.handleQueuedPackets = func(context.Context) error {
+		assertFlight13RecvDoneOpen(t, recvState)
+
+		return nil
+	}
 	conn.recvHandshake <- recvState
 
 	nextState, err = serverFSM.wait(context.Background(), conn)
@@ -910,7 +1103,8 @@ func clientFSMThroughServerFlight13(t *testing.T, fixture noHRRFlight13Fixture) 
 	require.NoError(t, err)
 	assert.Equal(t, StatePreparing, nextState)
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
-	assertFlight13RecvDoneClosed(t, recvState)
+	assertFlight13RecvDoneOpen(t, recvState)
+	t.Cleanup(fsm.releasePendingRecv)
 
 	return fsm
 }
@@ -1105,6 +1299,16 @@ func assertFlight13RecvDoneClosed(t *testing.T, state RecvHandshakeState) {
 	case <-state.Done:
 	default:
 		assert.Fail(t, "state.Done is not closed")
+	}
+}
+
+func assertFlight13RecvDoneOpen(t *testing.T, state RecvHandshakeState) {
+	t.Helper()
+
+	select {
+	case <-state.Done:
+		assert.Fail(t, "state.Done is closed")
+	default:
 	}
 }
 


### PR DESCRIPTION
#### Description
In DTLS 1.2 queued packets are serialized through handleIncomingPacket => handshakeRecv wait on state.done => fsm receives the signal and may call handleQueuedPackets => fsm finishes parsing queued packets and it closes state.done => reader continues.

In 1.3 FSM can call HandleQueuedPackets from fsm's send while the goroutine is processing packets and it cases a race https://github.com/pion/dtls/actions/runs/30643058217/job/91197549587
This fix makes FSM able to pause the reader while processing queued packets, queued buffer aren't returned to the pool. I avoided adding copy or a lock to the hot path. 