### PR TITLE
Simplify handshake connection adapter

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -133,49 +133,40 @@ type handshakeStart struct {
 	postSetup func(context.Context)
 }
 
-type handshakeConn interface {
-	notify(ctx context.Context, level alert.Level, desc alert.Description) error
-	writePackets(context.Context, []*dtlsflight.Packet) error
-	recvHandshake() <-chan dtlshandshake.RecvHandshakeState
-	setLocalEpoch(epoch uint16)
-	handleQueuedPackets(context.Context) error
-	sessionKey() []byte
+type handshakeConn struct {
+	conn *Conn
 }
 
-type handshakeConnAdapter struct {
-	handshakeConn
+func (c handshakeConn) Notify(ctx context.Context, level alert.Level, desc alert.Description) error {
+	return c.conn.notify(ctx, level, desc)
 }
 
-func (c handshakeConnAdapter) Notify(ctx context.Context, level alert.Level, desc alert.Description) error {
-	return c.notify(ctx, level, desc)
+func (c handshakeConn) WritePackets(ctx context.Context, pkts []*dtlsflight.Packet) error {
+	return c.conn.writePackets(ctx, pkts)
 }
 
-func (c handshakeConnAdapter) WritePackets(ctx context.Context, pkts []*dtlsflight.Packet) error {
-	return c.writePackets(ctx, pkts)
+func (c handshakeConn) RecvHandshake() <-chan dtlshandshake.RecvHandshakeState {
+	return c.conn.recvHandshake()
 }
 
-func (c handshakeConnAdapter) RecvHandshake() <-chan dtlshandshake.RecvHandshakeState {
-	return c.recvHandshake()
+func (c handshakeConn) SetLocalEpoch(epoch uint16) {
+	c.conn.setLocalEpoch(epoch)
 }
 
-func (c handshakeConnAdapter) SetLocalEpoch(epoch uint16) {
-	c.setLocalEpoch(epoch)
+func (c handshakeConn) HandleQueuedPackets(ctx context.Context) error {
+	return c.conn.handleQueuedPackets(ctx)
 }
 
-func (c handshakeConnAdapter) HandleQueuedPackets(ctx context.Context) error {
-	return c.handleQueuedPackets(ctx)
+func (c handshakeConn) SessionKey() []byte {
+	return c.conn.sessionKey()
 }
 
-func (c handshakeConnAdapter) SessionKey() []byte {
-	return c.sessionKey()
-}
-
-func adaptFlightConn(conn handshakeConn) dtlsflight.Conn {
+func adaptFlightConn(conn *Conn) dtlsflight.Conn {
 	if conn == nil {
 		return nil
 	}
 
-	return handshakeConnAdapter{conn}
+	return handshakeConn{conn}
 }
 
 func srvCliStr(isClient bool) string {
@@ -2608,7 +2599,7 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 	// The other party may request retransmission of the last flight to cope with packet drop.
 	go func() {
 		defer handshakeLoopsFinished.Done()
-		err := c.fsm.Run(ctxHs, handshakeConnAdapter{c}, start.fsmState)
+		err := c.fsm.Run(ctxHs, handshakeConn{c}, start.fsmState)
 		if !errors.Is(err, context.Canceled) {
 			select {
 			case firstErr <- err:

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -331,7 +331,7 @@ func runHandshakeFSM12ForTest(
 	}()
 
 	fsm := dtlshandshake.NewFSM12(&conn.state, conn.handshakeCache, cfg, initialFlight, nil, establishment)
-	err := fsm.Run(ctx, handshakeConnAdapter{conn}, dtlshandshake.StatePreparing)
+	err := fsm.Run(ctx, conn, dtlshandshake.StatePreparing)
 	switch {
 	case errors.Is(err, context.Canceled):
 	case errors.Is(err, context.DeadlineExceeded):
@@ -400,19 +400,19 @@ type flightTestConn struct {
 	otherEndRecv  chan dtlshandshake.RecvHandshakeState
 }
 
-func (c *flightTestConn) recvHandshake() <-chan dtlshandshake.RecvHandshakeState {
+func (c *flightTestConn) RecvHandshake() <-chan dtlshandshake.RecvHandshakeState {
 	return c.recv
 }
 
-func (c *flightTestConn) setLocalEpoch(epoch uint16) {
+func (c *flightTestConn) SetLocalEpoch(epoch uint16) {
 	c.epoch = epoch
 }
 
-func (c *flightTestConn) notify(context.Context, alert.Level, alert.Description) error {
+func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description) error {
 	return nil
 }
 
-func (c *flightTestConn) writePackets(_ context.Context, pkts []*dtlsflight.Packet) error { //nolint:cyclop
+func (c *flightTestConn) WritePackets(_ context.Context, pkts []*dtlsflight.Packet) error { //nolint:cyclop
 	time.Sleep(c.delay)
 	isRetransmit := false
 	for _, pkt := range pkts {
@@ -468,10 +468,10 @@ func (c *flightTestConn) writePackets(_ context.Context, pkts []*dtlsflight.Pack
 	return nil
 }
 
-func (c *flightTestConn) handleQueuedPackets(context.Context) error {
+func (c *flightTestConn) HandleQueuedPackets(context.Context) error {
 	return nil
 }
 
-func (c *flightTestConn) sessionKey() []byte {
+func (c *flightTestConn) SessionKey() []byte {
 	return nil
 }


### PR DESCRIPTION
Store the concrete DTLS connection in the FSM adapter instead of embedding a private interface with no production alternatives.

Let the handshake test connection implement the FSM interface directly.