### PR TITLE
Remove redundant wrappers

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -250,10 +250,6 @@ func defaultCipherSuitesForVersions(minVersion, maxVersion protocol.Version) []C
 	return cipherSuites
 }
 
-func cipherSuiteSupportedVersions(id CipherSuiteID) []protocol.Version {
-	return ciphersuite.SupportedVersions(id)
-}
-
 func cipherSuiteSupportedVersionIDs(id CipherSuiteID) []uint16 {
 	return ciphersuite.SupportedVersionIDs(id)
 }

--- a/cipher_suite_test.go
+++ b/cipher_suite_test.go
@@ -87,7 +87,7 @@ func TestCipherSuiteSupportedVersions(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			assert.Equal(t, testCase.expected, cipherSuiteSupportedVersions(testCase.suite))
+			assert.Equal(t, testCase.expected, ciphersuite.SupportedVersions(testCase.suite))
 		})
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -2250,17 +2250,13 @@ func (c *Conn) processIncomingPacket(
 }
 
 func (c *Conn) syncFragmentBufferHandshakeSequence() {
-	handshakeRecvSequence := c.handshakeRecvSequence()
+	handshakeRecvSequence := dtlsstate.HandshakeRecvSequence(c.state)
 	if c.fragmentBuffer == nil || handshakeRecvSequence <= 0 ||
 		handshakeRecvSequence > int(^uint16(0)) {
 		return
 	}
 
 	c.fragmentBuffer.AdvanceTo(uint16(handshakeRecvSequence))
-}
-
-func (c *Conn) handshakeRecvSequence() int {
-	return dtlsstate.HandshakeRecvSequence(c.state)
 }
 
 func (c *Conn) recvHandshake() <-chan dtlshandshake.RecvHandshakeState {
@@ -2415,7 +2411,7 @@ func (c *Conn) pickVersionFromServerResponse() (bool, error) {
 	}
 
 	if hvr, ok := c.findCachedServerMessage(handshake.TypeHelloVerifyRequest).(*handshake.MessageHelloVerifyRequest); ok {
-		if err := c.pickVersionFromHelloVerifyRequest(hvr); err != nil {
+		if err := c.selectRemoteVersion([]protocol.Version{hvr.Version}); err != nil {
 			return false, err
 		}
 
@@ -2432,10 +2428,6 @@ func (c *Conn) pickVersionFromServerHello(sh *handshake.MessageServerHello) erro
 	}
 
 	return c.selectRemoteVersion(remote)
-}
-
-func (c *Conn) pickVersionFromHelloVerifyRequest(hvr *handshake.MessageHelloVerifyRequest) error {
-	return c.selectRemoteVersion([]protocol.Version{hvr.Version})
 }
 
 func remoteVersionsFromServerHello(sh *handshake.MessageServerHello) ([]protocol.Version, error) {

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -71,17 +71,6 @@ func NewFSM12(
 	initialFlights []*dtlsflight.Packet,
 	establishment *Establishment,
 ) FSM {
-	return newFSM12(state, cache, cfg, initialFlight, initialFlights, establishment)
-}
-
-func newFSM12(
-	state *dtlsstate.State12,
-	cache *dtlsflight.Cache,
-	cfg *dtlsconfig.HandshakeConfig,
-	initialFlight dtlsflight12.Flight,
-	initialFlights []*dtlsflight.Packet,
-	establishment *Establishment,
-) *fsm12 {
 	return &fsm12{
 		currentFlight:      initialFlight,
 		flights:            initialFlights,

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -689,7 +689,7 @@ func AppendOutboundHandshakeFlight(
 
 	sender := transcriptSenderForSide13(isClient)
 	for _, p := range pkts {
-		h, canonical, ok, err := canonicalOutboundHandshake13(p)
+		handshakeMessage, canonical, ok, err := canonicalOutboundHandshake13(p)
 		if err != nil {
 			return err
 		}
@@ -697,7 +697,14 @@ func AppendOutboundHandshakeFlight(
 			continue
 		}
 
-		if err := appendOutboundHandshake13(transcript, sender, cipherSuite, h, canonical); err != nil {
+		if err := appendHandshake13(
+			transcript,
+			sender,
+			cipherSuite,
+			handshakeMessage.Header.MessageSequence,
+			handshakeMessage.Message,
+			canonical,
+		); err != nil {
 			return err
 		}
 	}
@@ -725,16 +732,6 @@ func canonicalOutboundHandshake13(p *dtlsflight.Packet) (*handshake.Handshake, [
 	}
 
 	return hs, canonical, true, nil
-}
-
-func appendOutboundHandshake13(
-	transcript *Transcript,
-	sender transcriptSender,
-	cipherSuite dtlsconfig.CipherSuite,
-	h *handshake.Handshake,
-	canonical []byte,
-) error {
-	return appendHandshake13(transcript, sender, cipherSuite, h.Header.MessageSequence, h.Message, canonical)
 }
 
 // AppendVerifiedInbound appends an inbound handshake message to the transcript

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -185,16 +185,16 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, pkts, nil)
 	require.NoError(t, err)
 	require.NotNil(t, fsm.transcript)
-	require.Len(t, fsm.transcript.pendingMessages(), 1)
-	require.Len(t, fsm.transcript.messageOrder(), 1)
+	require.Len(t, fsm.transcript.pending, 1)
+	require.Len(t, fsm.transcript.order, 1)
 
-	assert.Equal(t, expected, fsm.transcript.pendingMessages()[0])
+	assert.Equal(t, expected, fsm.transcript.pending[0])
 	assert.Equal(t, expected, fsm.transcript.Bytes())
 	assert.Equal(t, transcriptMessageID{
 		sender: transcriptSenderClient,
 		Seq:    messageSequence,
-	}, fsm.transcript.messageOrder()[0].ID)
-	assert.Equal(t, handshake.TypeClientHello, fsm.transcript.messageOrder()[0].Type)
+	}, fsm.transcript.order[0].ID)
+	assert.Equal(t, handshake.TypeClientHello, fsm.transcript.order[0].Type)
 }
 
 func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testing.T) {
@@ -215,7 +215,7 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 
 	transcript := fsm.transcript
 	before := append([]byte(nil), transcript.Bytes()...)
-	require.Len(t, transcript.pendingMessages(), 1)
+	require.Len(t, transcript.pending, 1)
 
 	fsm.currentFlight = dtlsflight13.Flight2
 	fsm.retransmit = true
@@ -228,7 +228,7 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 	require.NoError(t, fsm.seedTranscriptFromInitialFlights())
 	assert.Same(t, transcript, fsm.transcript)
 	assert.Equal(t, before, fsm.transcript.Bytes())
-	assert.Len(t, fsm.transcript.pendingMessages(), 1)
+	assert.Len(t, fsm.transcript.pending, 1)
 }
 
 func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
@@ -256,7 +256,7 @@ func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testi
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid)
 	assert.Equal(t, StateErrored, nextState)
 	require.Len(t, fsm.flights, 1)
-	assert.Empty(t, fsm.transcript.messageOrder())
+	assert.Empty(t, fsm.transcript.order)
 	assert.Empty(t, fsm.transcript.Bytes())
 	assert.Equal(t, 1, state.HandshakeSendSequence)
 }
@@ -275,9 +275,9 @@ func TestHandshakeFSM13PrepareCommitsOutboundClientHello(t *testing.T) {
 	require.Len(t, fsm.flights, 1)
 
 	expected := canonicalPacketHandshake13(t, fsm.flights[0])
-	require.Len(t, fsm.transcript.messageOrder(), 1)
-	assert.Equal(t, transcriptMessageID{sender: transcriptSenderClient, Seq: 0}, fsm.transcript.messageOrder()[0].ID)
-	assert.Equal(t, handshake.TypeClientHello, fsm.transcript.messageOrder()[0].Type)
+	require.Len(t, fsm.transcript.order, 1)
+	assert.Equal(t, transcriptMessageID{sender: transcriptSenderClient, Seq: 0}, fsm.transcript.order[0].ID)
+	assert.Equal(t, handshake.TypeClientHello, fsm.transcript.order[0].Type)
 	assert.Equal(t, expected, fsm.transcript.Bytes())
 	assert.Equal(t, 1, state.HandshakeSendSequence)
 }
@@ -305,9 +305,9 @@ func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscri
 	expectedTranscript := append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...)
 
 	assert.Equal(t, expectedTranscript, fsm.transcript.Bytes())
-	require.Len(t, fsm.transcript.messageOrder(), 2)
-	assert.Equal(t, transcriptMessageID{sender: transcriptSenderServer, Seq: 0}, fsm.transcript.messageOrder()[1].ID)
-	assert.Equal(t, handshake.TypeServerHello, fsm.transcript.messageOrder()[1].Type)
+	require.Len(t, fsm.transcript.order, 2)
+	assert.Equal(t, transcriptMessageID{sender: transcriptSenderServer, Seq: 0}, fsm.transcript.order[1].ID)
+	assert.Equal(t, handshake.TypeServerHello, fsm.transcript.order[1].Type)
 	assert.Equal(t, 1, state.HandshakeSendSequence)
 }
 
@@ -412,7 +412,7 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 2}, Type: handshake.TypeCertificate},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 3}, Type: handshake.TypeCertificateVerify},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 4}, Type: handshake.TypeFinished},
-	}, fsm.transcript.messageOrder())
+	}, fsm.transcript.order)
 
 	expectedSecrets, err := deriveHandshakeTrafficSecrets(
 		state.CipherSuite.HashFunc(),
@@ -733,7 +733,7 @@ func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {
 	assert.Equal(t, transcriptMessage{
 		ID:   transcriptMessageID{sender: transcriptSenderClient, Seq: 1},
 		Type: handshake.TypeFinished,
-	}, fsm.transcript.messageOrder()[6])
+	}, fsm.transcript.order[6])
 	assert.True(t, conn.setLocalEpochCalled)
 	assert.Equal(t, dtlsflight13.EpochHandshake, conn.localEpoch)
 }
@@ -871,7 +871,7 @@ func TestHandshakeFSM13ClientFlight5WithCertificate(t *testing.T) {
 		{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 1}, Type: handshake.TypeCertificate},
 		{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 2}, Type: handshake.TypeCertificateVerify},
 		{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 3}, Type: handshake.TypeFinished},
-	}, fsm.transcript.messageOrder()[7:])
+	}, fsm.transcript.order[7:])
 }
 
 func TestHandshakeFSM13ClientFlight5WithoutClientCertificate(t *testing.T) {
@@ -928,7 +928,7 @@ func TestHandshakeFSM13ClientFlight5WithoutClientCertificate(t *testing.T) {
 				assert.Equal(t, []transcriptMessage{
 					{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 1}, Type: handshake.TypeCertificate},
 					{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 2}, Type: handshake.TypeFinished},
-				}, fsm.transcript.messageOrder()[7:])
+				}, fsm.transcript.order[7:])
 
 				require.NoError(t, AppendOutboundHandshakeFlight(
 					transcriptThroughServerFinished,
@@ -980,7 +980,7 @@ func TestHandshakeFSM13ServerVerifiesClientFinishedAndCompletes(t *testing.T) {
 	assert.Equal(t, transcriptMessage{
 		ID:   transcriptMessageID{sender: transcriptSenderClient, Seq: 1},
 		Type: handshake.TypeFinished,
-	}, serverFSM.transcript.messageOrder()[6])
+	}, serverFSM.transcript.order[6])
 }
 
 func TestHandshakeFSM13ServerRejectsTamperedClientFinished(t *testing.T) {
@@ -1074,7 +1074,7 @@ func TestHandshakeFSM13RetransmittedFinalFlightDoesNotChangeTranscript(t *testin
 	assertFlight13RecvDoneClosed(t, first)
 
 	transcriptBefore := append([]byte(nil), serverFSM.transcript.Bytes()...)
-	orderBefore := append([]transcriptMessage(nil), serverFSM.transcript.messageOrder()...)
+	orderBefore := append([]transcriptMessage(nil), serverFSM.transcript.order...)
 	retransmit := RecvHandshakeState{Done: make(chan struct{}), IsRetransmit: true}
 	conn.recvHandshake <- retransmit
 	nextState, err = serverFSM.finish(context.Background(), conn)
@@ -1082,7 +1082,7 @@ func TestHandshakeFSM13RetransmittedFinalFlightDoesNotChangeTranscript(t *testin
 	assert.Equal(t, StateFinished, nextState)
 	assertFlight13RecvDoneClosed(t, retransmit)
 	assert.Equal(t, transcriptBefore, serverFSM.transcript.Bytes())
-	assert.Equal(t, orderBefore, serverFSM.transcript.messageOrder())
+	assert.Equal(t, orderBefore, serverFSM.transcript.order)
 }
 
 func serverFSMForClientFlight13(
@@ -1407,7 +1407,7 @@ func assertFlight13RecvDoneOpen(t *testing.T, state RecvHandshakeState) {
 func assertFlight13ClientTranscriptThroughServerFinished(t *testing.T, transcript *Transcript) {
 	t.Helper()
 
-	require.Len(t, transcript.messageOrder(), 6)
+	require.Len(t, transcript.order, 6)
 	assert.Equal(t, []transcriptMessage{
 		{ID: transcriptMessageID{sender: transcriptSenderClient, Seq: 0}, Type: handshake.TypeClientHello},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 0}, Type: handshake.TypeServerHello},
@@ -1415,7 +1415,7 @@ func assertFlight13ClientTranscriptThroughServerFinished(t *testing.T, transcrip
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 2}, Type: handshake.TypeCertificate},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 3}, Type: handshake.TypeCertificateVerify},
 		{ID: transcriptMessageID{sender: transcriptSenderServer, Seq: 4}, Type: handshake.TypeFinished},
-	}, transcript.messageOrder())
+	}, transcript.order)
 }
 
 func testHandshakeConfig13(t *testing.T) *dtlsconfig.HandshakeConfig {
@@ -1451,12 +1451,12 @@ func TestAppendOutboundHandshakeFlight13ClientHello(t *testing.T) {
 
 	err := AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt})
 	require.NoError(t, err)
-	require.Len(t, transcript.messageOrder(), 1)
-	require.Len(t, transcript.pendingMessages(), 1)
+	require.Len(t, transcript.order, 1)
+	require.Len(t, transcript.pending, 1)
 
-	assert.Equal(t, transcriptMessageID{sender: transcriptSenderClient, Seq: 3}, transcript.messageOrder()[0].ID)
-	assert.Equal(t, handshake.TypeClientHello, transcript.messageOrder()[0].Type)
-	assert.Equal(t, expected, transcript.pendingMessages()[0])
+	assert.Equal(t, transcriptMessageID{sender: transcriptSenderClient, Seq: 3}, transcript.order[0].ID)
+	assert.Equal(t, handshake.TypeClientHello, transcript.order[0].Type)
+	assert.Equal(t, expected, transcript.pending[0])
 	assert.Equal(t, expected, transcript.Bytes())
 }
 
@@ -1469,7 +1469,7 @@ func TestAppendOutboundHandshakeFlight13DuplicateNoop(t *testing.T) {
 
 	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt}))
 	assert.Equal(t, before, transcript.Bytes())
-	assert.Len(t, transcript.messageOrder(), 1)
+	assert.Len(t, transcript.order, 1)
 }
 
 func TestAppendOutboundHandshakeFlight13ChangedSameSequenceFails(t *testing.T) {
@@ -1503,19 +1503,19 @@ func TestAppendOutboundHandshakeFlight13HelloRetryRequest(t *testing.T) {
 	expectedTranscript := append(append([]byte(nil), messageHash...), helloRetryRequestCanonical...)
 	assert.Equal(t, expectedTranscript, transcript.Bytes())
 
-	sum, err := transcript.sum()
+	sum, err := transcript.SnapshotHash()
 	require.NoError(t, err)
 	assert.Equal(t, hashTranscript13(messageHash, helloRetryRequestCanonical), sum)
-	require.Len(t, transcript.messageOrder(), 2)
-	assert.Equal(t, handshake.TypeClientHello, transcript.messageOrder()[0].Type)
-	assert.Equal(t, handshake.TypeServerHello, transcript.messageOrder()[1].Type)
+	require.Len(t, transcript.order, 2)
+	assert.Equal(t, handshake.TypeClientHello, transcript.order[0].Type)
+	assert.Equal(t, handshake.TypeServerHello, transcript.order[1].Type)
 
 	before := append([]byte(nil), transcript.Bytes()...)
 	require.NoError(t, AppendOutboundHandshakeFlight(
 		transcript, false, cipherSuite, []*dtlsflight.Packet{helloRetryRequest},
 	))
 	assert.Equal(t, before, transcript.Bytes())
-	assert.Len(t, transcript.messageOrder(), 2)
+	assert.Len(t, transcript.order, 2)
 }
 
 func transcriptTestClientHelloPacket13(sessionID []byte, seq uint16) *dtlsflight.Packet {

--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -385,15 +385,6 @@ func CertificateVerifyInputFromTranscript(
 	return certificateVerifyInput(isClient, transcriptHash), nil
 }
 
-// certificateVerifyInputFromTranscript returns the TLS 1.3 CertificateVerify
-// input for the current transcript hash.
-func certificateVerifyInputFromTranscript(
-	isClient bool,
-	transcript *Transcript,
-) ([]byte, error) {
-	return CertificateVerifyInputFromTranscript(isClient, transcript)
-}
-
 // certificateVerifyInput returns the TLS 1.3 CertificateVerify input for a
 // transcript hash.
 func certificateVerifyInput(isClient bool, transcriptHash []byte) []byte {
@@ -439,16 +430,6 @@ func FinishedVerifyDataFromTranscript(
 	}
 
 	return finishedVerifyData(hashFunc, baseKey, transcriptHash)
-}
-
-// finishedVerifyDataFromTranscript returns verify_data for the current
-// transcript hash.
-func finishedVerifyDataFromTranscript(
-	hashFunc func() hash.Hash,
-	baseKey []byte,
-	transcript *Transcript,
-) ([]byte, error) {
-	return FinishedVerifyDataFromTranscript(hashFunc, baseKey, transcript)
 }
 
 // finishedVerifyData returns TLS 1.3 Finished verify_data.

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -186,17 +186,6 @@ func (t *Transcript) SnapshotHashWithSuffix(suffix []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// sum returns the current transcript hash.
-func (t *Transcript) sum() ([]byte, error) {
-	return t.SnapshotHash()
-}
-
-// sumWithSuffix returns the transcript hash with suffix appended, without
-// mutating the transcript.
-func (t *Transcript) sumWithSuffix(suffix []byte) ([]byte, error) {
-	return t.SnapshotHashWithSuffix(suffix)
-}
-
 func (t *Transcript) hasInitialClientHello() bool {
 	return len(t.order) == 1 &&
 		t.order[0].ID.sender == transcriptSenderClient &&
@@ -327,17 +316,7 @@ func (t *Transcript) replaceWith(src *Transcript) error {
 	return nil
 }
 
-// pending returns the messages waiting for hash selection.
-func (t *Transcript) pendingMessages() [][]byte {
-	return util.CloneByteSlices(t.pending)
-}
-
 // Bytes returns the canonical transcript bytes.
 func (t *Transcript) Bytes() []byte {
 	return append([]byte(nil), t.transcript...)
-}
-
-// order returns the transcript message order.
-func (t *Transcript) messageOrder() []transcriptMessage {
-	return append([]transcriptMessage(nil), t.order...)
 }

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -114,7 +114,7 @@ func TestHandshakeTranscript13DeferredHashSelection(t *testing.T) {
 
 	assert.NoError(t, transcript.selectHash(sha256.New))
 
-	sum, err := transcript.sum()
+	sum, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.Equal(t, hashTranscript13(expectedClientHello, serverHello), sum)
 }
@@ -122,7 +122,7 @@ func TestHandshakeTranscript13DeferredHashSelection(t *testing.T) {
 func TestHandshakeTranscript13RejectsSumBeforeHashSelection(t *testing.T) {
 	transcript := NewTranscript()
 
-	_, err := transcript.sum()
+	_, err := transcript.SnapshotHash()
 	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptHashNotSelected)
 }
 
@@ -149,7 +149,7 @@ func TestHandshakeTranscript13DuplicateHandling(t *testing.T) {
 
 	assert.NoError(t, transcript.appendCanonical(transcriptMessageID{sender: transcriptSenderServer}, serverHello))
 
-	sum, err := transcript.sum()
+	sum, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.Equal(t, hashTranscript13(clientHello, serverHello), sum)
 }
@@ -162,18 +162,18 @@ func TestAppendVerifiedInboundHandshake13DuplicateHandling(t *testing.T) {
 	transcript := NewTranscript()
 	require.NoError(t, transcript.AppendVerifiedInbound(true, cipherSuite, rawClientHello))
 	beforeBytes := transcript.Bytes()
-	beforePending := transcript.pendingMessages()
+	beforePending := util.CloneByteSlices(transcript.pending)
 
 	require.NoError(t, transcript.AppendVerifiedInbound(true, cipherSuite, rawClientHello))
 	assert.Equal(t, beforeBytes, transcript.Bytes())
-	assert.Equal(t, beforePending, transcript.pendingMessages())
-	assert.Len(t, transcript.messageOrder(), 1)
+	assert.Equal(t, beforePending, transcript.pending)
+	assert.Len(t, transcript.order, 1)
 
 	err := transcript.AppendVerifiedInbound(true, cipherSuite, changedClientHello)
 	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMessageChanged)
 	assert.Equal(t, beforeBytes, transcript.Bytes())
-	assert.Equal(t, beforePending, transcript.pendingMessages())
-	assert.Len(t, transcript.messageOrder(), 1)
+	assert.Equal(t, beforePending, transcript.pending)
+	assert.Len(t, transcript.order, 1)
 }
 
 func TestAppendVerifiedInboundHandshakeCacheItems13RequiresExplicitAuthentication(t *testing.T) {
@@ -189,8 +189,8 @@ func TestAppendVerifiedInboundHandshakeCacheItems13RequiresExplicitAuthenticatio
 	})
 	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptExplicitAuthenticationRequired)
 	assert.Empty(t, transcript.Bytes())
-	assert.Empty(t, transcript.pendingMessages())
-	assert.Empty(t, transcript.messageOrder())
+	assert.Empty(t, transcript.pending)
+	assert.Empty(t, transcript.order)
 }
 
 func TestHandshakeTranscript13RejectsInvalidCanonicalMessage(t *testing.T) {
@@ -222,7 +222,7 @@ func TestHandshakeTranscript13HelloRetryRequest(t *testing.T) {
 	messageHash := canonicalTranscriptHandshake13(handshake.TypeMessageHash, clientHello1Hash)
 	expected := hashTranscript13(messageHash, helloRetryRequest, clientHello2, serverHello)
 
-	sum, err := transcript.sum()
+	sum, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, sum)
 	assert.Equal(t, "MessageHash", handshake.TypeMessageHash.String())
@@ -249,9 +249,9 @@ func TestAppendVerifiedInboundHandshake13HelloRetryRequest(t *testing.T) {
 	sum, err := transcript.SnapshotHash()
 	require.NoError(t, err)
 	assert.Equal(t, hashTranscript13(messageHash, helloRetryRequest), sum)
-	require.Len(t, transcript.messageOrder(), 2)
-	assert.Equal(t, handshake.TypeClientHello, transcript.messageOrder()[0].Type)
-	assert.Equal(t, handshake.TypeServerHello, transcript.messageOrder()[1].Type)
+	require.Len(t, transcript.order, 2)
+	assert.Equal(t, handshake.TypeClientHello, transcript.order[0].Type)
+	assert.Equal(t, handshake.TypeServerHello, transcript.order[1].Type)
 }
 
 func TestHandshakeTranscript13HelloRetryRequestBinderFork(t *testing.T) {
@@ -266,11 +266,11 @@ func TestHandshakeTranscript13HelloRetryRequestBinderFork(t *testing.T) {
 	assert.NoError(t, transcript.applyHelloRetryRequest())
 	assert.NoError(t, transcript.appendCanonical(transcriptMessageID{sender: transcriptSenderServer}, helloRetryRequest))
 
-	mainSumBefore, err := transcript.sum()
+	mainSumBefore, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.ErrorIs(t, validateCanonicalHandshake(truncatedClientHello2), dtlserrors.ErrInvalidHandshakeTranscriptMessage)
 
-	binderTranscriptHash, err := transcript.sumWithSuffix(truncatedClientHello2)
+	binderTranscriptHash, err := transcript.SnapshotHashWithSuffix(truncatedClientHello2)
 	assert.NoError(t, err)
 
 	clientHello1Hash := hashTranscript13(clientHello1)
@@ -283,7 +283,7 @@ func TestHandshakeTranscript13HelloRetryRequestBinderFork(t *testing.T) {
 	expectedBinder := hmacSHA25613(binderKey, expectedBinderTranscriptHash)
 	assert.Equal(t, expectedBinder, binder)
 
-	mainSumAfter, err := transcript.sum()
+	mainSumAfter, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.Equal(t, mainSumBefore, mainSumAfter)
 
@@ -293,7 +293,7 @@ func TestHandshakeTranscript13HelloRetryRequestBinderFork(t *testing.T) {
 		t, transcript.appendCanonical(transcriptMessageID{sender: transcriptSenderClient, Seq: 1}, clientHello2),
 	)
 
-	sum, err := transcript.sum()
+	sum, err := transcript.SnapshotHash()
 	assert.NoError(t, err)
 	assert.Equal(t, hashTranscript13(messageHash, helloRetryRequest, clientHello2), sum)
 }
@@ -616,7 +616,7 @@ func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
 
 	require.NoError(t, DeriveAndStoreHandshakeTrafficSecrets(state, transcript))
 
-	transcriptHash, err := transcript.sum()
+	transcriptHash, err := transcript.SnapshotHash()
 	require.NoError(t, err)
 	expected, err := deriveHandshakeTrafficSecrets(cipherSuite.HashFunc(), state.KeyAgreementSecret, transcriptHash)
 	require.NoError(t, err)
@@ -1045,9 +1045,9 @@ func TestDTLS13TranscriptAuthenticatedHandshakeInputs(t *testing.T) {
 		Seq:    1,
 	}, certificate))
 
-	certVerifyInput, err := certificateVerifyInputFromTranscript(false, transcript)
+	certVerifyInput, err := CertificateVerifyInputFromTranscript(false, transcript)
 	require.NoError(t, err)
-	certVerifyTranscriptHash, err := transcript.sum()
+	certVerifyTranscriptHash, err := transcript.SnapshotHash()
 	require.NoError(t, err)
 	assert.Equal(t, certVerifyTranscriptHash, certVerifyInput[len(certVerifyInput)-sha256.Size:])
 
@@ -1057,13 +1057,13 @@ func TestDTLS13TranscriptAuthenticatedHandshakeInputs(t *testing.T) {
 		Seq:    2,
 	}, certVerify))
 
-	verifyData, err := finishedVerifyDataFromTranscript(
+	verifyData, err := FinishedVerifyDataFromTranscript(
 		sha256.New,
 		state.KeySchedule.HandshakeTraffic.Server,
 		transcript,
 	)
 	require.NoError(t, err)
-	finishedTranscriptHash, err := transcript.sum()
+	finishedTranscriptHash, err := transcript.SnapshotHash()
 	require.NoError(t, err)
 	assert.NoError(t, verifyFinishedData(
 		sha256.New,


### PR DESCRIPTION
Inline one-call helpers and remove production accessors that existed only for tests.

Update callers and tests to use the underlying APIs directly without changing behavior.