### PR TITLE
Add post-handshake message types

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -204,6 +204,10 @@ var ( //nolint:gochecknoglobals,lll
 	ErrMissingSignatureAlgorithmsExtension = stderrors.New(
 		"signature_algorithms extension is required in CertificateRequest",
 	)
+	ErrInvalidKeyUpdate         = stderrors.New("invalid KeyUpdate request")
+	ErrInvalidConnectionIDUsage = stderrors.New("invalid connection ID usage")
+	ErrTicketNonceTooLong       = stderrors.New("ticket nonce must not be longer than 255 bytes")
+	ErrInvalidTicketLength      = stderrors.New("ticket must be between 1 and 65535 bytes")
 
 	ErrInvalidPacketLength        = stderrors.New("packet length and declared length do not match")
 	ErrInvalidCiphertextHeader    = stderrors.New("invalid dtls 1.3 ciphertext header")

--- a/pkg/protocol/extension/extension.go
+++ b/pkg/protocol/extension/extension.go
@@ -164,6 +164,8 @@ func Unmarshal(buf []byte) ([]Extension, error) { //nolint:cyclop
 			err = unmarshalAndAppend(extensionData, &PskKeyExchangeModes{})
 		case PreSharedKeyValue:
 			err = unmarshalAndAppend(extensionData, &PreSharedKey{})
+		case EarlyDataIndicationTypeValue:
+			err = unmarshalAndAppend(extensionData, &EarlyDataIndication{})
 		default:
 		}
 

--- a/pkg/protocol/handshake/handshake.go
+++ b/pkg/protocol/handshake/handshake.go
@@ -21,7 +21,10 @@ const (
 	TypeClientHello         Type = 1
 	TypeServerHello         Type = 2
 	TypeHelloVerifyRequest  Type = 3
+	TypeNewSessionTicket    Type = 4
 	TypeEncryptedExtensions Type = 8
+	TypeRequestConnectionID Type = 9
+	TypeNewConnectionID     Type = 10
 	TypeCertificate         Type = 11
 	TypeServerKeyExchange   Type = 12
 	TypeCertificateRequest  Type = 13
@@ -29,6 +32,7 @@ const (
 	TypeCertificateVerify   Type = 15
 	TypeClientKeyExchange   Type = 16
 	TypeFinished            Type = 20
+	TypeKeyUpdate           Type = 24
 
 	// TypeMessageHash is a synthetic TLS 1.3 transcript-only handshake type.
 	TypeMessageHash Type = 254
@@ -57,8 +61,14 @@ func (t Type) String() string { //nolint:cyclop
 		return "ServerHello"
 	case TypeHelloVerifyRequest:
 		return "HelloVerifyRequest"
+	case TypeNewSessionTicket:
+		return "NewSessionTicket"
 	case TypeEncryptedExtensions:
 		return "EncryptedExtensions"
+	case TypeRequestConnectionID:
+		return "RequestConnectionID"
+	case TypeNewConnectionID:
+		return "NewConnectionID"
 	case TypeCertificate:
 		return "TypeCertificate"
 	case TypeServerKeyExchange:
@@ -73,6 +83,8 @@ func (t Type) String() string { //nolint:cyclop
 		return "ClientKeyExchange"
 	case TypeFinished:
 		return "Finished"
+	case TypeKeyUpdate:
+		return "KeyUpdate"
 	case TypeMessageHash:
 		return "MessageHash"
 	}
@@ -151,8 +163,14 @@ func (h *Handshake) Unmarshal(data []byte) error { //nolint:cyclop
 		h.Message = &MessageHelloVerifyRequest{}
 	case TypeServerHello:
 		h.Message = &MessageServerHello{}
+	case TypeNewSessionTicket:
+		h.Message = &MessageNewSessionTicket{}
 	case TypeEncryptedExtensions:
 		h.Message = &MessageEncryptedExtensions{}
+	case TypeRequestConnectionID:
+		h.Message = &MessageRequestConnectionID{}
+	case TypeNewConnectionID:
+		h.Message = &MessageNewConnectionID{}
 	case TypeCertificate:
 		h.Message = &MessageCertificate{}
 	case TypeServerKeyExchange:
@@ -167,6 +185,8 @@ func (h *Handshake) Unmarshal(data []byte) error { //nolint:cyclop
 		h.Message = &MessageFinished{}
 	case TypeCertificateVerify:
 		h.Message = &MessageCertificateVerify{}
+	case TypeKeyUpdate:
+		h.Message = &MessageKeyUpdate{}
 	default:
 		return dtlserrors.ErrNotImplemented
 	}

--- a/pkg/protocol/handshake/handshake_test.go
+++ b/pkg/protocol/handshake/handshake_test.go
@@ -51,3 +51,39 @@ func TestHandshakeMessage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, rawHandshakeMessage, raw, "handshakeMessageClientHello marshal")
 }
+
+func TestPostHandshakeMessageDispatch(t *testing.T) {
+	maxEarlyData := uint32(128)
+	tests := map[string]handshake.Message{
+		"NewSessionTicket": &handshake.MessageNewSessionTicket{
+			TicketLifetime: 1,
+			TicketAgeAdd:   2,
+			TicketNonce:    []byte{0x03},
+			Ticket:         []byte{0x04},
+			Extensions: []extension.Extension{
+				&extension.EarlyDataIndication{MaxEarlyData: &maxEarlyData},
+			},
+		},
+		"KeyUpdate": &handshake.MessageKeyUpdate{
+			RequestUpdate: handshake.KeyUpdateRequested,
+		},
+		"NewConnectionID": &handshake.MessageNewConnectionID{
+			CIDs:  [][]byte{{0x05}},
+			Usage: handshake.ConnectionIDSpare,
+		},
+		"RequestConnectionID": &handshake.MessageRequestConnectionID{
+			NumCIDs: 2,
+		},
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := (&handshake.Handshake{Message: message}).Marshal()
+			assert.NoError(t, err)
+
+			decoded := &handshake.Handshake{}
+			assert.NoError(t, decoded.Unmarshal(encoded))
+			assert.Equal(t, message, decoded.Message)
+		})
+	}
+}

--- a/pkg/protocol/handshake/message_key_update.go
+++ b/pkg/protocol/handshake/message_key_update.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import dtlserrors "github.com/pion/dtls/v3/internal/errors"
+
+// KeyUpdateRequest indicates whether the recipient should update its sending
+// traffic keys as well.
+type KeyUpdateRequest uint8
+
+// KeyUpdateRequest values.
+const (
+	KeyUpdateNotRequested KeyUpdateRequest = iota
+	KeyUpdateRequested
+)
+
+// MessageKeyUpdate requests an update of DTLS 1.3 application traffic keys.
+//
+// https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
+type MessageKeyUpdate struct {
+	RequestUpdate KeyUpdateRequest
+}
+
+// Type returns the Handshake Type.
+func (m MessageKeyUpdate) Type() Type {
+	return TypeKeyUpdate
+}
+
+// Marshal encodes the Handshake.
+func (m *MessageKeyUpdate) Marshal() ([]byte, error) {
+	if m.RequestUpdate != KeyUpdateNotRequested && m.RequestUpdate != KeyUpdateRequested {
+		return nil, dtlserrors.ErrInvalidKeyUpdate
+	}
+
+	return []byte{byte(m.RequestUpdate)}, nil
+}
+
+// Unmarshal populates the message from encoded data.
+func (m *MessageKeyUpdate) Unmarshal(data []byte) error {
+	if len(data) != 1 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	requestUpdate := KeyUpdateRequest(data[0])
+	if requestUpdate != KeyUpdateNotRequested && requestUpdate != KeyUpdateRequested {
+		return dtlserrors.ErrInvalidKeyUpdate
+	}
+	m.RequestUpdate = requestUpdate
+
+	return nil
+}

--- a/pkg/protocol/handshake/message_key_update_test.go
+++ b/pkg/protocol/handshake/message_key_update_test.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageKeyUpdate(t *testing.T) {
+	for _, request := range []KeyUpdateRequest{KeyUpdateNotRequested, KeyUpdateRequested} {
+		message := &MessageKeyUpdate{RequestUpdate: request}
+
+		raw, err := message.Marshal()
+		require.NoError(t, err)
+		assert.Equal(t, []byte{byte(request)}, raw)
+		assert.Equal(t, TypeKeyUpdate, message.Type())
+
+		decoded := &MessageKeyUpdate{}
+		require.NoError(t, decoded.Unmarshal(raw))
+		assert.Equal(t, message, decoded)
+	}
+}
+
+func TestMessageKeyUpdateErrors(t *testing.T) {
+	_, err := (&MessageKeyUpdate{RequestUpdate: 2}).Marshal()
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidKeyUpdate)
+
+	message := &MessageKeyUpdate{RequestUpdate: KeyUpdateRequested}
+	for _, raw := range [][]byte{nil, {0x00, 0x00}, {0x02}} {
+		err = message.Unmarshal(raw)
+		assert.Error(t, err)
+		assert.Equal(t, KeyUpdateRequested, message.RequestUpdate)
+	}
+}

--- a/pkg/protocol/handshake/message_new_connection_id.go
+++ b/pkg/protocol/handshake/message_new_connection_id.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+)
+
+const newConnectionIDMaxListLength = 65535
+
+// ConnectionIDUsage indicates whether new CIDs should be used immediately or
+// retained for future use.
+type ConnectionIDUsage uint8
+
+// ConnectionIDUsage values.
+const (
+	ConnectionIDImmediate ConnectionIDUsage = iota
+	ConnectionIDSpare
+)
+
+// MessageNewConnectionID supplies CIDs for a peer to use when sending records.
+//
+// https://datatracker.ietf.org/doc/html/rfc9147#section-9
+type MessageNewConnectionID struct {
+	CIDs  [][]byte
+	Usage ConnectionIDUsage
+}
+
+// Type returns the Handshake Type.
+func (m MessageNewConnectionID) Type() Type {
+	return TypeNewConnectionID
+}
+
+// Marshal encodes the Handshake.
+func (m *MessageNewConnectionID) Marshal() ([]byte, error) {
+	if m.Usage != ConnectionIDImmediate && m.Usage != ConnectionIDSpare {
+		return nil, dtlserrors.ErrInvalidConnectionIDUsage
+	}
+
+	cidsLength := 0
+	for _, cid := range m.CIDs {
+		if len(cid) > 255 {
+			return nil, dtlserrors.ErrCIDTooBig
+		}
+		cidsLength += 1 + len(cid)
+		if cidsLength > newConnectionIDMaxListLength {
+			return nil, dtlserrors.ErrCIDTooBig
+		}
+	}
+
+	out := make([]byte, 2, 2+cidsLength+1)
+	binary.BigEndian.PutUint16(out, uint16(cidsLength)) //nolint:gosec // length is checked above
+	for _, cid := range m.CIDs {
+		out = append(out, byte(len(cid))) //nolint:gosec // length is checked above
+		out = append(out, cid...)
+	}
+	out = append(out, byte(m.Usage))
+
+	return out, nil
+}
+
+// Unmarshal populates the message from encoded data.
+func (m *MessageNewConnectionID) Unmarshal(data []byte) error {
+	if len(data) < 3 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+
+	cidsLength := int(binary.BigEndian.Uint16(data))
+	if len(data) != 2+cidsLength+1 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	cids := make([][]byte, 0)
+	cidsData := data[2 : 2+cidsLength]
+	for len(cidsData) > 0 {
+		cidLength := int(cidsData[0])
+		cidsData = cidsData[1:]
+		if cidLength > len(cidsData) {
+			return dtlserrors.ErrLengthMismatch
+		}
+		cid := make([]byte, cidLength)
+		copy(cid, cidsData[:cidLength])
+		cids = append(cids, cid)
+		cidsData = cidsData[cidLength:]
+	}
+
+	usage := ConnectionIDUsage(data[len(data)-1])
+	if usage != ConnectionIDImmediate && usage != ConnectionIDSpare {
+		return dtlserrors.ErrInvalidConnectionIDUsage
+	}
+
+	m.CIDs = cids
+	m.Usage = usage
+
+	return nil
+}

--- a/pkg/protocol/handshake/message_new_connection_id_test.go
+++ b/pkg/protocol/handshake/message_new_connection_id_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageNewConnectionID(t *testing.T) {
+	message := &MessageNewConnectionID{
+		CIDs:  [][]byte{{0x01, 0x02}, {}, {0x03}},
+		Usage: ConnectionIDSpare,
+	}
+	want := []byte{
+		0x00, 0x06, // cids length
+		0x02, 0x01, 0x02,
+		0x00,
+		0x01, 0x03,
+		0x01, // cid_spare
+	}
+
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, want, raw)
+	assert.Equal(t, TypeNewConnectionID, message.Type())
+
+	decoded := &MessageNewConnectionID{}
+	require.NoError(t, decoded.Unmarshal(raw))
+	assert.Equal(t, message, decoded)
+}
+
+func TestMessageNewConnectionIDEmptyList(t *testing.T) {
+	message := &MessageNewConnectionID{Usage: ConnectionIDImmediate}
+
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x00, 0x00, 0x00}, raw)
+
+	decoded := &MessageNewConnectionID{}
+	require.NoError(t, decoded.Unmarshal(raw))
+	assert.Empty(t, decoded.CIDs)
+}
+
+func TestMessageNewConnectionIDMarshalErrors(t *testing.T) {
+	tests := map[string]*MessageNewConnectionID{
+		"CID too long": {
+			CIDs: [][]byte{make([]byte, 256)},
+		},
+		"CID list too long": {
+			CIDs: make([][]byte, 65536),
+		},
+		"invalid usage": {
+			Usage: 2,
+		},
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := message.Marshal()
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestMessageNewConnectionIDUnmarshalErrors(t *testing.T) {
+	tests := map[string][]byte{
+		"too short":            {0x00, 0x00},
+		"list length mismatch": {0x00, 0x01, 0x00},
+		"CID length mismatch":  {0x00, 0x02, 0x02, 0xaa, 0x00},
+		"invalid usage":        {0x00, 0x00, 0x02},
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			message := &MessageNewConnectionID{
+				CIDs:  [][]byte{{0xff}},
+				Usage: ConnectionIDSpare,
+			}
+			err := message.Unmarshal(raw)
+			assert.Error(t, err)
+			assert.Equal(t, [][]byte{{0xff}}, message.CIDs)
+			assert.Equal(t, ConnectionIDSpare, message.Usage)
+		})
+	}
+
+	assert.ErrorIs(t, (&MessageNewConnectionID{}).Unmarshal([]byte{0x00, 0x00}), dtlserrors.ErrBufferTooSmall)
+}

--- a/pkg/protocol/handshake/message_new_session_ticket.go
+++ b/pkg/protocol/handshake/message_new_session_ticket.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+const (
+	newSessionTicketMinLength           = 13
+	newSessionTicketMaxNonceLength      = 255
+	newSessionTicketMaxTicketLength     = 65535
+	newSessionTicketMaxExtensionsLength = 65534
+)
+
+// MessageNewSessionTicket establishes a PSK that a client can use to resume a
+// DTLS 1.3 connection.
+//
+// https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.1
+type MessageNewSessionTicket struct {
+	TicketLifetime uint32
+	TicketAgeAdd   uint32
+	TicketNonce    []byte
+	Ticket         []byte
+	Extensions     []extension.Extension
+}
+
+// Type returns the Handshake Type.
+func (m MessageNewSessionTicket) Type() Type {
+	return TypeNewSessionTicket
+}
+
+// Marshal encodes the Handshake.
+func (m *MessageNewSessionTicket) Marshal() ([]byte, error) {
+	if len(m.TicketNonce) > newSessionTicketMaxNonceLength {
+		return nil, dtlserrors.ErrTicketNonceTooLong
+	}
+	if len(m.Ticket) == 0 || len(m.Ticket) > newSessionTicketMaxTicketLength {
+		return nil, dtlserrors.ErrInvalidTicketLength
+	}
+
+	extensions, err := extension.Marshal(m.Extensions)
+	if err != nil {
+		return nil, err
+	}
+	if len(extensions)-2 > newSessionTicketMaxExtensionsLength {
+		return nil, dtlserrors.ErrInvalidExtensionsLength
+	}
+
+	out := make([]byte, 0, 8+1+len(m.TicketNonce)+2+len(m.Ticket)+len(extensions))
+	out = binary.BigEndian.AppendUint32(out, m.TicketLifetime)
+	out = binary.BigEndian.AppendUint32(out, m.TicketAgeAdd)
+	out = append(out, byte(len(m.TicketNonce))) //nolint:gosec // length is checked above
+	out = append(out, m.TicketNonce...)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(m.Ticket))) //nolint:gosec // length is checked above
+	out = append(out, m.Ticket...)
+	out = append(out, extensions...)
+
+	return out, nil
+}
+
+// Unmarshal populates the message from encoded data.
+func (m *MessageNewSessionTicket) Unmarshal(data []byte) error {
+	if len(data) < newSessionTicketMinLength {
+		return dtlserrors.ErrBufferTooSmall
+	}
+
+	offset := 0
+	ticketLifetime := binary.BigEndian.Uint32(data[offset:])
+	offset += 4
+	ticketAgeAdd := binary.BigEndian.Uint32(data[offset:])
+	offset += 4
+
+	nonceLength := int(data[offset])
+	offset++
+	if len(data)-offset < nonceLength+2 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+	ticketNonce := append([]byte(nil), data[offset:offset+nonceLength]...)
+	offset += nonceLength
+
+	ticketLength := int(binary.BigEndian.Uint16(data[offset:]))
+	offset += 2
+	if ticketLength == 0 {
+		return dtlserrors.ErrInvalidTicketLength
+	}
+	if len(data)-offset < ticketLength+2 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+	ticket := append([]byte(nil), data[offset:offset+ticketLength]...)
+	offset += ticketLength
+
+	extensions, err := extension.Unmarshal(data[offset:])
+	if err != nil {
+		return err
+	}
+
+	m.TicketLifetime = ticketLifetime
+	m.TicketAgeAdd = ticketAgeAdd
+	m.TicketNonce = ticketNonce
+	m.Ticket = ticket
+	m.Extensions = extensions
+
+	return nil
+}

--- a/pkg/protocol/handshake/message_new_session_ticket_test.go
+++ b/pkg/protocol/handshake/message_new_session_ticket_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageNewSessionTicket(t *testing.T) {
+	maxEarlyData := uint32(128)
+	message := &MessageNewSessionTicket{
+		TicketLifetime: 0x01020304,
+		TicketAgeAdd:   0x05060708,
+		TicketNonce:    []byte{0xaa, 0xbb},
+		Ticket:         []byte{0xcc, 0xdd, 0xee},
+		Extensions: []extension.Extension{
+			&extension.EarlyDataIndication{MaxEarlyData: &maxEarlyData},
+		},
+	}
+	want := []byte{
+		0x01, 0x02, 0x03, 0x04, // ticket_lifetime
+		0x05, 0x06, 0x07, 0x08, // ticket_age_add
+		0x02, 0xaa, 0xbb, // ticket_nonce
+		0x00, 0x03, 0xcc, 0xdd, 0xee, // ticket
+		0x00, 0x08, // extensions length
+		0x00, 0x2a, 0x00, 0x04, 0x00, 0x00, 0x00, 0x80, // early_data
+	}
+
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, want, raw)
+	assert.Equal(t, TypeNewSessionTicket, message.Type())
+
+	decoded := &MessageNewSessionTicket{}
+	require.NoError(t, decoded.Unmarshal(want))
+	assert.Equal(t, message, decoded)
+}
+
+func TestMessageNewSessionTicketEmptyVectors(t *testing.T) {
+	message := &MessageNewSessionTicket{Ticket: []byte{0x01}}
+
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+
+	decoded := &MessageNewSessionTicket{}
+	require.NoError(t, decoded.Unmarshal(raw))
+	assert.Empty(t, decoded.TicketNonce)
+	assert.Empty(t, decoded.Extensions)
+}
+
+func TestMessageNewSessionTicketMarshalErrors(t *testing.T) {
+	tooManyExtensions := make([]extension.Extension, 16384)
+	for i := range tooManyExtensions {
+		tooManyExtensions[i] = &extension.PostHandshakeAuth{Enabled: true}
+	}
+
+	tests := map[string]*MessageNewSessionTicket{
+		"nonce too long": {TicketNonce: make([]byte, 256), Ticket: []byte{0x01}},
+		"empty ticket":   {},
+		"ticket too long": {
+			Ticket: make([]byte, 65536),
+		},
+		"extensions too long": {
+			Ticket:     []byte{0x01},
+			Extensions: tooManyExtensions,
+		},
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := message.Marshal()
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestMessageNewSessionTicketUnmarshalErrors(t *testing.T) {
+	valid := []byte{
+		0x00, 0x00, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x02,
+		0x01, 0xaa,
+		0x00, 0x01, 0xbb,
+		0x00, 0x00,
+	}
+	tests := map[string][]byte{
+		"too short":          valid[:12],
+		"truncated nonce":    append(append([]byte(nil), valid[:9]...), 0x08, 0x00, 0x01, 0x02),
+		"empty ticket":       append(append([]byte(nil), valid[:10]...), 0x00, 0x00, 0x00, 0x00),
+		"truncated ticket":   append(append([]byte(nil), valid[:10]...), 0x00, 0x04, 0xbb, 0x00, 0x00),
+		"invalid extensions": append(append([]byte(nil), valid[:13]...), 0x00, 0x01, 0xff),
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			message := &MessageNewSessionTicket{
+				TicketLifetime: 42,
+				Ticket:         []byte("preserved"),
+			}
+			err := message.Unmarshal(raw)
+			assert.Error(t, err)
+			assert.Equal(t, uint32(42), message.TicketLifetime)
+			assert.Equal(t, []byte("preserved"), message.Ticket)
+		})
+	}
+
+	assert.ErrorIs(t, (&MessageNewSessionTicket{}).Unmarshal(valid[:12]), dtlserrors.ErrBufferTooSmall)
+}

--- a/pkg/protocol/handshake/message_request_connection_id.go
+++ b/pkg/protocol/handshake/message_request_connection_id.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import dtlserrors "github.com/pion/dtls/v3/internal/errors"
+
+// MessageRequestConnectionID requests spare CIDs from a peer.
+//
+// https://datatracker.ietf.org/doc/html/rfc9147#section-9
+type MessageRequestConnectionID struct {
+	NumCIDs uint8
+}
+
+// Type returns the Handshake Type.
+func (m MessageRequestConnectionID) Type() Type {
+	return TypeRequestConnectionID
+}
+
+// Marshal encodes the Handshake.
+func (m *MessageRequestConnectionID) Marshal() ([]byte, error) {
+	return []byte{m.NumCIDs}, nil
+}
+
+// Unmarshal populates the message from encoded data.
+func (m *MessageRequestConnectionID) Unmarshal(data []byte) error {
+	if len(data) != 1 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	m.NumCIDs = data[0]
+
+	return nil
+}

--- a/pkg/protocol/handshake/message_request_connection_id_test.go
+++ b/pkg/protocol/handshake/message_request_connection_id_test.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageRequestConnectionID(t *testing.T) {
+	message := &MessageRequestConnectionID{NumCIDs: 42}
+
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{42}, raw)
+	assert.Equal(t, TypeRequestConnectionID, message.Type())
+
+	decoded := &MessageRequestConnectionID{}
+	require.NoError(t, decoded.Unmarshal(raw))
+	assert.Equal(t, message, decoded)
+}
+
+func TestMessageRequestConnectionIDUnmarshalErrors(t *testing.T) {
+	message := &MessageRequestConnectionID{NumCIDs: 42}
+
+	for _, raw := range [][]byte{nil, {0x01, 0x02}} {
+		err := message.Unmarshal(raw)
+		assert.Error(t, err)
+		assert.Equal(t, uint8(42), message.NumCIDs)
+	}
+}


### PR DESCRIPTION
#### Description
Adds base message types for:
1. NewSessionTicket
2. KeyUpdate
3. NewConnectionId
4. RequestConnectionId

part of #824