### PR TITLE
Rename common flight handler utils

### DIFF
--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -6,11 +6,15 @@ package flight13
 
 import (
 	"context"
+	"crypto"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 const (
@@ -134,4 +138,27 @@ func Parse(
 	})
 
 	return nextFlight, dtlsAlert, err, true
+}
+
+func HandshakePacket(message handshake.Message) *dtlsflight.Packet {
+	return &dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header: recordlayer.Header{
+				Version: protocol.Version1_2,
+				Epoch:   EpochHandshake,
+			},
+			Content: &handshake.Handshake{Message: message},
+		},
+		ShouldEncrypt: true,
+	}
+}
+
+func CertificateVerifyPacket(
+	message *handshake.MessageCertificateVerify,
+	signer crypto.Signer,
+) *dtlsflight.Packet {
+	pkt := HandshakePacket(message)
+	pkt.CertificateVerifySigner = signer
+
+	return pkt
 }

--- a/internal/flight/flight13/flighthandlers_client.go
+++ b/internal/flight/flight13/flighthandlers_client.go
@@ -805,7 +805,7 @@ func flight5Generate(
 	if err != nil {
 		return nil, dtlsAlert, err
 	}
-	pkts = append(pkts, flight5HandshakePacket(&handshake.MessageFinished{}))
+	pkts = append(pkts, HandshakePacket(&handshake.MessageFinished{}))
 	pkts[0].ResetLocalSequenceNumber = true
 
 	return pkts, nil, nil
@@ -828,7 +828,7 @@ func flight5ClientAuthPackets(
 	}
 	if len(certificate.Certificate) == 0 {
 		return []*dtlsflight.Packet{
-			flight5HandshakePacket(&handshake.MessageCertificate13{
+			HandshakePacket(&handshake.MessageCertificate13{
 				CertificateRequestContext: append(
 					[]byte(nil),
 					certificateRequest.CertificateRequestContext...,
@@ -852,14 +852,14 @@ func flight5ClientAuthPackets(
 	}
 
 	return []*dtlsflight.Packet{
-		flight5HandshakePacket(&handshake.MessageCertificate13{
+		HandshakePacket(&handshake.MessageCertificate13{
 			CertificateRequestContext: append(
 				[]byte(nil),
 				certificateRequest.CertificateRequestContext...,
 			),
 			CertificateList: certificateEntries13(certificate.Certificate),
 		}),
-		flight5CertificateVerifyPacket(
+		CertificateVerifyPacket(
 			&handshake.MessageCertificateVerify{
 				HashAlgorithm:      signatureScheme.Hash,
 				SignatureAlgorithm: signatureScheme.Signature,
@@ -961,27 +961,4 @@ func certificateEntries13(certificates [][]byte) []handshake.CertificateEntry13 
 	}
 
 	return entries
-}
-
-func flight5HandshakePacket(message handshake.Message) *dtlsflight.Packet {
-	return &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   EpochHandshake,
-			},
-			Content: &handshake.Handshake{Message: message},
-		},
-		ShouldEncrypt: true,
-	}
-}
-
-func flight5CertificateVerifyPacket(
-	message *handshake.MessageCertificateVerify,
-	signer crypto.Signer,
-) *dtlsflight.Packet {
-	pkt := flight5HandshakePacket(message)
-	pkt.CertificateVerifySigner = signer
-
-	return pkt
 }

--- a/internal/flight/flight13/flighthandlers_server.go
+++ b/internal/flight/flight13/flighthandlers_server.go
@@ -621,22 +621,22 @@ func flight4Generate(
 		},
 	}
 
-	encryptedExtensions := flight5HandshakePacket(&handshake.MessageEncryptedExtensions{})
+	encryptedExtensions := HandshakePacket(&handshake.MessageEncryptedExtensions{})
 	encryptedExtensions.ResetLocalSequenceNumber = true
 
 	return []*dtlsflight.Packet{
 		serverHello,
 		encryptedExtensions,
-		flight5HandshakePacket(&handshake.MessageCertificate13{
+		HandshakePacket(&handshake.MessageCertificate13{
 			CertificateList: certificateEntries13(certificate.Certificate),
 		}),
-		flight5CertificateVerifyPacket(
+		CertificateVerifyPacket(
 			&handshake.MessageCertificateVerify{
 				HashAlgorithm:      signatureScheme.Hash,
 				SignatureAlgorithm: signatureScheme.Signature,
 			},
 			signer,
 		),
-		flight5HandshakePacket(&handshake.MessageFinished{}),
+		HandshakePacket(&handshake.MessageFinished{}),
 	}, nil, nil
 }


### PR DESCRIPTION
#### Description
flight5HandshakePacket and flight5CertificateVerifyPacket aren't just used by flight5 anymore.