### PR TITLE
Polish Go naming and cloning idioms

### DIFF
--- a/cipher_suite.go
+++ b/cipher_suite.go
@@ -212,21 +212,21 @@ func allCipherSuites() []CipherSuite {
 }
 
 func cipherSuiteIDs(cipherSuites []CipherSuite) []uint16 {
-	rtrn := []uint16{}
+	ids := []uint16{}
 	for _, c := range cipherSuites {
-		rtrn = append(rtrn, uint16(c.ID()))
+		ids = append(ids, uint16(c.ID()))
 	}
 
-	return rtrn
+	return ids
 }
 
 func configCipherSuiteIDs(cipherSuites []ciphersuite.CipherSuite) []uint16 {
-	rtrn := []uint16{}
+	ids := []uint16{}
 	for _, c := range cipherSuites {
-		rtrn = append(rtrn, uint16(c.ID()))
+		ids = append(ids, uint16(c.ID()))
 	}
 
-	return rtrn
+	return ids
 }
 
 func defaultCipherSuitesForVersions(minVersion, maxVersion protocol.Version) []CipherSuite {

--- a/conn.go
+++ b/conn.go
@@ -73,14 +73,14 @@ type addrPkt struct {
 	data  []byte
 }
 
-// packetQueueWriter owns a recyclable read buffer until a queued packet view
+// readBufferLease owns a recyclable read buffer until a queued packet view
 // takes responsibility for keeping its backing array alive.
-type packetQueueWriter struct {
+type readBufferLease struct {
 	conn                 *Conn
 	recyclableReadBuffer *[]byte
 }
 
-func (w *packetQueueWriter) enqueue(packet addrPkt) bool {
+func (w *readBufferLease) enqueue(packet addrPkt) bool {
 	if !w.conn.enqueueEncryptedPackets(packet) {
 		return false
 	}
@@ -90,7 +90,7 @@ func (w *packetQueueWriter) enqueue(packet addrPkt) bool {
 	return true
 }
 
-func (w *packetQueueWriter) releaseReadBuffer() {
+func (w *readBufferLease) releaseReadBuffer() {
 	readBuffer := w.recyclableReadBuffer
 	w.recyclableReadBuffer = nil
 	if readBuffer != nil {
@@ -1383,7 +1383,7 @@ func (c *Conn) processProtectedHandshakePacket(
 	dtlsHandshake *handshake.Handshake,
 ) ([][]byte, error) {
 	if pkt == nil || pkt.Record == nil || dtlsHandshake == nil {
-		// todo:  this is a temporary error until we handle this in a better way.
+		// TODO: Replace this temporary error when CID protection is implemented.
 		// nolint:godox
 		return nil, dtlserrors.ErrInvalidPacket
 	}
@@ -1502,8 +1502,8 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 	if !ok {
 		return datagramProcessingSummary{}, dtlserrors.ErrFailedToAccessPoolReadBuffer
 	}
-	queueWriter := packetQueueWriter{conn: c, recyclableReadBuffer: bufptr}
-	defer queueWriter.releaseReadBuffer()
+	bufferLease := readBufferLease{conn: c, recyclableReadBuffer: bufptr}
+	defer bufferLease.releaseReadBuffer()
 
 	b := *bufptr
 	i, rAddr, err := c.nextConn.ReadFromContext(ctx, b)
@@ -1518,7 +1518,7 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 
 	var summary datagramProcessingSummary
 	for _, p := range pkts {
-		outcome, err := c.processIncomingPacket(ctx, p, rAddr, &queueWriter)
+		outcome, err := c.processIncomingPacket(ctx, p, rAddr, &bufferLease)
 		if err != nil {
 			return datagramProcessingSummary{}, err
 		}
@@ -1753,19 +1753,19 @@ func marshalInnerPlaintextRecord(
 func (c *Conn) prepareIncomingPacket(
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) (incomingPacketState, bool) {
 	if protocol.IsDTLS13Ciphertext(protocol.ContentType(buf[0])) {
-		return c.prepareCiphertextPacket(buf, rAddr, queueWriter)
+		return c.prepareCiphertextPacket(buf, rAddr, bufferLease)
 	}
 
-	return c.prepareLegacyPacket(buf, rAddr, queueWriter)
+	return c.prepareLegacyPacket(buf, rAddr, bufferLease)
 }
 
 func (c *Conn) prepareCiphertextPacket(
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) (incomingPacketState, bool) {
 	ciphertext, err := c.unmarshalCiphertextRecord(buf)
 	if err != nil {
@@ -1776,7 +1776,7 @@ func (c *Conn) prepareCiphertextPacket(
 
 	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
 	if ciphertext.Header.EpochLow != uint8(remoteEpoch&recordlayer.TwoLowBitsMask) {
-		c.handleFutureCiphertextPacket(ciphertext.Header.EpochLow, remoteEpoch, rAddr, buf, queueWriter)
+		c.handleFutureCiphertextPacket(ciphertext.Header.EpochLow, remoteEpoch, rAddr, buf, bufferLease)
 
 		return incomingPacketState{}, false
 	}
@@ -1784,7 +1784,7 @@ func (c *Conn) prepareCiphertextPacket(
 	if c.queueIfCipherSuiteUninitialized(
 		rAddr,
 		buf,
-		queueWriter,
+		bufferLease,
 		"handshake not finished, queuing ciphertext packet",
 	) {
 		return incomingPacketState{}, false
@@ -1841,15 +1841,15 @@ func (c *Conn) handleFutureCiphertextPacket(
 	remoteEpoch uint16,
 	rAddr net.Addr,
 	buf []byte,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) {
 	if !c.queueableCiphertextEpoch(epochLow, remoteEpoch) {
 		c.log.Debugf("discarded future ciphertext packet (epoch low: %d)", epochLow)
 
 		return
 	}
-	if queueWriter != nil {
-		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
+	if bufferLease != nil {
+		if ok := bufferLease.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug("received ciphertext packet of next epoch, queuing packet")
 		}
 	}
@@ -1882,15 +1882,15 @@ func (c *Conn) protectedReplayMarker(epoch uint16, sequenceNumber uint64) (func(
 func (c *Conn) queueIfCipherSuiteUninitialized(
 	rAddr net.Addr,
 	buf []byte,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 	message string,
 ) bool {
 	common := dtlsstate.CommonState(c.state)
 	if common.CipherSuite != nil && common.CipherSuite.IsInitialized() {
 		return false
 	}
-	if queueWriter != nil {
-		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
+	if bufferLease != nil {
+		if ok := bufferLease.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug(message)
 		}
 	}
@@ -1901,13 +1901,13 @@ func (c *Conn) queueIfCipherSuiteUninitialized(
 func (c *Conn) prepareLegacyPacket(
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) (incomingPacketState, bool) {
 	header, ok := c.unmarshalLegacyHeader(buf)
 	if !ok {
 		return incomingPacketState{}, false
 	}
-	if c.handleFutureLegacyPacket(header, rAddr, buf, queueWriter) {
+	if c.handleFutureLegacyPacket(header, rAddr, buf, bufferLease) {
 		return incomingPacketState{}, false
 	}
 
@@ -1919,7 +1919,7 @@ func (c *Conn) prepareLegacyPacket(
 	originalCID := false
 	if header.Epoch != 0 {
 		var decryptOK bool
-		buf, originalCID, decryptOK = c.decryptLegacyPacket(header, buf, rAddr, queueWriter)
+		buf, originalCID, decryptOK = c.decryptLegacyPacket(header, buf, rAddr, bufferLease)
 		if !decryptOK {
 			return incomingPacketState{}, false
 		}
@@ -1956,7 +1956,7 @@ func (c *Conn) handleFutureLegacyPacket(
 	header *recordlayer.Header,
 	rAddr net.Addr,
 	buf []byte,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) bool {
 	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
 	if header.Epoch <= remoteEpoch {
@@ -1969,8 +1969,8 @@ func (c *Conn) handleFutureLegacyPacket(
 
 		return true
 	}
-	if queueWriter != nil {
-		if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
+	if bufferLease != nil {
+		if ok := bufferLease.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 			c.log.Debug("received packet of next epoch, queuing packet")
 		}
 	}
@@ -2001,12 +2001,12 @@ func (c *Conn) decryptLegacyPacket(
 	header *recordlayer.Header,
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) ([]byte, bool, bool) {
 	if c.queueIfCipherSuiteUninitialized(
 		rAddr,
 		buf,
-		queueWriter,
+		bufferLease,
 		"handshake not finished, queuing packet",
 	) {
 		return nil, false, false
@@ -2099,13 +2099,13 @@ func (c *Conn) handleIncomingPacket(
 	ctx context.Context,
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) (packetOutcome, error) {
 	if len(buf) == 0 {
 		return packetOutcome{}, nil
 	}
 
-	prepared, ok := c.prepareIncomingPacket(buf, rAddr, queueWriter)
+	prepared, ok := c.prepareIncomingPacket(buf, rAddr, bufferLease)
 	if !ok {
 		return packetOutcome{}, nil
 	}
@@ -2114,7 +2114,7 @@ func (c *Conn) handleIncomingPacket(
 	markPacketAsValid := prepared.markPacketAsValid
 
 	c.syncFragmentBufferHandshakeSequence()
-	isHandshake, isRetransmit, err := c.fragmentBuffer.Push(append([]byte{}, buf...))
+	isHandshake, isRetransmit, err := c.fragmentBuffer.Push(bytes.Clone(buf))
 	if err != nil {
 		// Decode error must be silently discarded
 		// [RFC6347 Section-4.1.2.7]
@@ -2167,8 +2167,8 @@ func (c *Conn) handleIncomingPacket(
 	case *protocol.ChangeCipherSpec:
 		common := dtlsstate.CommonState(c.state)
 		if common.CipherSuite == nil || !common.CipherSuite.IsInitialized() {
-			if queueWriter != nil {
-				if ok := queueWriter.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
+			if bufferLease != nil {
+				if ok := bufferLease.enqueue(addrPkt{rAddr: rAddr, data: buf}); ok {
 					c.log.Debugf("CipherSuite not initialized, queuing packet")
 				}
 			}
@@ -2222,9 +2222,9 @@ func (c *Conn) processIncomingPacket(
 	ctx context.Context,
 	buf []byte,
 	rAddr net.Addr,
-	queueWriter *packetQueueWriter,
+	bufferLease *readBufferLease,
 ) (packetOutcome, error) {
-	outcome, err := c.handleIncomingPacket(ctx, buf, rAddr, queueWriter)
+	outcome, err := c.handleIncomingPacket(ctx, buf, rAddr, bufferLease)
 	if outcome.responseAlert != nil {
 		responseAlert := outcome.responseAlert
 		if alertErr := c.notify(ctx, responseAlert.Level, responseAlert.Description); alertErr != nil && err == nil {
@@ -2612,7 +2612,7 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 		defer func() {
 			if c.isHandshakeCompletedSuccessfully() {
 				// Escaping read loop.
-				// It's safe to close decrypted channnel now.
+				// It's safe to close the decrypted channel now.
 				close(c.decrypted)
 			}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -56,7 +56,7 @@ var (
 	errTestPSKClientInvalidIdentity = errors.New("TestPSK: Client got invalid identity")
 	errPSKRejected                  = errors.New("psk Rejected")
 	errNotExpectedChain             = errors.New("not expected chain")
-	errExpecedChain                 = errors.New("expected chain")
+	errExpectedChain                = errors.New("expected chain")
 	errWrongCert                    = errors.New("wrong cert")
 	errConnectionAttemptFailed      = errors.New("connection attempt failed")
 )
@@ -1585,7 +1585,7 @@ func TestServerCertificate(t *testing.T) {
 					WithClientAuth(RequireAndVerifyClientCert),
 					WithVerifyPeerCertificate(func(_ [][]byte, chain [][]*x509.Certificate) error {
 						if len(chain) == 0 {
-							return errExpecedChain
+							return errExpectedChain
 						}
 
 						return nil
@@ -3037,8 +3037,8 @@ func TestSessionResume(t *testing.T) {
 
 		actualSessionID := state.SessionID
 		actualMasterSecret := state.masterSecret
-		assert.Equal(t, actualSessionID, id, "TestSessionResumetion SessionID mismatch")
-		assert.Equal(t, actualMasterSecret, secret, "TestSessionResumetion masterSecret mismatch")
+		assert.Equal(t, actualSessionID, id, "TestSessionResumption SessionID mismatch")
+		assert.Equal(t, actualMasterSecret, secret, "TestSessionResumption masterSecret mismatch")
 
 		defer func() {
 			assert.NoError(t, server.Close())
@@ -3082,7 +3082,7 @@ func TestSessionResume(t *testing.T) {
 		actualSessionID := state.SessionID
 		actualMasterSecret := state.masterSecret
 		ss, _ := s2.Get(actualSessionID)
-		assert.Equal(t, actualMasterSecret, ss.Secret, "TestSessionResumetion masterSecret mismatch")
+		assert.Equal(t, actualMasterSecret, ss.Secret, "TestSessionResumption masterSecret mismatch")
 
 		defer func() {
 			assert.NoError(t, server.Close())
@@ -3092,7 +3092,7 @@ func TestSessionResume(t *testing.T) {
 		assert.NoError(t, res.err)
 
 		cs, _ := s1.Get([]byte(ca.RemoteAddr().String() + "_example.com"))
-		assert.Equal(t, actualMasterSecret, cs.Secret, "TestSessionResumetion mismatch")
+		assert.Equal(t, actualMasterSecret, cs.Secret, "TestSessionResumption mismatch")
 		assert.NoError(t, res.c.Close())
 	})
 }
@@ -3492,19 +3492,19 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 func TestPacketQueueWriterRetiresReadBufferOnlyWhenQueued(t *testing.T) {
 	readBuffer := []byte{1, 2, 3}
 	conn := &Conn{}
-	writer := packetQueueWriter{conn: conn, recyclableReadBuffer: &readBuffer}
+	lease := readBufferLease{conn: conn, recyclableReadBuffer: &readBuffer}
 
-	require.True(t, writer.enqueue(addrPkt{data: readBuffer}))
-	assert.Nil(t, writer.recyclableReadBuffer)
+	require.True(t, lease.enqueue(addrPkt{data: readBuffer}))
+	assert.Nil(t, lease.recyclableReadBuffer)
 	require.Len(t, conn.encryptedPackets, 1)
 	assert.Same(t, &readBuffer[0], &conn.encryptedPackets[0].data[0])
 	assert.Equal(t, len(conn.encryptedPackets[0].data), cap(conn.encryptedPackets[0].data))
 
 	rejectedReadBuffer := []byte{4, 5, 6}
 	fullConn := &Conn{encryptedPackets: make([]addrPkt, maxAppDataPacketQueueSize)}
-	rejectedWriter := packetQueueWriter{conn: fullConn, recyclableReadBuffer: &rejectedReadBuffer}
-	assert.False(t, rejectedWriter.enqueue(addrPkt{data: rejectedReadBuffer}))
-	assert.Same(t, &rejectedReadBuffer, rejectedWriter.recyclableReadBuffer)
+	rejectedLease := readBufferLease{conn: fullConn, recyclableReadBuffer: &rejectedReadBuffer}
+	assert.False(t, rejectedLease.enqueue(addrPkt{data: rejectedReadBuffer}))
+	assert.Same(t, &rejectedReadBuffer, rejectedLease.recyclableReadBuffer)
 }
 
 func TestReadAndBufferNoFSMQueuesWithoutCopy(t *testing.T) {
@@ -3573,18 +3573,18 @@ func TestHandleIncomingPacket13QueuesHandshakeEpochBeforeProtection(t *testing.T
 	}).Marshal()
 	assert.NoError(t, err)
 
-	queueWriter := &packetQueueWriter{conn: conn, recyclableReadBuffer: &rawPacket}
+	bufferLease := &readBufferLease{conn: conn, recyclableReadBuffer: &rawPacket}
 	outcome, err := conn.handleIncomingPacket(
 		context.Background(),
 		rawPacket,
 		nil,
-		queueWriter,
+		bufferLease,
 	)
 	assert.NoError(t, err)
 	assert.Nil(t, outcome.responseAlert)
 	assert.False(t, outcome.containsHandshake)
 	assert.False(t, outcome.retransmit)
-	assert.Nil(t, queueWriter.recyclableReadBuffer)
+	assert.Nil(t, bufferLease.recyclableReadBuffer)
 	assert.Len(t, conn.encryptedPackets, 1)
 	assert.Equal(t, rawPacket, conn.encryptedPackets[0].data)
 }
@@ -4088,7 +4088,7 @@ func TestHandshakeCancellationWhilePostSetupBlocks(t *testing.T) {
 	}
 }
 
-// WIP! Tests if the dual stack mode client managed to negotiate a version successfully.
+// TestDTLSDualStackClient verifies that a dual-stack client negotiates successfully.
 func TestDTLSDualStackClient(t *testing.T) {
 	defer test.CheckRoutines(t)()
 	defer test.TimeOut(time.Second * 10).Stop()
@@ -4166,7 +4166,7 @@ func TestDTLSDualStackClientRejectsNonClientHelloBeforeWrite(t *testing.T) {
 	assert.Equal(t, int32(0), writes.Load())
 }
 
-// WIP! Tests if the dual stack mode server managed to negotiate a version successfully.
+// TestDTLSDualStackServer verifies that a dual-stack server negotiates successfully.
 func TestDTLSDualStackServer(t *testing.T) {
 	defer test.CheckRoutines(t)()
 	defer test.TimeOut(time.Second * 10).Stop()
@@ -4196,7 +4196,7 @@ func TestDTLSDualStackServer(t *testing.T) {
 	testDTLSDualStack(t, clientOpts, serverOpts)
 }
 
-// WIP! Tests if the dual stack mode managed to negotiate a version successfully.
+// testDTLSDualStack verifies successful version negotiation.
 func testDTLSDualStack(t *testing.T, clientOpts []ClientOption, serverOpts []ServerOption) {
 	t.Helper()
 	ca, cb := dpipe.Pipe()
@@ -4389,9 +4389,9 @@ func TestDTLS13DecryptedEncryptedExtensionsIsCached(t *testing.T) {
 	rawPacket, err := record.Marshal()
 	assert.NoError(t, err)
 
-	queueWriter := &packetQueueWriter{conn: conn}
+	bufferLease := &readBufferLease{conn: conn}
 	outcome, err := conn.handleIncomingPacket(
-		context.Background(), rawPacket, nil, queueWriter,
+		context.Background(), rawPacket, nil, bufferLease,
 	)
 	assert.NoError(t, err)
 	assert.Nil(t, outcome.responseAlert)
@@ -4419,7 +4419,7 @@ func TestDTLS13ProtectedHandshakeRecordKeepsEpochAndSequence(t *testing.T) {
 	rawPacket, err := record.Marshal()
 	assert.NoError(t, err)
 
-	prepared, ok := conn.prepareIncomingPacket(rawPacket, nil, &packetQueueWriter{conn: conn})
+	prepared, ok := conn.prepareIncomingPacket(rawPacket, nil, &readBufferLease{conn: conn})
 	assert.True(t, ok)
 	if assert.NotNil(t, prepared.header) {
 		assert.Equal(t, protocol.ContentTypeHandshake, prepared.header.ContentType)

--- a/connection_id.go
+++ b/connection_id.go
@@ -42,7 +42,7 @@ func OnlySendCIDGenerator() func() []byte {
 func cidDatagramRouter(size int) func([]byte) (string, bool) {
 	return func(packet []byte) (string, bool) {
 		pkts, err := recordlayer.ContentAwareUnpackDatagram(packet, size)
-		if err != nil || len(pkts) < 1 {
+		if err != nil || len(pkts) == 0 {
 			return "", false
 		}
 		for _, pkt := range pkts {
@@ -71,7 +71,7 @@ func cidDatagramRouter(size int) func([]byte) (string, bool) {
 func cidConnIdentifier() func([]byte) (string, bool) { //nolint:cyclop
 	return func(packet []byte) (string, bool) {
 		pkts, err := recordlayer.UnpackDatagram(packet)
-		if err != nil || len(pkts) < 1 {
+		if err != nil || len(pkts) == 0 {
 			return "", false
 		}
 		var h recordlayer.Header

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -285,7 +285,7 @@ func applySequenceNumberMask13(header *recordlayer.UnifiedHeader, mask []byte) e
 		return nil
 	}
 
-	if len(mask) < 1 {
+	if len(mask) == 0 {
 		return dtlserrors.ErrBufferTooSmall
 	}
 

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -198,7 +198,7 @@ func flight0Generate(
 	state.LocalEpoch.Store(zeroEpoch)
 	state.RemoteEpoch.Store(zeroEpoch)
 	ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
-	if len(ellipticCurves) < 1 {
+	if len(ellipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
 	state.NamedCurve = ellipticCurves[0]

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -4,6 +4,7 @@
 package flight12
 
 import (
+	"bytes"
 	"context"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -49,7 +50,7 @@ func flight1Parse(
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
-		state.Cookie = append([]byte{}, h.Cookie...)
+		state.Cookie = bytes.Clone(h.Cookie)
 		state.HandshakeRecvSequence = seq
 
 		return Flight3, nil, nil
@@ -69,7 +70,7 @@ func flight1Generate(
 	state.LocalEpoch.Store(zeroEpoch)
 	state.RemoteEpoch.Store(zeroEpoch)
 	ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
-	if len(ellipticCurves) < 1 {
+	if len(ellipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
 	state.NamedCurve = ellipticCurves[0]

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -42,7 +42,7 @@ func flight3Parse(
 			if !h.Version.Equal(protocol.Version1_0) && !h.Version.Equal(protocol.Version1_2) {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, dtlserrors.ErrUnsupportedProtocolVersion //nolint:lll
 			}
-			state.Cookie = append([]byte{}, h.Cookie...)
+			state.Cookie = bytes.Clone(h.Cookie)
 			state.HandshakeRecvSequence = seq
 
 			return Flight3, nil, nil

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -132,7 +132,7 @@ func flight0Generate(
 
 	state.LocalEpoch.Store(EpochInitial)
 	state.RemoteEpoch.Store(EpochInitial)
-	if len(cfg.EllipticCurves) < 1 {
+	if len(cfg.EllipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
 

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -28,10 +28,10 @@ func flight1Generate(
 
 	state.LocalEpoch.Store(EpochInitial)
 	state.RemoteEpoch.Store(EpochInitial)
-	if len(cfg.EllipticCurves) < 1 {
+	if len(cfg.EllipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
-	if len(cfg.LocalSignatureSchemes) < 1 {
+	if len(cfg.LocalSignatureSchemes) == 0 {
 		return nil, nil, dtlserrors.ErrNoAvailableSignatureSchemes
 	}
 	state.SelectedGroup = cfg.EllipticCurves[0]

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -237,7 +237,7 @@ func flight3Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	if len(flightCtx.cfg.LocalSignatureSchemes) < 1 {
+	if len(flightCtx.cfg.LocalSignatureSchemes) == 0 {
 		return nil, nil, dtlserrors.ErrNoAvailableSignatureSchemes
 	}
 

--- a/internal/flight/helpers.go
+++ b/internal/flight/helpers.go
@@ -32,10 +32,10 @@ func FindMatchingCipherSuite(a, b []dtlsconfig.CipherSuite) (dtlsconfig.CipherSu
 }
 
 func CipherSuiteIDs(cipherSuites []dtlsconfig.CipherSuite) []uint16 {
-	rtrn := []uint16{}
+	ids := []uint16{}
 	for _, c := range cipherSuites {
-		rtrn = append(rtrn, uint16(c.ID()))
+		ids = append(ids, uint16(c.ID()))
 	}
 
-	return rtrn
+	return ids
 }

--- a/internal/fragmentbuffer/fragment_buffer.go
+++ b/internal/fragmentbuffer/fragment_buffer.go
@@ -5,6 +5,8 @@
 package fragmentbuffer
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
@@ -127,7 +129,7 @@ func (f *FragmentBuffer) pushHandshakeFragments(
 		}
 
 		// Discard all headers, when rebuilding the packet we will re-build
-		frag.data = append([]byte{}, buf[handshake.HeaderLength:end]...)
+		frag.data = bytes.Clone(buf[handshake.HeaderLength:end])
 		frag.recordLayerHeader = recordLayerHeader
 
 		if _, ok = messageFragments.fragmentByOffset[frag.handshakeHeader.FragmentOffset]; !ok {

--- a/listener.go
+++ b/listener.go
@@ -16,7 +16,7 @@ func listenWithConfig(network string, laddr *net.UDPAddr, config *dtlsConfig) (n
 	lc := udp.ListenConfig{
 		AcceptFilter: func(packet []byte) bool {
 			pkts, err := recordlayer.UnpackDatagram(packet)
-			if err != nil || len(pkts) < 1 {
+			if err != nil || len(pkts) == 0 {
 				return false
 			}
 			h := &recordlayer.Header{}

--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"io"
 	"net"
+	"slices"
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -33,12 +34,6 @@ type ClientOption interface {
 type Option interface {
 	ServerOption
 	ClientOption
-}
-
-// defensiveCopy copies a slice. This prevents the caller from mutating
-// the config after construction. Returns empty slice if input is empty.
-func defensiveCopy[T any](t ...T) []T {
-	return append([]T{}, t...)
 }
 
 type dtlsConfig struct {
@@ -149,7 +144,7 @@ func WithCertificates(certs ...tls.Certificate) Option {
 		if len(certs) == 0 {
 			return dtlserrors.ErrEmptyCertificates
 		}
-		c.Certificates = defensiveCopy(certs...)
+		c.Certificates = slices.Clone(certs)
 
 		return nil
 	})
@@ -162,7 +157,7 @@ func WithCipherSuites(suites ...CipherSuiteID) Option {
 		if len(suites) == 0 {
 			return dtlserrors.ErrEmptyCipherSuites
 		}
-		c.CipherSuites = defensiveCopy(suites...)
+		c.CipherSuites = slices.Clone(suites)
 
 		return nil
 	})
@@ -188,7 +183,7 @@ func WithSignatureSchemes(schemes ...tls.SignatureScheme) Option {
 		if len(schemes) == 0 {
 			return dtlserrors.ErrEmptySignatureSchemes
 		}
-		c.SignatureSchemes = defensiveCopy(schemes...)
+		c.SignatureSchemes = slices.Clone(schemes)
 
 		return nil
 	})
@@ -204,7 +199,7 @@ func WithCertificateSignatureSchemes(schemes ...tls.SignatureScheme) Option {
 		if len(schemes) == 0 {
 			return dtlserrors.ErrEmptyCertificateSignatureSchemes
 		}
-		c.CertificateSignatureSchemes = defensiveCopy(schemes...)
+		c.CertificateSignatureSchemes = slices.Clone(schemes)
 
 		return nil
 	})
@@ -217,7 +212,7 @@ func WithSRTPProtectionProfiles(profiles ...SRTPProtectionProfile) Option {
 		if len(profiles) == 0 {
 			return dtlserrors.ErrEmptySRTPProtectionProfiles
 		}
-		c.SRTPProtectionProfiles = defensiveCopy(profiles...)
+		c.SRTPProtectionProfiles = slices.Clone(profiles)
 
 		return nil
 	})
@@ -226,7 +221,7 @@ func WithSRTPProtectionProfiles(profiles ...SRTPProtectionProfile) Option {
 // WithSRTPMasterKeyIdentifier sets the SRTP master key identifier.
 func WithSRTPMasterKeyIdentifier(identifier []byte) Option {
 	return sharedOption(func(c *dtlsConfig) error {
-		c.SRTPMasterKeyIdentifier = defensiveCopy(identifier...)
+		c.SRTPMasterKeyIdentifier = slices.Clone(identifier)
 
 		return nil
 	})
@@ -283,7 +278,7 @@ func WithPSK(callback PSKCallback) Option {
 // WithPSKIdentityHint sets the PSK identity hint.
 func WithPSKIdentityHint(hint []byte) Option {
 	return sharedOption(func(c *dtlsConfig) error {
-		c.PSKIdentityHint = defensiveCopy(hint...)
+		c.PSKIdentityHint = slices.Clone(hint)
 
 		return nil
 	})
@@ -413,7 +408,7 @@ func WithSupportedProtocols(protocols ...string) Option {
 		if len(protocols) == 0 {
 			return dtlserrors.ErrEmptySupportedProtocols
 		}
-		c.SupportedProtocols = defensiveCopy(protocols...)
+		c.SupportedProtocols = slices.Clone(protocols)
 
 		return nil
 	})
@@ -426,7 +421,7 @@ func WithEllipticCurves(curves ...elliptic.Curve) Option {
 		if len(curves) == 0 {
 			return dtlserrors.ErrEmptyEllipticCurves
 		}
-		c.EllipticCurves = defensiveCopy(curves...)
+		c.EllipticCurves = slices.Clone(curves)
 
 		return nil
 	})

--- a/pkg/crypto/ciphersuite/ciphersuite.go
+++ b/pkg/crypto/ciphersuite/ciphersuite.go
@@ -179,7 +179,7 @@ func generateAEADAdditionalDataCID(h *recordlayer.Header, payloadLen int) []byte
 //
 // https://github.com/golang/go/blob/039c2081d1178f90a8fa2f4e6958693129f8de33/src/crypto/tls/conn.go#L245
 func examinePadding(payload []byte) (toRemove int, good byte) {
-	if len(payload) < 1 {
+	if len(payload) == 0 {
 		return 0, 0
 	}
 

--- a/pkg/protocol/application_data.go
+++ b/pkg/protocol/application_data.go
@@ -3,6 +3,8 @@
 
 package protocol
 
+import "bytes"
+
 // ApplicationData messages are carried by the record layer and are
 // fragmented, compressed, and encrypted based on the current connection
 // state.  The messages are treated as transparent data to the record
@@ -19,12 +21,12 @@ func (a ApplicationData) ContentType() ContentType {
 
 // Marshal encodes the ApplicationData to binary.
 func (a *ApplicationData) Marshal() ([]byte, error) {
-	return append([]byte{}, a.Data...), nil
+	return bytes.Clone(a.Data), nil
 }
 
 // Unmarshal populates the ApplicationData from binary.
 func (a *ApplicationData) Unmarshal(data []byte) error {
-	a.Data = append([]byte{}, data...)
+	a.Data = bytes.Clone(data)
 
 	return nil
 }

--- a/pkg/protocol/compression_method.go
+++ b/pkg/protocol/compression_method.go
@@ -26,7 +26,7 @@ func CompressionMethods() map[CompressionMethodID]*CompressionMethod {
 
 // DecodeCompressionMethods the given compression methods.
 func DecodeCompressionMethods(buf []byte) ([]*CompressionMethod, error) {
-	if len(buf) < 1 {
+	if len(buf) == 0 {
 		return nil, dtlserrors.ErrBufferTooSmall
 	}
 	compressionMethodsCount := int(buf[0])

--- a/pkg/protocol/extension/certificate_auth.go
+++ b/pkg/protocol/extension/certificate_auth.go
@@ -24,7 +24,7 @@ func (c CertificateAuthorities) TypeValue() TypeValue {
 
 // Marshal encodes the extension.
 func (c *CertificateAuthorities) Marshal() ([]byte, error) {
-	if len(c.Authorities) < 1 {
+	if len(c.Authorities) == 0 {
 		return []byte{}, dtlserrors.ErrInvalidCertificateAuthFormat
 	}
 	var out cryptobyte.Builder
@@ -32,7 +32,7 @@ func (c *CertificateAuthorities) Marshal() ([]byte, error) {
 	out.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 			for _, ca := range c.Authorities {
-				if len(ca) < 1 {
+				if len(ca) == 0 {
 					b.SetError(dtlserrors.ErrInvalidCertificateAuthFormat)
 
 					return
@@ -72,7 +72,7 @@ func (c *CertificateAuthorities) unmarshalPayload(data []byte) error {
 	var cauths [][]byte
 	for !auths.Empty() {
 		var ca cryptobyte.String
-		if !auths.ReadUint16LengthPrefixed(&ca) || len(ca) < 1 {
+		if !auths.ReadUint16LengthPrefixed(&ca) || len(ca) == 0 {
 			return dtlserrors.ErrInvalidCertificateAuthFormat
 		}
 		cauths = append(cauths, ca)

--- a/pkg/protocol/extension/oid_filters.go
+++ b/pkg/protocol/extension/oid_filters.go
@@ -36,7 +36,7 @@ func (o *OIDFilters) Marshal() ([]byte, error) {
 		b.AddUint16LengthPrefixed(func(builder *cryptobyte.Builder) {
 			seen := map[string]struct{}{}
 			for _, filter := range o.Filters {
-				if len(filter.OID) < 1 {
+				if len(filter.OID) == 0 {
 					builder.SetError(dtlserrors.ErrEmptyOIDFilter)
 				}
 				if _, ok := seen[string(filter.OID)]; ok {

--- a/pkg/protocol/extension/supported_point_formats.go
+++ b/pkg/protocol/extension/supported_point_formats.go
@@ -59,7 +59,7 @@ func (s *SupportedPointFormats) Unmarshal(data []byte) error {
 
 func (s *SupportedPointFormats) unmarshalPayload(data []byte) error {
 	switch {
-	case len(data) < 1:
+	case len(data) == 0:
 		return dtlserrors.ErrBufferTooSmall
 	case int(data[0])+1 != len(data):
 		return dtlserrors.ErrLengthMismatch

--- a/pkg/protocol/handshake/cipher_suite.go
+++ b/pkg/protocol/handshake/cipher_suite.go
@@ -14,16 +14,16 @@ func decodeCipherSuiteIDs(buf []byte) ([]uint16, error) {
 		return nil, dtlserrors.ErrBufferTooSmall
 	}
 	cipherSuitesCount := int(binary.BigEndian.Uint16(buf[0:])) / 2
-	rtrn := make([]uint16, cipherSuitesCount)
+	ids := make([]uint16, cipherSuitesCount)
 	for i := range cipherSuitesCount {
 		if len(buf) < (i*2 + 4) {
 			return nil, dtlserrors.ErrBufferTooSmall
 		}
 
-		rtrn[i] = binary.BigEndian.Uint16(buf[(i*2)+2:])
+		ids[i] = binary.BigEndian.Uint16(buf[(i*2)+2:])
 	}
 
-	return rtrn, nil
+	return ids, nil
 }
 
 func encodeCipherSuiteIDs(cipherSuiteIDs []uint16) []byte {

--- a/pkg/protocol/handshake/message_certificate.go
+++ b/pkg/protocol/handshake/message_certificate.go
@@ -4,6 +4,8 @@
 package handshake
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/internal/util"
 )
@@ -75,7 +77,7 @@ func (m *MessageCertificate) Unmarshal(data []byte) error {
 			return dtlserrors.ErrLengthMismatch
 		}
 
-		m.Certificate = append(m.Certificate, append([]byte{}, data[offset:offset+certificateLen]...))
+		m.Certificate = append(m.Certificate, bytes.Clone(data[offset:offset+certificateLen]))
 		offset += certificateLen
 	}
 

--- a/pkg/protocol/handshake/message_certificate_verify.go
+++ b/pkg/protocol/handshake/message_certificate_verify.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/binary"
 
@@ -75,7 +76,7 @@ func (m *MessageCertificateVerify) Unmarshal(data []byte) error {
 		return dtlserrors.ErrBufferTooSmall
 	}
 
-	m.Signature = append([]byte{}, data[4:]...)
+	m.Signature = bytes.Clone(data[4:])
 
 	return nil
 }

--- a/pkg/protocol/handshake/message_client_hello.go
+++ b/pkg/protocol/handshake/message_client_hello.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -103,7 +104,7 @@ func (m *MessageClientHello) Unmarshal(data []byte) error { //nolint:cyclop
 	if len(data) <= currOffset+n {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	m.SessionID = append([]byte{}, data[currOffset:currOffset+n]...)
+	m.SessionID = bytes.Clone(data[currOffset : currOffset+n])
 	currOffset += len(m.SessionID)
 
 	currOffset++
@@ -114,7 +115,7 @@ func (m *MessageClientHello) Unmarshal(data []byte) error { //nolint:cyclop
 	if len(data) <= currOffset+n {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	m.Cookie = append([]byte{}, data[currOffset:currOffset+n]...)
+	m.Cookie = bytes.Clone(data[currOffset : currOffset+n])
 	currOffset += len(m.Cookie)
 
 	// Cipher Suites

--- a/pkg/protocol/handshake/message_client_key_exchange.go
+++ b/pkg/protocol/handshake/message_client_key_exchange.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite/types"
@@ -68,7 +69,7 @@ func (m *MessageClientKeyExchange) Unmarshal(data []byte) error {
 			return dtlserrors.ErrBufferTooSmall
 		}
 
-		m.IdentityHint = append([]byte{}, data[2:pskLength+2]...)
+		m.IdentityHint = bytes.Clone(data[2 : pskLength+2])
 		offset += pskLength + 2
 	}
 
@@ -78,7 +79,7 @@ func (m *MessageClientKeyExchange) Unmarshal(data []byte) error {
 			return dtlserrors.ErrBufferTooSmall
 		}
 
-		m.PublicKey = append([]byte{}, data[offset+1:]...)
+		m.PublicKey = bytes.Clone(data[offset+1:])
 	}
 
 	return nil

--- a/pkg/protocol/handshake/message_finished.go
+++ b/pkg/protocol/handshake/message_finished.go
@@ -3,6 +3,8 @@
 
 package handshake
 
+import "bytes"
+
 // MessageFinished is a DTLS Handshake Message
 // this message is the first one protected with the just
 // negotiated algorithms, keys, and secrets.  Recipients of Finished
@@ -20,12 +22,12 @@ func (m MessageFinished) Type() Type {
 
 // Marshal encodes the Handshake.
 func (m *MessageFinished) Marshal() ([]byte, error) {
-	return append([]byte{}, m.VerifyData...), nil
+	return bytes.Clone(m.VerifyData), nil
 }
 
 // Unmarshal populates the message from encoded data.
 func (m *MessageFinished) Unmarshal(data []byte) error {
-	m.VerifyData = append([]byte{}, data...)
+	m.VerifyData = bytes.Clone(data)
 
 	return nil
 }

--- a/pkg/protocol/handshake/message_server_hello.go
+++ b/pkg/protocol/handshake/message_server_hello.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -91,7 +92,7 @@ func (m *MessageServerHello) Unmarshal(data []byte) error {
 	if len(data) <= currOffset+n {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	m.SessionID = append([]byte{}, data[currOffset:currOffset+n]...)
+	m.SessionID = bytes.Clone(data[currOffset : currOffset+n])
 	currOffset += len(m.SessionID)
 
 	if len(data) < currOffset+2 {

--- a/pkg/protocol/handshake/message_server_key_exchange.go
+++ b/pkg/protocol/handshake/message_server_key_exchange.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/binary"
 
@@ -82,7 +83,7 @@ func (m *MessageServerKeyExchange) Unmarshal(data []byte) error { //nolint:cyclo
 
 	hintLength := binary.BigEndian.Uint16(data)
 	if int(hintLength) <= len(data)-2 && m.KeyExchangeAlgorithm.Has(types.KeyExchangeAlgorithmPsk) {
-		m.IdentityHint = append([]byte{}, data[2:2+hintLength]...)
+		m.IdentityHint = bytes.Clone(data[2 : 2+hintLength])
 		data = data[2+hintLength:]
 	}
 	if m.KeyExchangeAlgorithm == types.KeyExchangeAlgorithmPsk {
@@ -123,7 +124,7 @@ func (m *MessageServerKeyExchange) Unmarshal(data []byte) error { //nolint:cyclo
 	if len(data) < offset {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	m.PublicKey = append([]byte{}, data[4:offset]...)
+	m.PublicKey = bytes.Clone(data[4:offset])
 
 	// Anon connection doesn't contains hashAlgorithm, signatureAlgorithm, signature
 	if len(data) == offset {
@@ -152,7 +153,7 @@ func (m *MessageServerKeyExchange) Unmarshal(data []byte) error { //nolint:cyclo
 	if len(data) < offset+signatureLength {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	m.Signature = append([]byte{}, data[offset:offset+signatureLength]...)
+	m.Signature = bytes.Clone(data[offset : offset+signatureLength])
 
 	return nil
 }

--- a/pkg/protocol/recordlayer/inner_plaintext.go
+++ b/pkg/protocol/recordlayer/inner_plaintext.go
@@ -4,6 +4,8 @@
 package recordlayer
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"golang.org/x/crypto/cryptobyte"
@@ -48,7 +50,7 @@ func (p *InnerPlaintext) Unmarshal(data []byte) error {
 		return dtlserrors.ErrBufferTooSmall
 	}
 	p.RealType = protocol.ContentType(data[i])
-	p.Content = append([]byte{}, data[:i]...)
+	p.Content = bytes.Clone(data[:i])
 
 	return nil
 }

--- a/pkg/protocol/recordlayer/recordlayer_13.go
+++ b/pkg/protocol/recordlayer/recordlayer_13.go
@@ -165,7 +165,7 @@ func (r *CiphertextRecord13) Unmarshal(data []byte) error {
 		return ErrInvalidPacketLength
 	}
 
-	r.EncryptedRecord = append([]byte{}, data[headerSize:headerSize+recordLen]...)
+	r.EncryptedRecord = bytes.Clone(data[headerSize : headerSize+recordLen])
 
 	return nil
 }
@@ -246,7 +246,7 @@ func isMismatchedCiphertextCID(firstCID *[]byte, cid []byte, cidLength int) bool
 		return false
 	}
 	if *firstCID == nil {
-		*firstCID = append([]byte{}, cid...)
+		*firstCID = bytes.Clone(cid)
 
 		return false
 	}


### PR DESCRIPTION
Rename the queued-packet buffer guard to describe its ownership role and replace abbreviated locals with descriptive names.

Use standard clone helpers and consistent empty checks. Clarify comments without changing protocol behavior.
