### PR TITLE
Implement handshake lifecycle

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -230,10 +230,10 @@ type Conn struct {
 	maximumTransmissionUnit int
 	paddingLengthGenerator  func(uint) uint
 
-	handshakeCompletedSuccessfully atomic.Bool
-	handshakeMutex                 sync.Mutex
-	handshakeDone                  chan struct{}
-	writeLock                      sync.Mutex
+	handshakeEstablished *dtlshandshake.Establishment
+	handshakeMutex       sync.Mutex
+	handshakeDone        chan struct{}
+	writeLock            sync.Mutex
 
 	encryptedPackets []addrPkt
 
@@ -619,6 +619,7 @@ func newConn(
 
 		reading:               make(chan struct{}, 1),
 		handshakeRecv:         make(chan dtlshandshake.RecvHandshakeState),
+		handshakeEstablished:  dtlshandshake.NewEstablishment(),
 		closed:                closer.NewCloser(),
 		cancelHandshaker:      func() {},
 		cancelHandshakeReader: func() {},
@@ -2302,12 +2303,8 @@ func (c *Conn) notify(ctx context.Context, level alert.Level, desc alert.Descrip
 	})
 }
 
-func (c *Conn) setHandshakeCompletedSuccessfully() bool {
-	return c.handshakeCompletedSuccessfully.CompareAndSwap(false, true)
-}
-
 func (c *Conn) isHandshakeCompletedSuccessfully() bool {
-	return c.handshakeCompletedSuccessfully.Load()
+	return c.handshakeEstablished.Established()
 }
 
 func (c *Conn) negotiateVersionServer(ctx context.Context) error {
@@ -2594,13 +2591,12 @@ func (c *Conn) deliverReadError(ctx context.Context, err error) {
 
 //nolint:gocyclo,cyclop,gocognit,contextcheck
 func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
-	done := make(chan struct{})
 	if dtlsstate.CommonState(c.state).LocalVersion == protocol.Version1_3 {
-		if err := c.setupHandshakeFSM13(start, done); err != nil {
+		if err := c.setupHandshakeFSM13(start); err != nil {
 			return err
 		}
 	} else {
-		if err := c.setupHandshakeFSM12(start, done); err != nil {
+		if err := c.setupHandshakeFSM12(start); err != nil {
 			return err
 		}
 	}
@@ -2691,12 +2687,12 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 		handshakeLoopsFinished.Wait()
 
 		return c.translateHandshakeCtxError(ctx.Err())
-	case <-done:
+	case <-c.handshakeEstablished.Done():
 		return nil
 	}
 }
 
-func (c *Conn) setupHandshakeFSM13(start handshakeStart, done chan struct{}) error {
+func (c *Conn) setupHandshakeFSM13(start handshakeStart) error {
 	state13, err := dtlsstate.As13(c.state)
 	if err != nil {
 		return err
@@ -2707,34 +2703,29 @@ func (c *Conn) setupHandshakeFSM13(start handshakeStart, done chan struct{}) err
 		c.handshakeConfig,
 		start.flight13,
 		start.flights,
+		c.handshakeEstablished,
 	)
 	if err != nil {
 		return err
 	}
 	c.fsm = fsm
-	c.handshakeConfig.OnFlightState13 = func(_ uint8, s uint8) {
-		// The ACK for the last flights has been received and we are in a Finished state.
-		// nolint:godox
-		// TODO: should be moved to FSM.
-		if dtlshandshake.State(s) == dtlshandshake.StateFinished && c.setHandshakeCompletedSuccessfully() {
-			close(done)
-		}
-	}
 
 	return nil
 }
 
-func (c *Conn) setupHandshakeFSM12(start handshakeStart, done chan struct{}) error {
+func (c *Conn) setupHandshakeFSM12(start handshakeStart) error {
 	state12, err := dtlsstate.As12(c.state)
 	if err != nil {
 		return err
 	}
-	c.fsm = dtlshandshake.NewFSM12(state12, c.handshakeCache, c.handshakeConfig, start.flight12, start.flights)
-	c.handshakeConfig.OnFlightState = func(_ uint8, s uint8) {
-		if dtlshandshake.State(s) == dtlshandshake.StateFinished && c.setHandshakeCompletedSuccessfully() {
-			close(done)
-		}
-	}
+	c.fsm = dtlshandshake.NewFSM12(
+		state12,
+		c.handshakeCache,
+		c.handshakeConfig,
+		start.flight12,
+		start.flights,
+		c.handshakeEstablished,
+	)
 
 	return nil
 }

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -163,10 +164,10 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		"SlowServerTest": func() (TestEndpoint, TestEndpoint, func(t *testing.T)) {
 			var (
 				cntClientFinished               = 0
-				isClientFinished                = false
+				isClientFinished                atomic.Bool
 				cntClientFinishedLastRetransmit = 0
 				cntServerFinished               = 0
-				isServerFinished                = false
+				isServerFinished                atomic.Bool
 				cntServerFinishedLastRetransmit = 0
 			)
 
@@ -177,7 +178,7 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 						return true
 					}
 					if _, ok := h.Message.(*handshake.MessageFinished); ok {
-						if isClientFinished {
+						if isClientFinished.Load() {
 							cntClientFinishedLastRetransmit++
 						} else {
 							cntClientFinished++
@@ -188,7 +189,7 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 				},
 				Delay: 0,
 				OnFinished: func() {
-					isClientFinished = true
+					isClientFinished.Store(true)
 				},
 				FinishWait: 2000 * time.Millisecond,
 			}
@@ -200,7 +201,7 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 						return true
 					}
 					if _, ok := h.Message.(*handshake.MessageFinished); ok {
-						if isServerFinished {
+						if isServerFinished.Load() {
 							cntServerFinishedLastRetransmit++
 						} else {
 							cntServerFinished++
@@ -211,7 +212,7 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 				},
 				Delay: 1000 * time.Millisecond,
 				OnFinished: func() {
-					isServerFinished = true
+					isServerFinished.Store(true)
 				},
 				FinishWait: 2000 * time.Millisecond,
 			}
@@ -224,11 +225,11 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 				// using a range of 3 - 5 for checking.
 				assert.LessOrEqual(t, 3, cntClientFinished, "Number of client finished should be greater than 3")
 				assert.GreaterOrEqual(t, 5, cntClientFinished, "Number of client finished should be less than 5")
-				assert.True(t, isClientFinished)
+				assert.True(t, isClientFinished.Load())
 				// there should be no `Finished` last retransmit from client
 				assert.Equal(t, 0, cntClientFinishedLastRetransmit, "Number of client finished last retransmit greater than zero")
 				assert.LessOrEqual(t, 1, cntServerFinished, "Number of server finished less than 1")
-				assert.True(t, isServerFinished)
+				assert.True(t, isServerFinished.Load())
 				// there should be `Finished` last retransmit from server.
 				// Because of slow server, client would have sent several `Finished`.
 				assert.LessOrEqual(t, 1, cntServerFinished, "Number of server finished last retransmit is less than 1")
@@ -309,24 +310,27 @@ func runHandshakeFSM12ForTest(
 	t.Helper()
 
 	cfg := &dtlsconfig.HandshakeConfig{
-		LocalCipherSuites:     cipherSuites,
-		LocalCertificates:     []tls.Certificate{clientCert},
-		EllipticCurves:        defaultCurves,
-		LocalSignatureSchemes: signaturehash.Algorithms(),
-		InsecureSkipVerify:    true,
-		Log:                   logger,
-		OnFlightState: func(_ uint8, state uint8) {
-			if dtlshandshake.State(state) == dtlshandshake.StateFinished {
-				if endpoint.OnFinished != nil {
-					endpoint.OnFinished()
-				}
-				time.AfterFunc(endpoint.FinishWait, cancel)
-			}
-		},
+		LocalCipherSuites:         cipherSuites,
+		LocalCertificates:         []tls.Certificate{clientCert},
+		EllipticCurves:            defaultCurves,
+		LocalSignatureSchemes:     signaturehash.Algorithms(),
+		InsecureSkipVerify:        true,
+		Log:                       logger,
 		InitialRetransmitInterval: nonZeroRetransmitInterval,
 	}
+	establishment := dtlshandshake.NewEstablishment()
+	go func() {
+		select {
+		case <-establishment.Done():
+			if endpoint.OnFinished != nil {
+				endpoint.OnFinished()
+			}
+			time.AfterFunc(endpoint.FinishWait, cancel)
+		case <-ctx.Done():
+		}
+	}()
 
-	fsm := dtlshandshake.NewFSM12(&conn.state, conn.handshakeCache, cfg, initialFlight, nil)
+	fsm := dtlshandshake.NewFSM12(&conn.state, conn.handshakeCache, cfg, initialFlight, nil, establishment)
 	err := fsm.Run(ctx, handshakeConnAdapter{conn}, dtlshandshake.StatePreparing)
 	switch {
 	case errors.Is(err, context.Canceled):

--- a/internal/config/handshake.go
+++ b/internal/config/handshake.go
@@ -126,7 +126,6 @@ type HandshakeConfig struct {
 	InsecureSkipHelloVerify       bool
 	ConnectionIDGenerator         func() []byte
 	HelloRandomBytesGenerator     func() [handshake.RandomBytesLength]byte
-	OnFlightState                 func(flight, state uint8)
 	Log                           logging.LeveledLogger
 	KeyLogWriter                  io.Writer
 	LocalGetCertificate           func(*ClientHelloInfo) (*tls.Certificate, error)
@@ -138,7 +137,6 @@ type HandshakeConfig struct {
 	ResumeState                   *internalstate.State
 	MinVersion                    protocol.Version
 	MaxVersion                    protocol.Version
-	OnFlightState13               func(flight, state uint8)
 
 	nameToCertificate map[string]*tls.Certificate
 	mu                sync.Mutex

--- a/internal/handshake/establishment.go
+++ b/internal/handshake/establishment.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtlshandshake
+
+import "sync"
+
+// Establishment represents the one-way transition from handshaking to an
+// established DTLS connection.
+//
+// It is separate from FSM.Done() because the FSM remains active after
+// establishment to handle final-flight retransmissions.
+type Establishment struct {
+	once sync.Once
+	done chan struct{}
+}
+
+// NewEstablishment creates an unestablished handshake lifecycle signal.
+func NewEstablishment() *Establishment {
+	return &Establishment{done: make(chan struct{})}
+}
+
+// Done is closed when the handshake first becomes established.
+func (e *Establishment) Done() <-chan struct{} {
+	return e.done
+}
+
+// Established reports whether the handshake has become established.
+func (e *Establishment) Established() bool {
+	select {
+	case <-e.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// mark the handshake as established.
+func (e *Establishment) mark() {
+	e.once.Do(func() {
+		close(e.done)
+	})
+}

--- a/internal/handshake/fsm.go
+++ b/internal/handshake/fsm.go
@@ -18,8 +18,8 @@ func runHandshakeFSM(
 	conn Conn,
 	initialState State,
 	closed chan struct{},
+	establishment *Establishment,
 	trace func(State),
-	onFlightState func(State),
 	prepare, send, wait, finish fsmStateHandler,
 ) error {
 	state := initialState
@@ -27,8 +27,8 @@ func runHandshakeFSM(
 
 	for {
 		trace(state)
-		if onFlightState != nil {
-			onFlightState(state)
+		if state == StateFinished {
+			establishment.mark()
 		}
 
 		var err error

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -60,6 +60,7 @@ type fsm12 struct {
 	cache              *dtlsflight.Cache
 	cfg                *dtlsconfig.HandshakeConfig
 	closed             chan struct{}
+	establishment      *Establishment
 }
 
 func NewFSM12(
@@ -68,8 +69,9 @@ func NewFSM12(
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight12.Flight,
 	initialFlights []*dtlsflight.Packet,
+	establishment *Establishment,
 ) FSM {
-	return newFSM12(state, cache, cfg, initialFlight, initialFlights)
+	return newFSM12(state, cache, cfg, initialFlight, initialFlights, establishment)
 }
 
 func newFSM12(
@@ -78,6 +80,7 @@ func newFSM12(
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight12.Flight,
 	initialFlights []*dtlsflight.Packet,
+	establishment *Establishment,
 ) *fsm12 {
 	return &fsm12{
 		currentFlight:      initialFlight,
@@ -88,6 +91,7 @@ func newFSM12(
 		cfg:                cfg,
 		retransmitInterval: cfg.InitialRetransmitInterval,
 		closed:             make(chan struct{}),
+		establishment:      establishment,
 	}
 }
 
@@ -97,6 +101,7 @@ func (s *fsm12) Run(ctx context.Context, conn Conn, initialState State) error {
 		conn,
 		initialState,
 		s.closed,
+		s.establishment,
 		func(state State) {
 			s.cfg.Log.Tracef(
 				"[handshake:%s] %s: %s",
@@ -104,11 +109,6 @@ func (s *fsm12) Run(ctx context.Context, conn Conn, initialState State) error {
 				s.currentFlight.String(),
 				state.String(),
 			)
-		},
-		func(state State) {
-			if s.cfg.OnFlightState != nil {
-				s.cfg.OnFlightState(uint8(s.currentFlight), uint8(state))
-			}
 		},
 		s.prepare,
 		s.send,

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -79,6 +79,7 @@ type fsm13 struct {
 	cfg                *dtlsconfig.HandshakeConfig
 	transcript         *Transcript
 	closed             chan struct{}
+	establishment      *Establishment
 	pendingRecvDone    chan struct{} // keeps the reader paused across a prepare/send transition
 }
 
@@ -93,8 +94,9 @@ func NewFSM13(
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight13.Flight,
 	initialFlights []*dtlsflight.Packet,
+	establishment *Establishment,
 ) (FSM, error) {
-	return newFSM13(state, cache, cfg, initialFlight, initialFlights, nil)
+	return newFSM13WithEstablishment(state, cache, cfg, initialFlight, initialFlights, nil, establishment)
 }
 
 func newFSM13(
@@ -104,6 +106,20 @@ func newFSM13(
 	initialFlight dtlsflight13.Flight,
 	initialFlights []*dtlsflight.Packet,
 	initialTranscript *Transcript,
+) (*fsm13, error) {
+	return newFSM13WithEstablishment(
+		state, cache, cfg, initialFlight, initialFlights, initialTranscript, NewEstablishment(),
+	)
+}
+
+func newFSM13WithEstablishment(
+	state *dtlsstate.State13,
+	cache *dtlsflight.Cache,
+	cfg *dtlsconfig.HandshakeConfig,
+	initialFlight dtlsflight13.Flight,
+	initialFlights []*dtlsflight.Packet,
+	initialTranscript *Transcript,
+	establishment *Establishment,
 ) (*fsm13, error) {
 	if initialTranscript == nil {
 		initialTranscript = NewTranscript()
@@ -119,6 +135,7 @@ func newFSM13(
 		transcript:         initialTranscript,
 		retransmitInterval: cfg.InitialRetransmitInterval,
 		closed:             make(chan struct{}),
+		establishment:      establishment,
 	}
 	if err := fsm.seedTranscriptFromInitialFlights(); err != nil {
 		return nil, err
@@ -217,6 +234,7 @@ func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
 		conn,
 		initialState,
 		s.closed,
+		s.establishment,
 		func(state State) {
 			s.cfg.Log.Tracef(
 				"[handshake13:%s] %s: %s",
@@ -224,13 +242,6 @@ func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
 				s.currentFlight.String(),
 				state.String(),
 			)
-		},
-		func(state State) {
-			// nolint:godox
-			// TODO:: refactor callback, see discussion in https://github.com/pion/dtls/pull/738#discussion_r3131501159
-			if s.cfg.OnFlightState13 != nil {
-				s.cfg.OnFlightState13(uint8(s.currentFlight), uint8(state))
-			}
 		},
 		s.prepare,
 		s.send,


### PR DESCRIPTION
#### Description
We currently use a callback to try to observe `StateFinished` by a callback OnFlightState / OnFlightState13 and to close Done channel, this is the state before Done(), but goroutines are still alive to process retransmissions of the final flight. and we can go back to `StateSending` from `StateFinished` after the callback is called.
This removes the callback from 1.2 and 1.3 and adds a small sync helper that hopefully makes the code more "Go" and fixes the 1.3 issues with the current callback design 
#### Reference issue
https://github.com/pion/dtls/pull/738#discussion_r3131501159 
https://github.com/pion/dtls/blob/deb71ba674d1db31e681a31beae9be4891f9a897/internal/handshake/fsm13.go#L230
https://github.com/pion/dtls/blob/deb71ba674d1db31e681a31beae9be4891f9a897/conn.go#L2716-L2718