### PR TITLE
Clean fsm13

### DIFF
--- a/internal/flight/flight13/flight.go
+++ b/internal/flight/flight13/flight.go
@@ -32,3 +32,16 @@ func (f Flight) String() string {
 		return "Invalid Flight"
 	}
 }
+
+// IsLastSendFlight reports whether f is the final handshake flight sent by
+// either endpoint. DTLS 1.3 completes when the client sends Flight 5.
+func (f Flight) IsLastSendFlight() bool {
+	return f == Flight5
+}
+
+// IsLastRecvFlight reports whether f is the final handshake flight received
+// by either endpoint. The server completes when it receives the client's
+// Flight 5 while it is in Flight 4.
+func (f Flight) IsLastRecvFlight() bool {
+	return f == Flight4
+}

--- a/internal/handshake/conn.go
+++ b/internal/handshake/conn.go
@@ -9,6 +9,7 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 // RecvHandshakeState signals that a handshake packet has been received.
@@ -16,6 +17,27 @@ type RecvHandshakeState struct {
 	Done         chan struct{}
 	IsRetransmit bool
 	Records      []protocol.RecordNumber
+}
+
+// recvHandshakeLease keeps the reader paused while an FSM transition needs
+// exclusive access to the received records. Releasing the lease lets the
+// reader process the next datagram.
+type recvHandshakeLease struct {
+	done chan struct{}
+}
+
+func (l *recvHandshakeLease) retain(state RecvHandshakeState) {
+	l.release()
+	l.done = state.Done
+}
+
+func (l *recvHandshakeLease) release() {
+	if l.done == nil {
+		return
+	}
+
+	close(l.done)
+	l.done = nil
 }
 
 // FSM is the common DTLS handshake FSM interface.
@@ -39,4 +61,18 @@ func sideString(isClient bool) string {
 	}
 
 	return "server"
+}
+
+func sendACK(ctx context.Context, conn Conn, epoch uint16, records []protocol.RecordNumber) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	return conn.WritePackets(ctx, []*dtlsflight.Packet{{
+		Record: &recordlayer.RecordLayer{
+			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: epoch},
+			Content: &protocol.ACK{Records: records},
+		},
+		ShouldEncrypt: true,
+	}})
 }

--- a/internal/handshake/fsm.go
+++ b/internal/handshake/fsm.go
@@ -5,7 +5,9 @@ package dtlshandshake
 
 import (
 	"context"
+	"time"
 
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 )
@@ -60,4 +62,35 @@ func notifyAlert(ctx context.Context, conn Conn, dtlsAlert *alert.Alert, err err
 	}
 
 	return err
+}
+
+func handleRetransmitTimeout(
+	retransmit bool,
+	retransmitInterval *time.Duration,
+	cfg *dtlsconfig.HandshakeConfig,
+) State {
+	if !retransmit {
+		return StateWaiting
+	}
+
+	// RFC 4347 4.2.4.1: retransmissions use exponential backoff, capped at
+	// 60 seconds.
+	if !cfg.DisableRetransmitBackoff {
+		*retransmitInterval *= 2
+	}
+	if *retransmitInterval > time.Second*60 {
+		*retransmitInterval = time.Second * 60
+	}
+
+	return StateSending
+}
+
+func handleWaitCancellation(
+	retransmitInterval *time.Duration,
+	cfg *dtlsconfig.HandshakeConfig,
+	err error,
+) (State, error) {
+	*retransmitInterval = cfg.InitialRetransmitInterval
+
+	return StateErrored, err
 }

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -218,25 +218,9 @@ func (s *fsm12) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 			return StatePreparing, nil
 
 		case <-retransmitTimer.C:
-			if !s.retransmit {
-				return StateWaiting, nil
-			}
-
-			// RFC 4347 4.2.4.1:
-			// Implementations SHOULD use an initial timer value of 1 second (the minimum defined in RFC 2988 [RFC2988])
-			// and double the value at each retransmission, up to no less than the RFC 2988 maximum of 60 seconds.
-			if !s.cfg.DisableRetransmitBackoff {
-				s.retransmitInterval *= 2
-			}
-			if s.retransmitInterval > time.Second*60 {
-				s.retransmitInterval = time.Second * 60
-			}
-
-			return StateSending, nil
+			return handleRetransmitTimeout(s.retransmit, &s.retransmitInterval, s.cfg), nil
 		case <-ctx.Done():
-			s.retransmitInterval = s.cfg.InitialRetransmitInterval
-
-			return StateErrored, ctx.Err()
+			return handleWaitCancellation(&s.retransmitInterval, s.cfg, ctx.Err())
 		}
 	}
 }

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -7,17 +7,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/pion/dtls/v3/internal/ciphersuite/types"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
-	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
-	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
-	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 // [RFC9147 Section-5.8.1]
@@ -74,18 +69,10 @@ type fsm13 struct {
 	flights            []*dtlsflight.Packet
 	retransmit         bool
 	retransmitInterval time.Duration
-	state              *dtlsstate.State13
-	cache              *dtlsflight.Cache
-	cfg                *dtlsconfig.HandshakeConfig
-	transcript         *Transcript
-	closed             chan struct{}
-	establishment      *Establishment
-	pendingRecvDone    chan struct{} // keeps the reader paused across a prepare/send transition
-}
-
-type receivedFlightTransition struct {
-	state             State
-	retainPendingRecv bool
+	handshakeContext
+	closed        chan struct{}
+	establishment *Establishment
+	received      recvHandshakeLease // keeps the reader paused across a prepare/send transition
 }
 
 func NewFSM13(
@@ -129,105 +116,20 @@ func newFSM13WithEstablishment(
 		currentFlight:      initialFlight,
 		flights:            initialFlights,
 		retransmit:         initialFlights != nil,
-		state:              state,
-		cache:              cache,
-		cfg:                cfg,
-		transcript:         initialTranscript,
+		handshakeContext:   handshakeContext{state: state, cache: cache, cfg: cfg, transcript: initialTranscript},
 		retransmitInterval: cfg.InitialRetransmitInterval,
 		closed:             make(chan struct{}),
 		establishment:      establishment,
 	}
-	if err := fsm.seedTranscriptFromInitialFlights(); err != nil {
+	if err := fsm.seedInitialFlights(fsm.flights, fsm.retransmit); err != nil {
 		return nil, err
 	}
 
 	return fsm, nil
 }
 
-// seedTranscriptFromInitialFlights imports the dual-stack ClientHello generated
-// before the DTLS 1.3 FSM exists.
-func (s *fsm13) seedTranscriptFromInitialFlights() error {
-	if !s.state.IsClient {
-		return nil
-	}
-
-	appended, err := AppendClientHelloInitialFlights(s.transcript, s.flights)
-	if err != nil {
-		return err
-	}
-	if s.retransmit && !appended {
-		return dtlserrors.ErrHandshakeTranscriptMissingClientHello
-	}
-
-	return nil
-}
-
-func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflight.Packet) (bool, error) {
-	if transcript == nil {
-		return false, dtlserrors.ErrHandshakeTranscriptMissingClientHello
-	}
-
-	appended := false
-	for _, p := range flights {
-		seq, canonical, ok, err := canonicalClientHelloInitialFlight13(p)
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			continue
-		}
-		if err := transcript.appendCanonical(transcriptMessageID{
-			sender: transcriptSenderClient,
-			Seq:    seq,
-		}, canonical); err != nil {
-			return false, err
-		}
-		appended = true
-	}
-
-	return appended, nil
-}
-
-// ValidateClientHelloInitialFlights verifies that the dual-stack initial flight
-// contains a canonical ClientHello before it is written.
-func ValidateClientHelloInitialFlights(flights []*dtlsflight.Packet) error {
-	appended, err := AppendClientHelloInitialFlights(NewTranscript(), flights)
-	if err != nil {
-		return err
-	}
-	if !appended {
-		return dtlserrors.ErrHandshakeTranscriptMissingClientHello
-	}
-
-	return nil
-}
-
-func canonicalClientHelloInitialFlight13(p *dtlsflight.Packet) (uint16, []byte, bool, error) {
-	if p == nil || p.Record == nil {
-		return 0, nil, false, nil
-	}
-	hand, ok := p.Record.Content.(*handshake.Handshake)
-	if !ok {
-		return 0, nil, false, nil
-	}
-	if hand.Message == nil || hand.Message.Type() != handshake.TypeClientHello {
-		return 0, nil, false, nil
-	}
-
-	raw, err := hand.Marshal()
-	if err != nil {
-		return 0, nil, false, err
-	}
-	canonical, err := canonicalHandshake(raw)
-	if err != nil {
-		return 0, nil, false, err
-	}
-
-	return hand.Header.MessageSequence, canonical, true, nil
-}
-
 func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
-	defer s.releasePendingRecv()
+	defer s.received.release()
 
 	return runHandshakeFSM(
 		ctx,
@@ -257,7 +159,7 @@ func (s *fsm13) Done() <-chan struct{} {
 func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err error) {
 	defer func() {
 		if err != nil {
-			s.releasePendingRecv()
+			s.received.release()
 		}
 	}()
 
@@ -280,197 +182,35 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 	}
 
 	s.flights = pkts
-	if err := s.commitPreparedFlights(conn); err != nil {
+	if err := s.commitPreparedFlight(conn, s.currentFlight, s.flights); err != nil {
 		return StateErrored, err
-	}
-	if !s.state.IsClient && s.currentFlight == dtlsflight13.Flight4 {
-		if err := DeriveAndStoreApplicationTrafficSecrets(s.state, s.transcript); err != nil {
-			return StateErrored, err
-		}
 	}
 
 	return StateSending, nil
 }
 
-func (s *fsm13) commitPreparedFlights(conn Conn) error { //nolint:cyclop,nestif
-	epoch := s.cfg.InitialEpoch
-	nextEpoch := epoch
-	protectedFlightStart := len(s.flights)
-	for i, p := range s.flights {
-		p.Record.Header.Epoch += epoch
-		if p.Record.Header.Epoch > nextEpoch {
-			nextEpoch = p.Record.Header.Epoch
-		}
-		if p.ShouldEncrypt && protectedFlightStart == len(s.flights) {
-			protectedFlightStart = i
-		}
-		if h, ok := p.Record.Content.(*handshake.Handshake); ok {
-			h.Header.MessageSequence = uint16(s.state.HandshakeSendSequence) //nolint:gosec // G115
-			s.state.HandshakeSendSequence++
-		}
-	}
-
-	if protectedFlightStart == len(s.flights) { //nolint:nestif
-		if err := s.appendCommittedOutboundHandshakeFlight(s.flights); err != nil {
-			return err
-		}
-	} else {
-		if err := s.appendCommittedOutboundHandshakeFlight(s.flights[:protectedFlightStart]); err != nil {
-			return err
-		}
-		if err := s.ensureHandshakeTrafficSecrets(); err != nil {
-			return err
-		}
-		if err := InitHandshakeRecordProtection(s.state); err != nil {
-			return err
-		}
-		if err := s.appendCommittedOutboundHandshakeFlight(s.flights[protectedFlightStart:]); err != nil {
-			return err
-		}
-	}
-
-	if epoch != nextEpoch {
-		s.cfg.Log.Tracef("[handshake13:%s] -> changeCipherSpec (epoch: %d)", sideString(s.state.IsClient), nextEpoch)
-		conn.SetLocalEpoch(nextEpoch)
-	}
-
-	return nil
-}
-
-func (s *fsm13) ensureHandshakeTrafficSecrets() error {
-	secrets := s.state.KeySchedule.HandshakeTraffic
-	if len(secrets.Client) == 0 && len(secrets.Server) == 0 {
-		return DeriveAndStoreHandshakeTrafficSecrets(s.state, s.transcript)
-	}
-
-	return selectHashIfReady(s.transcript, s.state.CipherSuite)
-}
-
-func (s *fsm13) appendCommittedOutboundHandshakeFlight(pkts []*dtlsflight.Packet) error {
-	for _, p := range pkts {
-		if err := s.populateOutboundCertificateVerify(p); err != nil {
-			return err
-		}
-		if err := s.populateOutboundFinished(p); err != nil {
-			return err
-		}
-		if err := AppendOutboundHandshakeFlight(
-			s.transcript,
-			s.state.IsClient,
-			s.state.CipherSuite,
-			[]*dtlsflight.Packet{p},
-		); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *fsm13) populateOutboundCertificateVerify(pkt *dtlsflight.Packet) error {
-	if pkt == nil || pkt.Record == nil {
-		return nil
-	}
-	h, ok := pkt.Record.Content.(*handshake.Handshake)
-	if !ok {
-		return nil
-	}
-	certificateVerify, ok := h.Message.(*handshake.MessageCertificateVerify)
-	if !ok || len(certificateVerify.Signature) != 0 {
-		return nil
-	}
-	if pkt.CertificateVerifySigner == nil {
-		return dtlserrors.ErrInvalidPrivateKey
-	}
-
-	input, err := CertificateVerifyInputFromTranscript(s.state.IsClient, s.transcript)
-	if err != nil {
-		return err
-	}
-	certificateVerify.Signature, err = dtlscrypto.GenerateCertificateVerify(
-		input,
-		pkt.CertificateVerifySigner,
-		certificateVerify.HashAlgorithm,
-		certificateVerify.SignatureAlgorithm,
-	)
-
-	return err
-}
-
-func (s *fsm13) populateOutboundFinished(p *dtlsflight.Packet) error {
-	if p == nil || p.Record == nil {
-		return nil
-	}
-	h, ok := p.Record.Content.(*handshake.Handshake)
-	if !ok {
-		return nil
-	}
-	finished, ok := h.Message.(*handshake.MessageFinished)
-	if !ok || len(finished.VerifyData) != 0 {
-		return nil
-	}
-	if s.state.CipherSuite == nil {
-		return dtlserrors.ErrCipherSuiteNotSet
-	}
-
-	baseKey, err := ServerHandshakeFinishedBaseKey(s.state)
-	if s.state.IsClient {
-		baseKey, err = ClientHandshakeFinishedBaseKey(s.state)
-	}
-	if err != nil {
-		return err
-	}
-
-	verifyData, err := FinishedVerifyDataFromTranscript(s.state.CipherSuite.HashFunc(), baseKey, s.transcript)
-	if err != nil {
-		return err
-	}
-	finished.VerifyData = verifyData
-
-	return nil
-}
-
 func (s *fsm13) send(ctx context.Context, conn Conn) (State, error) {
-	defer s.releasePendingRecv()
+	defer s.received.release()
 
 	if err := conn.WritePackets(ctx, s.flights); err != nil {
 		return StateErrored, err
 	}
-	if !s.state.IsClient &&
-		s.currentFlight == dtlsflight13.Flight4 &&
-		s.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake {
-		// Only the first send advances the epoch and drains packets. A timer
-		// retransmission has no receive-side rendezvous and the reader is active.
-		s.state.RemoteEpoch.Store(dtlsflight13.EpochHandshake)
-		if err := conn.HandleQueuedPackets(ctx); err != nil {
-			return StateErrored, err
-		}
+	finished, err := s.afterSend(ctx, conn, s.currentFlight)
+	if err != nil {
+		return StateErrored, err
 	}
-	if s.state.IsClient && s.currentFlight == dtlsflight13.Flight5 {
-		if err := s.activateApplicationRecordProtection(ctx, conn); err != nil {
-			return StateErrored, err
-		}
-
+	if finished {
 		return StateFinished, nil
 	}
 
 	return StateWaiting, nil
 }
 
-func (s *fsm13) transitionRequiresReaderPause(nextFlight dtlsflight13.Flight) bool {
-	if s.state.IsClient {
-		return nextFlight == dtlsflight13.Flight5
-	}
-
-	return nextFlight == dtlsflight13.Flight4 &&
-		s.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake
-}
-
 func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) {
 	retainPendingRecv := false
 	defer func() {
 		if !retainPendingRecv {
-			s.releasePendingRecv()
+			s.received.release()
 		}
 	}()
 
@@ -479,156 +219,23 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) {
 	for {
 		select {
 		case received := <-conn.RecvHandshake():
-			nextFlight, err := s.parseReceivedFlight(ctx, conn, received)
+			transition, err := s.handleReceivedFlight(ctx, conn, received)
 			if err != nil {
 				return StateErrored, err
 			}
-			if nextFlight == 0 {
-				s.releasePendingRecv()
-
+			if transition.state == StateWaiting {
 				continue
-			}
-
-			transition, err := s.advanceAfterReceivedFlight(ctx, conn, nextFlight, received.Records)
-			if err != nil {
-				return StateErrored, err
 			}
 			retainPendingRecv = transition.retainPendingRecv
 
 			return transition.state, nil
 
 		case <-retransmitTimer.C:
-			return s.handleRetransmitTimeout(), nil
+			return handleRetransmitTimeout(s.retransmit, &s.retransmitInterval, s.cfg), nil
 		case <-ctx.Done():
-			return s.handleWaitCancellation(ctx.Err())
+			return handleWaitCancellation(&s.retransmitInterval, s.cfg, ctx.Err())
 		}
 	}
-}
-
-func (s *fsm13) parseReceivedFlight(
-	ctx context.Context,
-	conn Conn,
-	received RecvHandshakeState,
-) (dtlsflight13.Flight, error) {
-	// Keep the reader paused while this receive state is parsed.
-	s.pendingRecvDone = received.Done
-	if !received.IsRetransmit {
-		s.retransmitInterval = s.cfg.InitialRetransmitInterval
-	}
-
-	nextFlight, dtlsAlert, err, ok := dtlsflight13.Parse(
-		ctx,
-		s.currentFlight,
-		conn,
-		s.parseDependencies(),
-	)
-	if !ok {
-		if alertErr := conn.Notify(ctx, alert.Fatal, alert.InternalError); alertErr != nil {
-			return 0, alertErr
-		}
-
-		return 0, dtlserrors.ErrFlightUnimplemented13
-	}
-	if err = notifyAlert(ctx, conn, dtlsAlert, err); err != nil {
-		return 0, err
-	}
-
-	return nextFlight, nil
-}
-
-func (s *fsm13) advanceAfterReceivedFlight(
-	ctx context.Context,
-	conn Conn,
-	nextFlight dtlsflight13.Flight,
-	receivedRecords []protocol.RecordNumber,
-) (receivedFlightTransition, error) {
-	if s.state.IsClient && nextFlight == dtlsflight13.Flight5 {
-		if err := DeriveAndStoreApplicationTrafficSecrets(s.state, s.transcript); err != nil {
-			return receivedFlightTransition{}, err
-		}
-	}
-	if !s.state.IsClient &&
-		s.currentFlight == dtlsflight13.Flight4 &&
-		nextFlight == dtlsflight13.Flight4 {
-		if err := s.activateApplicationRecordProtection(ctx, conn); err != nil {
-			return receivedFlightTransition{}, err
-		}
-		if err := s.sendACK(ctx, conn, receivedRecords); err != nil {
-			return receivedFlightTransition{}, err
-		}
-
-		return receivedFlightTransition{state: StateFinished}, nil
-	}
-
-	s.cfg.Log.Tracef(
-		"[handshake13:%s] %s -> %s",
-		sideString(s.state.IsClient),
-		s.currentFlight.String(),
-		nextFlight.String(),
-	)
-	transition := receivedFlightTransition{
-		state:             StatePreparing,
-		retainPendingRecv: s.transitionRequiresReaderPause(nextFlight),
-	}
-	s.currentFlight = nextFlight
-
-	return transition, nil
-}
-
-func (s *fsm13) handleRetransmitTimeout() State {
-	if !s.retransmit {
-		return StateWaiting
-	}
-
-	if !s.cfg.DisableRetransmitBackoff {
-		s.retransmitInterval *= 2
-	}
-	if s.retransmitInterval > time.Second*60 {
-		s.retransmitInterval = time.Second * 60
-	}
-
-	return StateSending
-}
-
-func (s *fsm13) handleWaitCancellation(err error) (State, error) {
-	s.retransmitInterval = s.cfg.InitialRetransmitInterval
-
-	return StateErrored, err
-}
-
-func (s *fsm13) parseDependencies() dtlsflight13.ParseDependencies {
-	return dtlsflight13.ParseDependencies{
-		State:  s.state,
-		Cache:  s.cache,
-		Config: s.cfg,
-		Hooks: dtlsflight13.ParseHooks{
-			InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
-				return AppendVerifiedInboundHandshakeCacheItems(s.transcript, cipherSuite, items)
-			},
-			ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
-				return VerifyAndAppendProtectedHandshakeCacheItems13(
-					s.transcript,
-					s.state,
-					s.cfg,
-					cipherSuite,
-					items,
-				)
-			},
-			HandshakeTrafficSecretDeriver: func(state *dtlsstate.State13) error {
-				return DeriveAndStoreHandshakeTrafficSecrets(state, s.transcript)
-			},
-			HandshakeRecordProtectionInitializer: InitHandshakeRecordProtection,
-		},
-	}
-}
-
-func (s *fsm13) releasePendingRecv() {
-	if s.pendingRecvDone == nil {
-		return
-	}
-
-	close(s.pendingRecvDone)
-	s.pendingRecvDone = nil
 }
 
 func (s *fsm13) finish(ctx context.Context, c Conn) (State, error) {
@@ -643,192 +250,34 @@ func (s *fsm13) finish(ctx context.Context, c Conn) (State, error) {
 	}
 }
 
-func (s *fsm13) activateApplicationRecordProtection(ctx context.Context, c Conn) error {
-	if err := InitApplicationRecordProtection(s.state); err != nil {
-		return err
-	}
-	c.SetLocalEpoch(dtlsflight13.EpochApplication)
-	s.state.RemoteEpoch.Store(dtlsflight13.EpochApplication)
-
-	return c.HandleQueuedPackets(ctx)
-}
-
-func (s *fsm13) sendACK(ctx context.Context, c Conn, records []protocol.RecordNumber) error {
-	if len(records) == 0 {
-		return nil
+func (s *fsm13) handleReceivedFlight(
+	ctx context.Context,
+	conn Conn,
+	received RecvHandshakeState,
+) (receivedFlightTransition, error) {
+	// Keep the reader paused while this receive state is parsed.
+	s.received.retain(received)
+	if !received.IsRetransmit {
+		s.retransmitInterval = s.cfg.InitialRetransmitInterval
 	}
 
-	epoch := s.state.GetLocalEpoch()
-
-	return c.WritePackets(ctx, []*dtlsflight.Packet{{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: epoch},
-			Content: &protocol.ACK{Records: records},
-		},
-		ShouldEncrypt: true,
-	}})
-}
-
-func transcriptSenderForSide13(isClient bool) transcriptSender {
-	if isClient {
-		return transcriptSenderClient
-	}
-
-	return transcriptSenderServer
-}
-
-func AppendOutboundHandshakeFlight(
-	transcript *Transcript,
-	isClient bool,
-	cipherSuite dtlsconfig.CipherSuite,
-	pkts []*dtlsflight.Packet,
-) error {
-	if transcript == nil {
-		return nil
-	}
-
-	sender := transcriptSenderForSide13(isClient)
-	for _, p := range pkts {
-		handshakeMessage, canonical, ok, err := canonicalOutboundHandshake13(p)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			continue
-		}
-
-		if err := appendHandshake13(
-			transcript,
-			sender,
-			cipherSuite,
-			handshakeMessage.Header.MessageSequence,
-			handshakeMessage.Message,
-			canonical,
-		); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func canonicalOutboundHandshake13(p *dtlsflight.Packet) (*handshake.Handshake, []byte, bool, error) {
-	if p == nil || p.Record == nil {
-		return nil, nil, false, nil
-	}
-
-	hs, ok := p.Record.Content.(*handshake.Handshake)
-	if !ok || hs.Message == nil {
-		return nil, nil, false, nil
-	}
-
-	raw, err := hs.Marshal()
+	nextFlight, err := s.parseReceivedFlight(ctx, conn, s.currentFlight)
 	if err != nil {
-		return nil, nil, false, err
+		return receivedFlightTransition{}, err
 	}
-	canonical, err := canonicalHandshake(raw)
+	if nextFlight == 0 {
+		s.received.release()
+
+		return receivedFlightTransition{state: StateWaiting}, nil
+	}
+
+	transition, err := s.advanceAfterReceivedFlight(ctx, conn, s.currentFlight, nextFlight, received.Records)
 	if err != nil {
-		return nil, nil, false, err
+		return receivedFlightTransition{}, err
+	}
+	if transition.nextFlight != 0 {
+		s.currentFlight = transition.nextFlight
 	}
 
-	return hs, canonical, true, nil
-}
-
-// AppendVerifiedInbound appends an inbound handshake message to the transcript
-// after the caller has validated and accepted it. For CertificateVerify and
-// Finished, callers must authenticate the message against SnapshotHash before
-// calling this method.
-func (t *Transcript) AppendVerifiedInbound(
-	isClient bool,
-	cipherSuite dtlsconfig.CipherSuite,
-	raw []byte,
-) error {
-	if t == nil {
-		return nil
-	}
-
-	canonical, err := canonicalHandshake(raw)
-	if err != nil {
-		return err
-	}
-
-	var keyExchangeAlgorithm types.KeyExchangeAlgorithm
-	if cipherSuite != nil {
-		keyExchangeAlgorithm = cipherSuite.KeyExchangeAlgorithm()
-	}
-
-	h := &handshake.Handshake{
-		KeyExchangeAlgorithm: keyExchangeAlgorithm,
-	}
-	if err := h.Unmarshal(raw); err != nil {
-		return err
-	}
-
-	return appendHandshake13(
-		t,
-		transcriptSenderForSide13(isClient),
-		cipherSuite,
-		h.Header.MessageSequence,
-		h.Message,
-		canonical,
-	)
-}
-
-// AppendVerifiedInboundHandshakeCacheItems appends inbound cache items to the
-// transcript after the caller has validated and accepted each item.
-//
-// Messages that require explicit authentication, such as CertificateVerify and
-// Finished, must be verified first and then appended with AppendVerifiedInbound.
-func AppendVerifiedInboundHandshakeCacheItems(
-	transcript *Transcript,
-	cipherSuite dtlsconfig.CipherSuite,
-	items []*dtlsflight.HandshakeCacheItem,
-) error {
-	if transcript == nil {
-		return nil
-	}
-
-	for _, item := range items {
-		if requiresExplicitAuthenticationBeforeTranscriptCommit(item.Typ) {
-			return dtlserrors.ErrHandshakeTranscriptExplicitAuthenticationRequired
-		}
-		if err := transcript.AppendVerifiedInbound(item.IsClient, cipherSuite, item.Data); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func requiresExplicitAuthenticationBeforeTranscriptCommit(typ handshake.Type) bool {
-	return typ == handshake.TypeCertificateVerify || typ == handshake.TypeFinished
-}
-
-func appendHandshake13(
-	transcript *Transcript,
-	sender transcriptSender,
-	cipherSuite dtlsconfig.CipherSuite,
-	seq uint16,
-	message handshake.Message,
-	canonical []byte,
-) error {
-	id := transcriptMessageID{
-		sender: sender,
-		Seq:    seq,
-	}
-	if sh, ok := message.(*handshake.MessageServerHello); ok && dtlsflight13.IsHelloRetryRequest(sh) {
-		duplicate, err := transcript.hasCanonical(id, canonical)
-		if err != nil || duplicate {
-			return err
-		}
-
-		if err := selectHashIfReady(transcript, cipherSuite); err != nil {
-			return err
-		}
-		if err := transcript.applyHelloRetryRequest(); err != nil {
-			return err
-		}
-	}
-
-	return transcript.appendCanonical(id, canonical)
+	return transition, nil
 }

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -32,26 +32,14 @@ import (
 
 var testCurves13 = []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384} //nolint:gochecknoglobals
 
-type handshakeContext13 struct {
-	state      *dtlsstate.State13
-	cache      *dtlsflight.Cache
-	cfg        *dtlsconfig.HandshakeConfig
-	transcript *Transcript
-}
-
-func (s *fsm13) flightContext() *handshakeContext13 {
-	return &handshakeContext13{
-		state:      s.state,
-		cache:      s.cache,
-		cfg:        s.cfg,
-		transcript: s.transcript,
-	}
+func (s *fsm13) flightContext() *handshakeContext {
+	return &s.handshakeContext
 }
 
 func flight13GenerateForTest(
 	testingT require.TestingT,
 	flight dtlsflight13.Flight,
-	flightCtx *handshakeContext13,
+	flightCtx *handshakeContext,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {
 		helper.Helper()
@@ -116,6 +104,67 @@ func newTestState13(isClient bool) *dtlsstate.State13 {
 	return &state
 }
 
+func TestHandshakeFSMRetransmitTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		retransmit        bool
+		disableBackoff    bool
+		initial, expected time.Duration
+		expectedState     State
+	}{
+		{
+			name:          "no retransmit",
+			initial:       time.Second,
+			expected:      time.Second,
+			expectedState: StateWaiting,
+		},
+		{
+			name:          "backoff",
+			retransmit:    true,
+			initial:       time.Second,
+			expected:      2 * time.Second,
+			expectedState: StateSending,
+		},
+		{
+			name:           "backoff disabled",
+			retransmit:     true,
+			disableBackoff: true,
+			initial:        time.Second,
+			expected:       time.Second,
+			expectedState:  StateSending,
+		},
+		{
+			name:          "cap",
+			retransmit:    true,
+			initial:       45 * time.Second,
+			expected:      60 * time.Second,
+			expectedState: StateSending,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			interval := test.initial
+			cfg := &dtlsconfig.HandshakeConfig{DisableRetransmitBackoff: test.disableBackoff}
+
+			assert.Equal(t, test.expectedState, handleRetransmitTimeout(test.retransmit, &interval, cfg))
+			assert.Equal(t, test.expected, interval)
+		})
+	}
+}
+
+func TestHandshakeFSMWaitCancellationResetsRetransmitInterval(t *testing.T) {
+	cfg := &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second}
+	interval := 30 * time.Second
+	errExpected := context.Canceled
+
+	state, err := handleWaitCancellation(&interval, cfg, errExpected)
+
+	assert.Equal(t, StateErrored, state)
+	assert.ErrorIs(t, err, errExpected)
+	assert.Equal(t, cfg.InitialRetransmitInterval, interval)
+}
+
 func TestHandshakeFSM13OwnsTranscriptAndPropagatesContext(t *testing.T) {
 	state := newTestState13(true)
 	cache := dtlsflight.NewCache()
@@ -136,10 +185,10 @@ func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
 	state := newTestState13(true)
 	state.LocalEpoch.Store(dtlsflight13.EpochApplication)
 	conn := &flightTestConn{}
-	fsm := &fsm13{state: state}
+	fsm := &fsm13{handshakeContext: handshakeContext{state: state}}
 	records := []protocol.RecordNumber{{Epoch: 2, SequenceNumber: 7}}
 
-	require.NoError(t, fsm.sendACK(context.Background(), conn, records))
+	require.NoError(t, sendACK(context.Background(), conn, fsm.state.GetLocalEpoch(), records))
 	require.Len(t, conn.writtenPackets, 1)
 	assert.True(t, conn.writtenPackets[0].ShouldEncrypt)
 	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Record.Header.Epoch)
@@ -150,9 +199,9 @@ func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
 
 func TestHandshakeFSM13DoesNotSendEmptyACK(t *testing.T) {
 	conn := &flightTestConn{}
-	fsm := &fsm13{state: newTestState13(false)}
+	fsm := &fsm13{handshakeContext: handshakeContext{state: newTestState13(false)}}
 
-	require.NoError(t, fsm.sendACK(context.Background(), conn, nil))
+	require.NoError(t, sendACK(context.Background(), conn, fsm.state.GetLocalEpoch(), nil))
 	assert.Empty(t, conn.writtenPackets)
 }
 
@@ -166,7 +215,7 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 		return &ch
 	}
 
-	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext13{
+	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext{
 		state: state,
 		cache: cache,
 		cfg:   cfg,
@@ -202,7 +251,7 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
 
-	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext13{
+	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext{
 		state: state,
 		cache: cache,
 		cfg:   cfg,
@@ -225,7 +274,7 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 	assert.Equal(t, before, fsm.transcript.Bytes())
 	assert.Same(t, transcript, fsm.flightContext().transcript)
 
-	require.NoError(t, fsm.seedTranscriptFromInitialFlights())
+	require.NoError(t, fsm.seedInitialFlights(fsm.flights, fsm.retransmit))
 	assert.Same(t, transcript, fsm.transcript)
 	assert.Equal(t, before, fsm.transcript.Bytes())
 	assert.Len(t, fsm.transcript.pending, 1)
@@ -582,9 +631,8 @@ func TestHandshakeFSM13ReaderPauseRequiredOnlyForQueueDrainingTransitions(t *tes
 		t.Run(test.name, func(t *testing.T) {
 			state := newTestState13(test.isClient)
 			state.RemoteEpoch.Store(test.remoteEpoch)
-			fsm := &fsm13{state: state}
-
-			assert.Equal(t, test.expected, fsm.transitionRequiresReaderPause(test.nextFlight))
+			flightContext := handshakeContext{state: state}
+			assert.Equal(t, test.expected, flightContext.transitionRequiresReaderPause(test.nextFlight))
 		})
 	}
 }
@@ -684,7 +732,7 @@ func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T)
 	assert.Equal(t, 5, fixture.clientState.HandshakeRecvSequence)
 	assertFlight13RecvDoneOpen(t, recvState)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
-	fsm.releasePendingRecv()
+	fsm.received.release()
 	assertFlight13RecvDoneClosed(t, recvState)
 }
 
@@ -750,7 +798,7 @@ func TestHandshakeFSM13SendErrorReleasesReader(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fsm := clientFSMThroughServerFlight13(t, newNoHRRFlight13Fixture(t))
-			recvState := RecvHandshakeState{Done: fsm.pendingRecvDone}
+			recvState := RecvHandshakeState{Done: fsm.received.done}
 			conn := &flightTestConn{
 				writePackets: func(context.Context, []*dtlsflight.Packet) error {
 					assertFlight13RecvDoneOpen(t, recvState)
@@ -1168,7 +1216,7 @@ func clientFSMThroughServerFlight13(t *testing.T, fixture noHRRFlight13Fixture) 
 	assert.Equal(t, StatePreparing, nextState)
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
 	assertFlight13RecvDoneOpen(t, recvState)
-	t.Cleanup(fsm.releasePendingRecv)
+	t.Cleanup(fsm.received.release)
 
 	return fsm
 }
@@ -1282,7 +1330,7 @@ func newNoHRRFlight13Fixture(t *testing.T) noHRRFlight13Fixture {
 	serverState := newTestState13(false)
 	serverCache := dtlsflight.NewCache()
 
-	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight0, &handshakeContext13{
+	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight0, &handshakeContext{
 		state: serverState,
 		cache: serverCache,
 		cfg:   cfg,
@@ -1336,7 +1384,7 @@ func newFlight13ClientHelloFixture(
 	t.Helper()
 
 	clientState := newTestState13(true)
-	clientHello, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext13{
+	clientHello, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext{
 		state: clientState,
 		cache: dtlsflight.NewCache(),
 		cfg:   cfg,

--- a/internal/handshake/handshake_context.go
+++ b/internal/handshake/handshake_context.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtlshandshake
+
+import (
+	"context"
+
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+)
+
+// handshakeContext groups the DTLS 1.3 state that must move together while
+// flights are generated, committed, and parsed.
+type handshakeContext struct {
+	state      *dtlsstate.State13
+	cache      *dtlsflight.Cache
+	cfg        *dtlsconfig.HandshakeConfig
+	transcript *Transcript
+}
+
+func (c *handshakeContext) seedInitialFlights(flights []*dtlsflight.Packet, retransmit bool) error {
+	return seedTranscriptFromInitialFlights(c.state, c.transcript, flights, retransmit)
+}
+
+func (c *handshakeContext) commitPreparedFlight(
+	conn Conn,
+	flight dtlsflight13.Flight,
+	flights []*dtlsflight.Packet,
+) error {
+	if err := commitPreparedFlights(conn, c.state, c.transcript, c.cfg, flights); err != nil {
+		return err
+	}
+	if !c.state.IsClient && flight == dtlsflight13.Flight4 {
+		return DeriveAndStoreApplicationTrafficSecrets(c.state, c.transcript)
+	}
+
+	return nil
+}
+
+func (c *handshakeContext) afterSend(
+	ctx context.Context,
+	conn Conn,
+	flight dtlsflight13.Flight,
+) (bool, error) {
+	if !c.state.IsClient &&
+		flight == dtlsflight13.Flight4 &&
+		c.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake {
+		// Only the first send advances the epoch and drains packets. A timer
+		// retransmission has no receive-side rendezvous and the reader is active.
+		c.state.RemoteEpoch.Store(dtlsflight13.EpochHandshake)
+		if err := conn.HandleQueuedPackets(ctx); err != nil {
+			return false, err
+		}
+	}
+	if !c.state.IsClient || !flight.IsLastSendFlight() {
+		return false, nil
+	}
+
+	return true, activateApplicationRecordProtection(ctx, conn, c.state)
+}
+
+func (c *handshakeContext) parseReceivedFlight(
+	ctx context.Context,
+	conn Conn,
+	currentFlight dtlsflight13.Flight,
+) (dtlsflight13.Flight, error) {
+	nextFlight, dtlsAlert, err, ok := dtlsflight13.Parse(ctx, currentFlight, conn, c.parseDependencies())
+	if !ok {
+		if alertErr := conn.Notify(ctx, alert.Fatal, alert.InternalError); alertErr != nil {
+			return 0, alertErr
+		}
+
+		return 0, dtlserrors.ErrFlightUnimplemented13
+	}
+	if err = notifyAlert(ctx, conn, dtlsAlert, err); err != nil {
+		return 0, err
+	}
+
+	return nextFlight, nil
+}
+
+type receivedFlightTransition struct {
+	state             State
+	nextFlight        dtlsflight13.Flight
+	retainPendingRecv bool
+}
+
+func (c *handshakeContext) advanceAfterReceivedFlight(
+	ctx context.Context,
+	conn Conn,
+	currentFlight, nextFlight dtlsflight13.Flight,
+	receivedRecords []protocol.RecordNumber,
+) (receivedFlightTransition, error) {
+	if c.state.IsClient && nextFlight.IsLastSendFlight() {
+		if err := DeriveAndStoreApplicationTrafficSecrets(c.state, c.transcript); err != nil {
+			return receivedFlightTransition{}, err
+		}
+	}
+	if !c.state.IsClient &&
+		currentFlight == nextFlight &&
+		nextFlight.IsLastRecvFlight() {
+		if err := activateApplicationRecordProtection(ctx, conn, c.state); err != nil {
+			return receivedFlightTransition{}, err
+		}
+		if err := sendACK(ctx, conn, c.state.GetLocalEpoch(), receivedRecords); err != nil {
+			return receivedFlightTransition{}, err
+		}
+
+		return receivedFlightTransition{state: StateFinished}, nil
+	}
+
+	c.cfg.Log.Tracef(
+		"[handshake13:%s] %s -> %s",
+		sideString(c.state.IsClient),
+		currentFlight.String(),
+		nextFlight.String(),
+	)
+
+	return receivedFlightTransition{
+		state:             StatePreparing,
+		nextFlight:        nextFlight,
+		retainPendingRecv: c.transitionRequiresReaderPause(nextFlight),
+	}, nil
+}
+
+func (c *handshakeContext) transitionRequiresReaderPause(nextFlight dtlsflight13.Flight) bool {
+	if c.state.IsClient {
+		return nextFlight.IsLastSendFlight()
+	}
+
+	return nextFlight == dtlsflight13.Flight4 &&
+		c.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake
+}
+
+func (c *handshakeContext) parseDependencies() dtlsflight13.ParseDependencies {
+	return dtlsflight13.ParseDependencies{
+		State:  c.state,
+		Cache:  c.cache,
+		Config: c.cfg,
+		Hooks: dtlsflight13.ParseHooks{
+			InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+				return AppendVerifiedInboundHandshakeCacheItems(c.transcript, cipherSuite, items)
+			},
+			ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+				return VerifyAndAppendProtectedHandshakeCacheItems13(
+					c.transcript,
+					c.state,
+					c.cfg,
+					cipherSuite,
+					items,
+				)
+			},
+			HandshakeTrafficSecretDeriver: func(state *dtlsstate.State13) error {
+				return DeriveAndStoreHandshakeTrafficSecrets(state, c.transcript)
+			},
+			HandshakeRecordProtectionInitializer: InitHandshakeRecordProtection,
+		},
+	}
+}

--- a/internal/handshake/protected_flight.go
+++ b/internal/handshake/protected_flight.go
@@ -477,9 +477,9 @@ func appendParsedInboundHandshake13(
 		return err
 	}
 
-	return appendHandshake13(
+	return appendHandshake(
 		transcript,
-		transcriptSenderForSide13(isClient),
+		transcriptSenderForSide(isClient),
 		cipherSuite,
 		hs.Header.MessageSequence,
 		hs.Message,

--- a/internal/handshake/record_protection.go
+++ b/internal/handshake/record_protection.go
@@ -4,8 +4,11 @@
 package dtlshandshake
 
 import (
+	"context"
+
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 )
 
@@ -28,6 +31,16 @@ func InitApplicationRecordProtection(state *dtlsstate.State13) error {
 		Client: state.KeySchedule.ClientApplicationTrafficSecret0,
 		Server: state.KeySchedule.ServerApplicationTrafficSecret0,
 	}, true)
+}
+
+func activateApplicationRecordProtection(ctx context.Context, conn Conn, state *dtlsstate.State13) error {
+	if err := InitApplicationRecordProtection(state); err != nil {
+		return err
+	}
+	conn.SetLocalEpoch(dtlsflight13.EpochApplication)
+	state.RemoteEpoch.Store(dtlsflight13.EpochApplication)
+
+	return conn.HandleQueuedPackets(ctx)
 }
 
 func initRecordProtectionFromTrafficSecrets(

--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -7,9 +7,13 @@ import (
 	"crypto/hmac"
 	"hash"
 
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/keyschedule"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 const (
@@ -30,6 +34,178 @@ const (
 type handshakeKeySchedule struct {
 	HandshakeTrafficSecrets dtlsstate.TrafficSecrets
 	MasterSecret            []byte
+}
+
+func commitPreparedFlights(
+	conn Conn,
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	cfg *dtlsconfig.HandshakeConfig,
+	flights []*dtlsflight.Packet,
+) error {
+	nextEpoch, protectedFlightStart := prepareFlightPackets(state, cfg.InitialEpoch, flights)
+	if err := commitOutboundFlight(state, transcript, flights, protectedFlightStart); err != nil {
+		return err
+	}
+	if nextEpoch == cfg.InitialEpoch {
+		return nil
+	}
+
+	cfg.Log.Tracef("[handshake13:%s] -> changeCipherSpec (epoch: %d)", sideString(state.IsClient), nextEpoch)
+	conn.SetLocalEpoch(nextEpoch)
+
+	return nil
+}
+
+func prepareFlightPackets(
+	state *dtlsstate.State13,
+	epoch uint16,
+	flights []*dtlsflight.Packet,
+) (uint16, int) {
+	nextEpoch := epoch
+	protectedFlightStart := len(flights)
+	for i, packet := range flights {
+		packet.Record.Header.Epoch += epoch
+		if packet.Record.Header.Epoch > nextEpoch {
+			nextEpoch = packet.Record.Header.Epoch
+		}
+		if packet.ShouldEncrypt && protectedFlightStart == len(flights) {
+			protectedFlightStart = i
+		}
+		if handshakeMessage, ok := packet.Record.Content.(*handshake.Handshake); ok {
+			handshakeMessage.Header.MessageSequence = uint16(state.HandshakeSendSequence) //nolint:gosec // G115
+			state.HandshakeSendSequence++
+		}
+	}
+
+	return nextEpoch, protectedFlightStart
+}
+
+func commitOutboundFlight(
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	flights []*dtlsflight.Packet,
+	protectedFlightStart int,
+) error {
+	if err := appendCommittedOutboundHandshakeFlight(state, transcript, flights[:protectedFlightStart]); err != nil {
+		return err
+	}
+	if protectedFlightStart == len(flights) {
+		return nil
+	}
+	if err := ensureHandshakeTrafficSecrets(state, transcript); err != nil {
+		return err
+	}
+	if err := InitHandshakeRecordProtection(state); err != nil {
+		return err
+	}
+
+	return appendCommittedOutboundHandshakeFlight(state, transcript, flights[protectedFlightStart:])
+}
+
+func ensureHandshakeTrafficSecrets(state *dtlsstate.State13, transcript *Transcript) error {
+	secrets := state.KeySchedule.HandshakeTraffic
+	if len(secrets.Client) == 0 && len(secrets.Server) == 0 {
+		return DeriveAndStoreHandshakeTrafficSecrets(state, transcript)
+	}
+
+	return selectHashIfReady(transcript, state.CipherSuite)
+}
+
+func appendCommittedOutboundHandshakeFlight(
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	pkts []*dtlsflight.Packet,
+) error {
+	for _, p := range pkts {
+		if err := populateOutboundCertificateVerify(state, transcript, p); err != nil {
+			return err
+		}
+		if err := populateOutboundFinished(state, transcript, p); err != nil {
+			return err
+		}
+		if err := AppendOutboundHandshakeFlight(
+			transcript,
+			state.IsClient,
+			state.CipherSuite,
+			[]*dtlsflight.Packet{p},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func populateOutboundCertificateVerify(
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	pkt *dtlsflight.Packet,
+) error {
+	if pkt == nil || pkt.Record == nil {
+		return nil
+	}
+	h, ok := pkt.Record.Content.(*handshake.Handshake)
+	if !ok {
+		return nil
+	}
+	certificateVerify, ok := h.Message.(*handshake.MessageCertificateVerify)
+	if !ok || len(certificateVerify.Signature) != 0 {
+		return nil
+	}
+	if pkt.CertificateVerifySigner == nil {
+		return dtlserrors.ErrInvalidPrivateKey
+	}
+
+	input, err := CertificateVerifyInputFromTranscript(state.IsClient, transcript)
+	if err != nil {
+		return err
+	}
+	certificateVerify.Signature, err = dtlscrypto.GenerateCertificateVerify(
+		input,
+		pkt.CertificateVerifySigner,
+		certificateVerify.HashAlgorithm,
+		certificateVerify.SignatureAlgorithm,
+	)
+
+	return err
+}
+
+func populateOutboundFinished(
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	p *dtlsflight.Packet,
+) error {
+	if p == nil || p.Record == nil {
+		return nil
+	}
+	h, ok := p.Record.Content.(*handshake.Handshake)
+	if !ok {
+		return nil
+	}
+	finished, ok := h.Message.(*handshake.MessageFinished)
+	if !ok || len(finished.VerifyData) != 0 {
+		return nil
+	}
+	if state.CipherSuite == nil {
+		return dtlserrors.ErrCipherSuiteNotSet
+	}
+
+	baseKey, err := ServerHandshakeFinishedBaseKey(state)
+	if state.IsClient {
+		baseKey, err = ClientHandshakeFinishedBaseKey(state)
+	}
+	if err != nil {
+		return err
+	}
+
+	verifyData, err := FinishedVerifyDataFromTranscript(state.CipherSuite.HashFunc(), baseKey, transcript)
+	if err != nil {
+		return err
+	}
+	finished.VerifyData = verifyData
+
+	return nil
 }
 
 // deriveHandshakeTrafficSecrets derives the DTLS 1.3 client and server

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -10,7 +10,12 @@ import (
 	"hash"
 	"maps"
 
+	"github.com/pion/dtls/v3/internal/ciphersuite/types"
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
@@ -319,4 +324,255 @@ func (t *Transcript) replaceWith(src *Transcript) error {
 // Bytes returns the canonical transcript bytes.
 func (t *Transcript) Bytes() []byte {
 	return append([]byte(nil), t.transcript...)
+}
+
+// seedTranscriptFromInitialFlights imports the dual-stack ClientHello generated
+// before the DTLS 1.3 FSM exists.
+func seedTranscriptFromInitialFlights(
+	state *dtlsstate.State13,
+	transcript *Transcript,
+	flights []*dtlsflight.Packet,
+	retransmit bool,
+) error {
+	if !state.IsClient {
+		return nil
+	}
+
+	appended, err := AppendClientHelloInitialFlights(transcript, flights)
+	if err != nil {
+		return err
+	}
+	if retransmit && !appended {
+		return dtlserrors.ErrHandshakeTranscriptMissingClientHello
+	}
+
+	return nil
+}
+
+func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflight.Packet) (bool, error) {
+	if transcript == nil {
+		return false, dtlserrors.ErrHandshakeTranscriptMissingClientHello
+	}
+
+	appended := false
+	for _, p := range flights {
+		seq, canonical, ok, err := canonicalClientHelloInitialFlight(p)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+		if err := transcript.appendCanonical(transcriptMessageID{
+			sender: transcriptSenderClient,
+			Seq:    seq,
+		}, canonical); err != nil {
+			return false, err
+		}
+		appended = true
+	}
+
+	return appended, nil
+}
+
+// ValidateClientHelloInitialFlights verifies that the dual-stack initial flight
+// contains a canonical ClientHello before it is written.
+func ValidateClientHelloInitialFlights(flights []*dtlsflight.Packet) error {
+	appended, err := AppendClientHelloInitialFlights(NewTranscript(), flights)
+	if err != nil {
+		return err
+	}
+	if !appended {
+		return dtlserrors.ErrHandshakeTranscriptMissingClientHello
+	}
+
+	return nil
+}
+
+func canonicalClientHelloInitialFlight(p *dtlsflight.Packet) (uint16, []byte, bool, error) {
+	if p == nil || p.Record == nil {
+		return 0, nil, false, nil
+	}
+	hand, ok := p.Record.Content.(*handshake.Handshake)
+	if !ok {
+		return 0, nil, false, nil
+	}
+	if hand.Message == nil || hand.Message.Type() != handshake.TypeClientHello {
+		return 0, nil, false, nil
+	}
+
+	raw, err := hand.Marshal()
+	if err != nil {
+		return 0, nil, false, err
+	}
+	canonical, err := canonicalHandshake(raw)
+	if err != nil {
+		return 0, nil, false, err
+	}
+
+	return hand.Header.MessageSequence, canonical, true, nil
+}
+
+func transcriptSenderForSide(isClient bool) transcriptSender {
+	if isClient {
+		return transcriptSenderClient
+	}
+
+	return transcriptSenderServer
+}
+
+func AppendOutboundHandshakeFlight(
+	transcript *Transcript,
+	isClient bool,
+	cipherSuite dtlsconfig.CipherSuite,
+	pkts []*dtlsflight.Packet,
+) error {
+	if transcript == nil {
+		return nil
+	}
+
+	sender := transcriptSenderForSide(isClient)
+	for _, p := range pkts {
+		handshakeMessage, canonical, ok, err := canonicalOutboundHandshake(p)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+
+		if err := appendHandshake(
+			transcript,
+			sender,
+			cipherSuite,
+			handshakeMessage.Header.MessageSequence,
+			handshakeMessage.Message,
+			canonical,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func canonicalOutboundHandshake(p *dtlsflight.Packet) (*handshake.Handshake, []byte, bool, error) {
+	if p == nil || p.Record == nil {
+		return nil, nil, false, nil
+	}
+
+	hs, ok := p.Record.Content.(*handshake.Handshake)
+	if !ok || hs.Message == nil {
+		return nil, nil, false, nil
+	}
+
+	raw, err := hs.Marshal()
+	if err != nil {
+		return nil, nil, false, err
+	}
+	canonical, err := canonicalHandshake(raw)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	return hs, canonical, true, nil
+}
+
+// AppendVerifiedInbound appends an inbound handshake message to the transcript
+// after the caller has validated and accepted it. For CertificateVerify and
+// Finished, callers must authenticate the message against SnapshotHash before
+// calling this method.
+func (t *Transcript) AppendVerifiedInbound(
+	isClient bool,
+	cipherSuite dtlsconfig.CipherSuite,
+	raw []byte,
+) error {
+	if t == nil {
+		return nil
+	}
+
+	canonical, err := canonicalHandshake(raw)
+	if err != nil {
+		return err
+	}
+
+	var keyExchangeAlgorithm types.KeyExchangeAlgorithm
+	if cipherSuite != nil {
+		keyExchangeAlgorithm = cipherSuite.KeyExchangeAlgorithm()
+	}
+
+	h := &handshake.Handshake{
+		KeyExchangeAlgorithm: keyExchangeAlgorithm,
+	}
+	if err := h.Unmarshal(raw); err != nil {
+		return err
+	}
+
+	return appendHandshake(
+		t,
+		transcriptSenderForSide(isClient),
+		cipherSuite,
+		h.Header.MessageSequence,
+		h.Message,
+		canonical,
+	)
+}
+
+// AppendVerifiedInboundHandshakeCacheItems appends inbound cache items to the
+// transcript after the caller has validated and accepted each item.
+//
+// Messages that require explicit authentication, such as CertificateVerify and
+// Finished, must be verified first and then appended with AppendVerifiedInbound.
+func AppendVerifiedInboundHandshakeCacheItems(
+	transcript *Transcript,
+	cipherSuite dtlsconfig.CipherSuite,
+	items []*dtlsflight.HandshakeCacheItem,
+) error {
+	if transcript == nil {
+		return nil
+	}
+
+	for _, item := range items {
+		if requiresExplicitAuthenticationBeforeTranscriptCommit(item.Typ) {
+			return dtlserrors.ErrHandshakeTranscriptExplicitAuthenticationRequired
+		}
+		if err := transcript.AppendVerifiedInbound(item.IsClient, cipherSuite, item.Data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func requiresExplicitAuthenticationBeforeTranscriptCommit(typ handshake.Type) bool {
+	return typ == handshake.TypeCertificateVerify || typ == handshake.TypeFinished
+}
+
+func appendHandshake(
+	transcript *Transcript,
+	sender transcriptSender,
+	cipherSuite dtlsconfig.CipherSuite,
+	seq uint16,
+	message handshake.Message,
+	canonical []byte,
+) error {
+	id := transcriptMessageID{
+		sender: sender,
+		Seq:    seq,
+	}
+	if sh, ok := message.(*handshake.MessageServerHello); ok && dtlsflight13.IsHelloRetryRequest(sh) {
+		duplicate, err := transcript.hasCanonical(id, canonical)
+		if err != nil || duplicate {
+			return err
+		}
+
+		if err := selectHashIfReady(transcript, cipherSuite); err != nil {
+			return err
+		}
+		if err := transcript.applyHelloRetryRequest(); err != nil {
+			return err
+		}
+	}
+
+	return transcript.appendCanonical(id, canonical)
 }


### PR DESCRIPTION
#### Description
Move FSM13 helpers and handshake, transcript functions into more correct files, This is me trying to make FSM13 look like FSM12
Still draft, not done.
1. moves all helpers out of fsm.
2. move pendingRecvDone back to conn.
3. adds helpers for "is it last flight" instead of hard-coding that inside fsm.
4. share timeouts and cancellation helpers between fsm 12 and 13.