### PR TITLE
Clarify connection state storage

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -929,7 +929,7 @@ func (c *Conn) Write(payload []byte) (int, error) {
 		{
 			Record: &recordlayer.RecordLayer{
 				Header: recordlayer.Header{
-					Epoch:   dtlsstate.CommonState(c.state).GetLocalEpoch(),
+					Epoch:   dtlsstate.CommonState(c.state).LocalEpoch(),
 					Version: protocol.Version1_2,
 				},
 				Content: &protocol.ApplicationData{
@@ -970,7 +970,7 @@ func (c *Conn) ConnectionState() (State, bool) {
 
 // SelectedSRTPProtectionProfile returns the selected SRTPProtectionProfile.
 func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
-	profile := dtlsstate.CommonState(c.state).GetSRTPProtectionProfile()
+	profile := dtlsstate.CommonState(c.state).SRTPProtectionProfile()
 	if profile == 0 {
 		return 0, false
 	}
@@ -981,7 +981,7 @@ func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
 // RemoteSRTPMasterKeyIdentifier returns the MasterKeyIdentifier value from the use_srtp.
 func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
 	common := dtlsstate.CommonState(c.state)
-	if profile := common.GetSRTPProtectionProfile(); profile == 0 {
+	if profile := common.SRTPProtectionProfile(); profile == 0 {
 		return nil, false
 	}
 
@@ -1599,7 +1599,7 @@ func (c *Conn) unpackDatagram(buf []byte) ([][]byte, error) {
 		return recordlayer.UnpackDatagram13(buf, 0, true)
 	}
 
-	return recordlayer.ContentAwareUnpackDatagram(buf, len(common.GetLocalConnectionID()))
+	return recordlayer.ContentAwareUnpackDatagram(buf, len(common.LocalConnectionID()))
 }
 
 func (c *Conn) queueableCiphertextEpoch(epochLow uint8, remoteEpoch uint16) bool {
@@ -1615,7 +1615,7 @@ func (c *Conn) queueableCiphertextEpoch(epochLow uint8, remoteEpoch uint16) bool
 func (c *Conn) unmarshalCiphertextRecord(buf []byte) (recordlayer.CiphertextRecord13, error) {
 	record := recordlayer.CiphertextRecord13{}
 	hasCID := buf[0]&recordlayer.UnifiedHeaderCIDBit != 0
-	localCID := dtlsstate.CommonState(c.state).GetLocalConnectionID()
+	localCID := dtlsstate.CommonState(c.state).LocalConnectionID()
 	if hasCID {
 		if len(localCID) == 0 {
 			return record, dtlserrors.ErrInvalidCiphertextHeader
@@ -1647,7 +1647,7 @@ func (c *Conn) openCiphertextRecord(
 		return recordlayer.InnerPlaintext{}, 0, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 	}
 
-	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
+	remoteEpoch := dtlsstate.CommonState(c.state).RemoteEpoch()
 	if record.Header.EpochLow != uint8(remoteEpoch&recordlayer.TwoLowBitsMask) {
 		return recordlayer.InnerPlaintext{}, 0, dtlserrors.ErrInvalidEpoch
 	}
@@ -1774,7 +1774,7 @@ func (c *Conn) prepareCiphertextPacket(
 		return incomingPacketState{}, false
 	}
 
-	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
+	remoteEpoch := dtlsstate.CommonState(c.state).RemoteEpoch()
 	if ciphertext.Header.EpochLow != uint8(remoteEpoch&recordlayer.TwoLowBitsMask) {
 		c.handleFutureCiphertextPacket(ciphertext.Header.EpochLow, remoteEpoch, rAddr, buf, bufferLease)
 
@@ -1937,7 +1937,7 @@ func (c *Conn) unmarshalLegacyHeader(buf []byte) (*recordlayer.Header, bool) {
 	header := &recordlayer.Header{}
 	// Set connection ID size so that records of content type tls12_cid will
 	// be parsed correctly.
-	localCID := dtlsstate.CommonState(c.state).GetLocalConnectionID()
+	localCID := dtlsstate.CommonState(c.state).LocalConnectionID()
 	if len(localCID) > 0 {
 		header.ConnectionID = make([]byte, len(localCID))
 	}
@@ -1958,7 +1958,7 @@ func (c *Conn) handleFutureLegacyPacket(
 	buf []byte,
 	bufferLease *readBufferLease,
 ) bool {
-	remoteEpoch := dtlsstate.CommonState(c.state).GetRemoteEpoch()
+	remoteEpoch := dtlsstate.CommonState(c.state).RemoteEpoch()
 	if header.Epoch <= remoteEpoch {
 		return false
 	}
@@ -2035,7 +2035,7 @@ func (c *Conn) decryptLegacyPacket(
 
 func (c *Conn) validateLegacyCIDPresence(header *recordlayer.Header) bool {
 	common := dtlsstate.CommonState(c.state)
-	if len(common.GetLocalConnectionID()) == 0 || header.ContentType == protocol.ContentTypeConnectionID {
+	if len(common.LocalConnectionID()) == 0 || header.ContentType == protocol.ContentTypeConnectionID {
 		return true
 	}
 
@@ -2048,7 +2048,7 @@ func (c *Conn) decryptLegacyRecord(header *recordlayer.Header, buf []byte) ([]by
 	var decryptHeader recordlayer.Header
 	common := dtlsstate.CommonState(c.state)
 	if header.ContentType == protocol.ContentTypeConnectionID {
-		decryptHeader.ConnectionID = make([]byte, len(common.GetLocalConnectionID()))
+		decryptHeader.ConnectionID = make([]byte, len(common.LocalConnectionID()))
 	}
 	decrypted, err := common.CipherSuite.Decrypt(decryptHeader, buf)
 	if err != nil {
@@ -2061,7 +2061,7 @@ func (c *Conn) decryptLegacyRecord(header *recordlayer.Header, buf []byte) ([]by
 }
 
 func (c *Conn) validateLegacyCID(header *recordlayer.Header) bool {
-	if bytes.Equal(dtlsstate.CommonState(c.state).GetLocalConnectionID(), header.ConnectionID) {
+	if bytes.Equal(dtlsstate.CommonState(c.state).LocalConnectionID(), header.ConnectionID) {
 		return true
 	}
 
@@ -2179,7 +2179,7 @@ func (c *Conn) handleIncomingPacket(
 		newRemoteEpoch := header.Epoch + 1
 		c.log.Tracef("%s: <- ChangeCipherSpec (epoch: %d)", srvCliStr(common.IsClient), newRemoteEpoch)
 
-		if common.GetRemoteEpoch()+1 == newRemoteEpoch {
+		if common.RemoteEpoch()+1 == newRemoteEpoch {
 			c.setRemoteEpoch(newRemoteEpoch)
 			isLatestSeqNum = markPacketAsValid()
 		}
@@ -2274,7 +2274,7 @@ func (c *Conn) notify(ctx context.Context, level alert.Level, desc alert.Descrip
 		{
 			Record: &recordlayer.RecordLayer{
 				Header: recordlayer.Header{
-					Epoch:   common.GetLocalEpoch(),
+					Epoch:   common.LocalEpoch(),
 					Version: protocol.Version1_2,
 				},
 				Content: &alert.Alert{
@@ -2762,11 +2762,11 @@ func (c *Conn) isConnectionClosed() bool {
 }
 
 func (c *Conn) setLocalEpoch(epoch uint16) {
-	dtlsstate.CommonState(c.state).LocalEpoch.Store(epoch)
+	dtlsstate.CommonState(c.state).SetLocalEpoch(epoch)
 }
 
 func (c *Conn) setRemoteEpoch(epoch uint16) {
-	dtlsstate.CommonState(c.state).RemoteEpoch.Store(epoch)
+	dtlsstate.CommonState(c.state).SetRemoteEpoch(epoch)
 }
 
 // LocalAddr implements net.Conn.LocalAddr.

--- a/conn_test.go
+++ b/conn_test.go
@@ -1420,11 +1420,11 @@ func TestConnectionID(t *testing.T) {
 				}
 			}()
 
-			assert.True(t, bytes.Equal(tt.clientConnectionID, dtlsstate.CommonState(res.c.state).GetLocalConnectionID()),
+			assert.True(t, bytes.Equal(tt.clientConnectionID, dtlsstate.CommonState(res.c.state).LocalConnectionID()),
 				"Unexpected client local connection ID")
 			assert.True(t, bytes.Equal(tt.serverConnectionID, dtlsstate.CommonState(res.c.state).RemoteConnectionID),
 				"Unexpected client remote connection ID")
-			assert.True(t, bytes.Equal(tt.serverConnectionID, dtlsstate.CommonState(server.state).GetLocalConnectionID()),
+			assert.True(t, bytes.Equal(tt.serverConnectionID, dtlsstate.CommonState(server.state).LocalConnectionID()),
 				"Unexpected server local connection ID")
 			assert.True(t, bytes.Equal(tt.clientConnectionID, dtlsstate.CommonState(server.state).RemoteConnectionID),
 				"Unexpected server remote connection ID")

--- a/flight_test.go
+++ b/flight_test.go
@@ -920,7 +920,7 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, dtlsflight13.Flight3, nextFlight)
-	entries := *state.RemoteKeyEntries
+	entries := state.RemoteKeyEntries
 	require.Len(t, entries, 1)
 	assert.Equal(t, selectedGroup, entries[0].Group)
 	assert.Empty(t, entries[0].KeyExchange)
@@ -954,7 +954,7 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *test
 	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
 	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
 	assert.Zero(t, nextFlight)
-	assert.Nil(t, state.RemoteKeyEntries)
+	assert.False(t, state.HasRemoteKeyEntries)
 }
 
 func TestFlight13_1ParseRejectsHelloRetryRequestWithWrongSelectedVersion(t *testing.T) {
@@ -989,7 +989,7 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithWrongSelectedVersion(t *test
 	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
 	assert.Equal(t, alert.ProtocolVersion, dtlsAlert.Description)
 	assert.Zero(t, nextFlight)
-	assert.Nil(t, state.RemoteKeyEntries)
+	assert.False(t, state.HasRemoteKeyEntries)
 }
 
 func TestFlight13_1ParseRejectsHelloRetryRequestWithClientHelloSupportedVersionsEncoding(t *testing.T) {
@@ -1029,7 +1029,7 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithClientHelloSupportedVersions
 	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
 	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
 	assert.Zero(t, nextFlight)
-	assert.Nil(t, state.RemoteKeyEntries)
+	assert.False(t, state.HasRemoteKeyEntries)
 }
 
 func TestFlight13_3GenerateRejectsWithoutCommonVersion(t *testing.T) {
@@ -1119,7 +1119,8 @@ func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.
 	state.LocalKeyEntries = []extension.KeyShareEntry{
 		{Group: originalKeypair.Curve, KeyExchange: originalKeypair.PublicKey},
 	}
-	state.RemoteKeyEntries = &[]extension.KeyShareEntry{{Group: selectedGroup}}
+	state.RemoteKeyEntries = []extension.KeyShareEntry{{Group: selectedGroup}}
+	state.HasRemoteKeyEntries = true
 	require.NoError(t, state.LocalRandom.Populate())
 
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight3, &handshakeTestContext13{
@@ -1171,7 +1172,8 @@ func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T)
 	state.LocalKeyEntries = []extension.KeyShareEntry{
 		{Group: keypair.Curve, KeyExchange: keypair.PublicKey},
 	}
-	state.RemoteKeyEntries = &[]extension.KeyShareEntry{{Group: selectedGroup}}
+	state.RemoteKeyEntries = []extension.KeyShareEntry{{Group: selectedGroup}}
+	state.HasRemoteKeyEntries = true
 	require.NoError(t, state.LocalRandom.Populate())
 
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight3, &handshakeTestContext13{
@@ -1283,9 +1285,9 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	assert.Equal(t, cfg.LocalCipherSuites[0].ID(), state.CipherSuite.ID())
 	assert.Equal(t, group, state.SelectedGroup)
 	assert.Equal(t, random.RandomBytes, state.RemoteRandom.RandomBytes)
-	require.NotNil(t, state.RemoteKeyEntries)
-	require.Len(t, *state.RemoteKeyEntries, 1)
-	assert.Equal(t, group, (*state.RemoteKeyEntries)[0].Group)
+	require.True(t, state.HasRemoteKeyEntries)
+	require.Len(t, state.RemoteKeyEntries, 1)
+	assert.Equal(t, group, state.RemoteKeyEntries[0].Group)
 
 	assert.Equal(t, expected, state.KeyAgreementSecret)
 	assert.NotEmpty(t, state.KeyAgreementSecret)
@@ -1356,7 +1358,7 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 		handleQueuedPackets: func(context.Context) error {
 			drained = true
 			assert.True(t, state.CipherSuite.IsInitialized())
-			assert.Equal(t, dtlsflight13.EpochHandshake, state.GetRemoteEpoch())
+			assert.Equal(t, dtlsflight13.EpochHandshake, state.RemoteEpoch())
 			cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 			cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
 

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -195,8 +195,8 @@ func flight0Generate(
 	}
 
 	var zeroEpoch uint16
-	state.LocalEpoch.Store(zeroEpoch)
-	state.RemoteEpoch.Store(zeroEpoch)
+	state.SetLocalEpoch(zeroEpoch)
+	state.SetRemoteEpoch(zeroEpoch)
 	ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
 	if len(ellipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -67,8 +67,8 @@ func flight1Generate(
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	var zeroEpoch uint16
-	state.LocalEpoch.Store(zeroEpoch)
-	state.RemoteEpoch.Store(zeroEpoch)
+	state.SetLocalEpoch(zeroEpoch)
+	state.SetRemoteEpoch(zeroEpoch)
 	ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
 	if len(ellipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
@@ -162,10 +162,10 @@ func flight1Generate(
 		// use the presence of a non-nil local CID in flight 3 to determine
 		// whether we send a CID in the second ClientHello, so we convert any
 		// nil CID returned by a generator to []byte{}.
-		if state.GetLocalConnectionID() == nil {
+		if state.LocalConnectionID() == nil {
 			state.SetLocalConnectionID([]byte{})
 		}
-		extensions = append(extensions, &extension.ConnectionID{CID: state.GetLocalConnectionID()})
+		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
 	}
 
 	clientHello := &handshake.MessageClientHello{

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -100,7 +100,7 @@ func flight3Parse(
 		if cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret && !state.ExtendedMasterSecret {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrClientRequiredButNoServerEMS //nolint:lll
 		}
-		if len(cfg.LocalSRTPProtectionProfiles) > 0 && state.GetSRTPProtectionProfile() == 0 {
+		if len(cfg.LocalSRTPProtectionProfiles) > 0 && state.SRTPProtectionProfile() == 0 {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrRequestedButNoSRTPExtension //nolint:lll
 		}
 
@@ -346,8 +346,8 @@ func flight3Generate(
 
 	// If we sent a connection ID on the first ClientHello, send it on the
 	// second.
-	if state.GetLocalConnectionID() != nil {
-		extensions = append(extensions, &extension.ConnectionID{CID: state.GetLocalConnectionID()})
+	if state.LocalConnectionID() != nil {
+		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
 	}
 
 	clientHello := &handshake.MessageClientHello{

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -75,9 +75,9 @@ func flight4bGenerate(
 			Supported: true,
 		})
 	}
-	if state.GetSRTPProtectionProfile() != 0 {
+	if state.SRTPProtectionProfile() != 0 {
 		extensions = append(extensions, &extension.UseSRTP{
-			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.GetSRTPProtectionProfile()},
+			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.SRTPProtectionProfile()},
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
 	}

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -261,9 +261,9 @@ func flight4Generate(
 			Supported: true,
 		})
 	}
-	if state.GetSRTPProtectionProfile() != 0 {
+	if state.SRTPProtectionProfile() != 0 {
 		extensions = append(extensions, &extension.UseSRTP{
-			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.GetSRTPProtectionProfile()},
+			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.SRTPProtectionProfile()},
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
 	}
@@ -295,7 +295,7 @@ func flight4Generate(
 	// client won't send it.
 	if cfg.ConnectionIDGenerator != nil && state.RemoteConnectionID != nil {
 		state.SetLocalConnectionID(cfg.ConnectionIDGenerator())
-		extensions = append(extensions, &extension.ConnectionID{CID: state.GetLocalConnectionID()})
+		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
 	}
 
 	var pkts []*dtlsflight.Packet

--- a/internal/flight/flight13/extensions.go
+++ b/internal/flight/flight13/extensions.go
@@ -109,6 +109,7 @@ func processClientHelloStateExtension(
 		// Store the client's certificate signature schemes for later validation.
 		state.RemoteCertSignatureSchemes = ext.SignatureHashAlgorithms
 	case *extension.KeyShare:
-		state.RemoteKeyEntries = &ext.ClientShares
+		state.RemoteKeyEntries = ext.ClientShares
+		state.HasRemoteKeyEntries = true
 	}
 }

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -130,8 +130,8 @@ func flight0Generate(
 		}
 	}
 
-	state.LocalEpoch.Store(EpochInitial)
-	state.RemoteEpoch.Store(EpochInitial)
+	state.SetLocalEpoch(EpochInitial)
+	state.SetRemoteEpoch(EpochInitial)
 	if len(cfg.EllipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -26,8 +26,8 @@ func flight1Generate(
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 
-	state.LocalEpoch.Store(EpochInitial)
-	state.RemoteEpoch.Store(EpochInitial)
+	state.SetLocalEpoch(EpochInitial)
+	state.SetRemoteEpoch(EpochInitial)
 	if len(cfg.EllipticCurves) == 0 {
 		return nil, nil, dtlserrors.ErrEmptyEllipticCurves
 	}
@@ -224,9 +224,10 @@ func flight1Parse(
 			state.Cookie = ext.Cookie
 		case *extension.KeyShare:
 			if ext.SelectedGroup != nil {
-				state.RemoteKeyEntries = &[]extension.KeyShareEntry{
+				state.RemoteKeyEntries = []extension.KeyShareEntry{
 					{Group: *ext.SelectedGroup},
 				}
+				state.HasRemoteKeyEntries = true
 			}
 		}
 	}

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -166,7 +166,8 @@ func applyFlight3ServerKeyShare(
 	}
 	flightCtx.state.KeyAgreementSecret = keyAgreementSecret
 	flightCtx.state.SelectedGroup = serverShare.Group
-	flightCtx.state.RemoteKeyEntries = &[]extension.KeyShareEntry{*serverShare}
+	flightCtx.state.RemoteKeyEntries = []extension.KeyShareEntry{*serverShare}
+	flightCtx.state.HasRemoteKeyEntries = true
 
 	return nil
 }
@@ -193,7 +194,7 @@ func initializeFlight3HandshakeProtection(
 	if err := flightCtx.handshakeRecordProtectionInitializer(flightCtx.state); err != nil {
 		return newFlightParseFailure(alert.InternalError, err)
 	}
-	flightCtx.state.RemoteEpoch.Store(EpochHandshake)
+	flightCtx.state.SetRemoteEpoch(EpochHandshake)
 	if conn == nil {
 		return nil
 	}
@@ -276,12 +277,12 @@ func flight3Generate(
 	var localGroups []elliptic.Curve
 	var newEntries []extension.KeyShareEntry
 	newKeypairs := map[elliptic.Curve]*elliptic.Keypair{}
-	if flightCtx.state.RemoteKeyEntries != nil {
+	if flightCtx.state.HasRemoteKeyEntries {
 		for _, entry := range flightCtx.state.LocalKeyEntries {
 			localGroups = append(localGroups, entry.Group)
 		}
 
-		for _, entry := range *flightCtx.state.RemoteKeyEntries {
+		for _, entry := range flightCtx.state.RemoteKeyEntries {
 			if !slices.Contains(localGroups, entry.Group) && slices.Contains(flightCtx.cfg.EllipticCurves, entry.Group) {
 				keypair, err := elliptic.GenerateKeypair(entry.Group)
 				if err != nil {

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -158,10 +158,10 @@ func clientKeyShareForGroup(
 	state *dtlsstate.State13,
 	group elliptic.Curve,
 ) (extension.KeyShareEntry, bool) {
-	if state.RemoteKeyEntries == nil {
+	if !state.HasRemoteKeyEntries {
 		return extension.KeyShareEntry{}, false
 	}
-	for _, entry := range *state.RemoteKeyEntries {
+	for _, entry := range state.RemoteKeyEntries {
 		if entry.Group == group {
 			return entry, true
 		}

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -183,12 +183,12 @@ func TestHandshakeFSM13OwnsTranscriptAndPropagatesContext(t *testing.T) {
 
 func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
 	state := newTestState13(true)
-	state.LocalEpoch.Store(dtlsflight13.EpochApplication)
+	state.SetLocalEpoch(dtlsflight13.EpochApplication)
 	conn := &flightTestConn{}
 	fsm := &fsm13{handshakeContext: handshakeContext{state: state}}
 	records := []protocol.RecordNumber{{Epoch: 2, SequenceNumber: 7}}
 
-	require.NoError(t, sendACK(context.Background(), conn, fsm.state.GetLocalEpoch(), records))
+	require.NoError(t, sendACK(context.Background(), conn, fsm.state.LocalEpoch(), records))
 	require.Len(t, conn.writtenPackets, 1)
 	assert.True(t, conn.writtenPackets[0].ShouldEncrypt)
 	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Record.Header.Epoch)
@@ -201,7 +201,7 @@ func TestHandshakeFSM13DoesNotSendEmptyACK(t *testing.T) {
 	conn := &flightTestConn{}
 	fsm := &fsm13{handshakeContext: handshakeContext{state: newTestState13(false)}}
 
-	require.NoError(t, sendACK(context.Background(), conn, fsm.state.GetLocalEpoch(), nil))
+	require.NoError(t, sendACK(context.Background(), conn, fsm.state.LocalEpoch(), nil))
 	assert.Empty(t, conn.writtenPackets)
 }
 
@@ -556,14 +556,14 @@ func TestHandshakeFSM13ServerFlight4KeepsReaderPausedThroughQueueDrain(t *testin
 	require.Equal(t, StateWaiting, nextState)
 	assertFlight13RecvDoneClosed(t, recvState)
 	assert.Equal(t, 1, queueDrains)
-	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.GetRemoteEpoch())
+	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.RemoteEpoch())
 
 	conn.writePackets = nil
 	nextState, err = fsm.send(context.Background(), conn)
 	require.NoError(t, err)
 	require.Equal(t, StateWaiting, nextState)
 	assert.Equal(t, 1, queueDrains)
-	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.GetRemoteEpoch())
+	assert.Equal(t, dtlsflight13.EpochHandshake, serverState.RemoteEpoch())
 }
 
 func TestHandshakeFSM13NonDrainingTransitionReleasesReaderAfterWait(t *testing.T) {
@@ -630,7 +630,7 @@ func TestHandshakeFSM13ReaderPauseRequiredOnlyForQueueDrainingTransitions(t *tes
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			state := newTestState13(test.isClient)
-			state.RemoteEpoch.Store(test.remoteEpoch)
+			state.SetRemoteEpoch(test.remoteEpoch)
 			flightContext := handshakeContext{state: state}
 			assert.Equal(t, test.expected, flightContext.transitionRequiresReaderPause(test.nextFlight))
 		})
@@ -682,7 +682,7 @@ func TestHandshakeFSM13WaitParsesProtectedEncryptedExtensions(t *testing.T) {
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
 	assert.Equal(t, 5, fixture.clientState.HandshakeRecvSequence)
 	assert.True(t, fixture.clientState.CipherSuite.IsInitialized())
-	assert.Equal(t, dtlsflight13.EpochHandshake, fixture.clientState.GetRemoteEpoch())
+	assert.Equal(t, dtlsflight13.EpochHandshake, fixture.clientState.RemoteEpoch())
 	assertFlight13RecvDoneOpen(t, recvState)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
 
@@ -1021,7 +1021,7 @@ func TestHandshakeFSM13ServerVerifiesClientFinishedAndCompletes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StateFinished, nextState)
 	assert.Equal(t, 2, fixture.serverState.HandshakeRecvSequence)
-	assert.Equal(t, dtlsflight13.EpochApplication, fixture.serverState.GetRemoteEpoch())
+	assert.Equal(t, dtlsflight13.EpochApplication, fixture.serverState.RemoteEpoch())
 	assert.True(t, conn.setLocalEpochCalled)
 	assert.Equal(t, dtlsflight13.EpochApplication, conn.localEpoch)
 	assertFlight13RecvDoneClosed(t, recvState)

--- a/internal/handshake/handshake_context.go
+++ b/internal/handshake/handshake_context.go
@@ -50,10 +50,10 @@ func (c *handshakeContext) afterSend(
 ) (bool, error) {
 	if !c.state.IsClient &&
 		flight == dtlsflight13.Flight4 &&
-		c.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake {
+		c.state.RemoteEpoch() < dtlsflight13.EpochHandshake {
 		// Only the first send advances the epoch and drains packets. A timer
 		// retransmission has no receive-side rendezvous and the reader is active.
-		c.state.RemoteEpoch.Store(dtlsflight13.EpochHandshake)
+		c.state.SetRemoteEpoch(dtlsflight13.EpochHandshake)
 		if err := conn.HandleQueuedPackets(ctx); err != nil {
 			return false, err
 		}
@@ -108,7 +108,7 @@ func (c *handshakeContext) advanceAfterReceivedFlight(
 		if err := activateApplicationRecordProtection(ctx, conn, c.state); err != nil {
 			return receivedFlightTransition{}, err
 		}
-		if err := sendACK(ctx, conn, c.state.GetLocalEpoch(), receivedRecords); err != nil {
+		if err := sendACK(ctx, conn, c.state.LocalEpoch(), receivedRecords); err != nil {
 			return receivedFlightTransition{}, err
 		}
 
@@ -135,7 +135,7 @@ func (c *handshakeContext) transitionRequiresReaderPause(nextFlight dtlsflight13
 	}
 
 	return nextFlight == dtlsflight13.Flight4 &&
-		c.state.GetRemoteEpoch() < dtlsflight13.EpochHandshake
+		c.state.RemoteEpoch() < dtlsflight13.EpochHandshake
 }
 
 func (c *handshakeContext) parseDependencies() dtlsflight13.ParseDependencies {

--- a/internal/handshake/protected_flight.go
+++ b/internal/handshake/protected_flight.go
@@ -344,22 +344,11 @@ func cloneState13ForVerifyConnection(state *dtlsstate.State13, peerCertificates 
 	if !state.LocalVersion.Equal(protocol.Version{}) {
 		common.LocalVersion = state.LocalVersion
 	}
-	if localEpoch, ok := state.LocalEpoch.Load().(uint16); ok {
-		common.LocalEpoch.Store(localEpoch)
-	}
-	if remoteEpoch, ok := state.RemoteEpoch.Load().(uint16); ok {
-		common.RemoteEpoch.Store(remoteEpoch)
-	}
-	if profile, ok := state.SRTPProtectionProfile.Load().(extension.SRTPProtectionProfile); ok {
-		common.SRTPProtectionProfile.Store(profile)
-	}
-	if localCID := state.GetLocalConnectionID(); localCID != nil {
+	common.SetLocalEpoch(state.LocalEpoch())
+	common.SetRemoteEpoch(state.RemoteEpoch())
+	common.SetSRTPProtectionProfile(state.SRTPProtectionProfile())
+	if localCID := state.LocalConnectionID(); localCID != nil {
 		common.SetLocalConnectionID(bytes.Clone(localCID))
-	}
-	var remoteKeyEntries *[]extension.KeyShareEntry
-	if state.RemoteKeyEntries != nil {
-		entries := append([]extension.KeyShareEntry(nil), (*state.RemoteKeyEntries)...)
-		remoteKeyEntries = &entries
 	}
 
 	return &dtlsstate.State13{
@@ -368,7 +357,8 @@ func cloneState13ForVerifyConnection(state *dtlsstate.State13, peerCertificates 
 		KeyAgreementSecret:    bytes.Clone(state.KeyAgreementSecret),
 		SelectedGroup:         state.SelectedGroup,
 		LocalKeyEntries:       append([]extension.KeyShareEntry(nil), state.LocalKeyEntries...),
-		RemoteKeyEntries:      remoteKeyEntries,
+		RemoteKeyEntries:      append([]extension.KeyShareEntry(nil), state.RemoteKeyEntries...),
+		HasRemoteKeyEntries:   state.HasRemoteKeyEntries,
 		RemoteGroups:          append([]elliptic.Curve(nil), state.RemoteGroups...),
 		Cookie:                bytes.Clone(state.Cookie),
 		HandshakeSendSequence: state.HandshakeSendSequence,

--- a/internal/handshake/record_protection.go
+++ b/internal/handshake/record_protection.go
@@ -38,7 +38,7 @@ func activateApplicationRecordProtection(ctx context.Context, conn Conn, state *
 		return err
 	}
 	conn.SetLocalEpoch(dtlsflight13.EpochApplication)
-	state.RemoteEpoch.Store(dtlsflight13.EpochApplication)
+	state.SetRemoteEpoch(dtlsflight13.EpochApplication)
 
 	return conn.HandleQueuedPackets(ctx)
 }

--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -213,10 +213,10 @@ func populateOutboundFinished(
 func deriveHandshakeTrafficSecrets(
 	hashFunc func() hash.Hash,
 	keyAgreementSecret, transcriptHash []byte,
-) (dtlsstate.HandshakeTrafficSecrets, error) {
+) (dtlsstate.TrafficSecrets, error) {
 	secrets, err := deriveHandshakeKeySchedule(hashFunc, keyAgreementSecret, transcriptHash)
 	if err != nil {
-		return dtlsstate.HandshakeTrafficSecrets{}, err
+		return dtlsstate.TrafficSecrets{}, err
 	}
 
 	return secrets.HandshakeTrafficSecrets, nil

--- a/internal/state/common.go
+++ b/internal/state/common.go
@@ -18,7 +18,7 @@ import (
 
 // Common is the protocol-independent connection state shared by DTLS versions.
 type Common struct {
-	LocalEpoch, RemoteEpoch   atomic.Value
+	localEpoch, remoteEpoch   atomic.Uint32
 	LocalSequenceNumber       []uint64 // uint48
 	RemoteSequenceNumber      []uint64
 	LocalRandom, RemoteRandom handshake.Random
@@ -28,7 +28,7 @@ type Common struct {
 	SessionID                 []byte
 	NegotiatedProtocol        string
 
-	SRTPProtectionProfile         atomic.Value // Negotiated SRTPProtectionProfile
+	srtpProtectionProfile         atomic.Uint32 // Negotiated SRTPProtectionProfile
 	RemoteSRTPMasterKeyIdentifier []byte
 
 	// Connection Identifiers must be negotiated afresh on session resumption.
@@ -38,7 +38,7 @@ type Common struct {
 	// to be received from the remote endpoint.
 	// For a server, this is the connection ID sent in ServerHello.
 	// For a client, this is the connection ID sent in the ClientHello.
-	LocalConnectionID atomic.Value
+	localConnectionID atomic.Value
 	// RemoteConnectionID is the connection ID that the remote endpoint
 	// specifies should be sent.
 	// For a server, this is the connection ID received in the ClientHello.
@@ -59,36 +59,32 @@ type Common struct {
 	RemoteVersions []protocol.Version
 }
 
-func (s *Common) GetRemoteEpoch() uint16 {
-	if remoteEpoch, ok := s.RemoteEpoch.Load().(uint16); ok {
-		return remoteEpoch
-	}
-
-	return 0
+func (s *Common) RemoteEpoch() uint16 {
+	return uint16(s.remoteEpoch.Load()) //nolint:gosec // Epochs are stored as uint16 values.
 }
 
-func (s *Common) GetLocalEpoch() uint16 {
-	if localEpoch, ok := s.LocalEpoch.Load().(uint16); ok {
-		return localEpoch
-	}
+func (s *Common) SetRemoteEpoch(epoch uint16) {
+	s.remoteEpoch.Store(uint32(epoch))
+}
 
-	return 0
+func (s *Common) LocalEpoch() uint16 {
+	return uint16(s.localEpoch.Load()) //nolint:gosec // Epochs are stored as uint16 values.
+}
+
+func (s *Common) SetLocalEpoch(epoch uint16) {
+	s.localEpoch.Store(uint32(epoch))
 }
 
 func (s *Common) SetSRTPProtectionProfile(profile extension.SRTPProtectionProfile) {
-	s.SRTPProtectionProfile.Store(profile)
+	s.srtpProtectionProfile.Store(uint32(profile))
 }
 
-func (s *Common) GetSRTPProtectionProfile() extension.SRTPProtectionProfile {
-	if val, ok := s.SRTPProtectionProfile.Load().(extension.SRTPProtectionProfile); ok {
-		return val
-	}
-
-	return 0
+func (s *Common) SRTPProtectionProfile() extension.SRTPProtectionProfile {
+	return extension.SRTPProtectionProfile(s.srtpProtectionProfile.Load()) //nolint:gosec // Stored profile is uint16.
 }
 
-func (s *Common) GetLocalConnectionID() []byte {
-	if val, ok := s.LocalConnectionID.Load().([]byte); ok {
+func (s *Common) LocalConnectionID() []byte {
+	if val, ok := s.localConnectionID.Load().([]byte); ok {
 		return val
 	}
 
@@ -96,7 +92,7 @@ func (s *Common) GetLocalConnectionID() []byte {
 }
 
 func (s *Common) SetLocalConnectionID(v []byte) {
-	s.LocalConnectionID.Store(v)
+	s.localConnectionID.Store(v)
 }
 
 // State is retained as the DTLS 1.2 state alias for callers that still only

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -14,10 +14,6 @@ type TrafficSecrets struct {
 	Server []byte
 }
 
-// HandshakeTrafficSecrets is retained as a type alias for tests and helper
-// code that name the DTLS 1.3 handshake traffic secrets directly.
-type HandshakeTrafficSecrets = TrafficSecrets
-
 type KeySchedule struct {
 	EarlySecret     []byte
 	HandshakeSecret []byte
@@ -52,8 +48,9 @@ type State13 struct {
 
 	LocalKeyEntries []extension.KeyShareEntry
 
-	RemoteKeyEntries *[]extension.KeyShareEntry
-	RemoteGroups     []elliptic.Curve
+	RemoteKeyEntries    []extension.KeyShareEntry
+	HasRemoteKeyEntries bool
+	RemoteGroups        []elliptic.Curve
 
 	Cookie                []byte
 	HandshakeSendSequence int

--- a/state.go
+++ b/state.go
@@ -64,17 +64,17 @@ func generateState(internalState *dtlsstate.State) (*State, error) {
 		return nil, ErrStateSerializationUnsupported
 	}
 
-	epoch := internalState.GetLocalEpoch()
+	epoch := internalState.LocalEpoch()
 
 	return &State{
-		localEpoch:            internalState.GetLocalEpoch(),
-		remoteEpoch:           internalState.GetRemoteEpoch(),
+		localEpoch:            internalState.LocalEpoch(),
+		remoteEpoch:           internalState.RemoteEpoch(),
 		localRandom:           internalState.LocalRandom,
 		remoteRandom:          internalState.RemoteRandom,
 		masterSecret:          internalState.MasterSecret,
 		sequenceNumber:        atomic.LoadUint64(&internalState.LocalSequenceNumber[epoch]),
-		srtpProtectionProfile: internalState.GetSRTPProtectionProfile(),
-		localConnectionID:     internalState.GetLocalConnectionID(),
+		srtpProtectionProfile: internalState.SRTPProtectionProfile(),
+		localConnectionID:     internalState.LocalConnectionID(),
 		remoteConnectionID:    internalState.RemoteConnectionID,
 		isClient:              internalState.IsClient,
 		version:               protocol.Version1_2,
@@ -107,20 +107,20 @@ func generateState13(internalState *dtlsstate.State13) (*State, error) {
 		return nil, dtlserrors.ErrInvalidProtocolVersionState
 	}
 
-	epoch := common.GetLocalEpoch()
+	epoch := common.LocalEpoch()
 	var sequenceNumber uint64
 	if int(epoch) < len(common.LocalSequenceNumber) {
 		sequenceNumber = atomic.LoadUint64(&common.LocalSequenceNumber[epoch])
 	}
 
 	return &State{
-		localEpoch:            common.GetLocalEpoch(),
-		remoteEpoch:           common.GetRemoteEpoch(),
+		localEpoch:            common.LocalEpoch(),
+		remoteEpoch:           common.RemoteEpoch(),
 		localRandom:           common.LocalRandom,
 		remoteRandom:          common.RemoteRandom,
 		sequenceNumber:        sequenceNumber,
-		srtpProtectionProfile: common.GetSRTPProtectionProfile(),
-		localConnectionID:     bytes.Clone(common.GetLocalConnectionID()),
+		srtpProtectionProfile: common.SRTPProtectionProfile(),
+		localConnectionID:     bytes.Clone(common.LocalConnectionID()),
 		remoteConnectionID:    bytes.Clone(common.RemoteConnectionID),
 		isClient:              common.IsClient,
 		version:               protocol.Version1_3,
@@ -239,8 +239,8 @@ func (s *State) generateInternalState() (*dtlsstate.State, error) {
 		},
 		MasterSecret: s.masterSecret,
 	}
-	state.LocalEpoch.Store(s.localEpoch)
-	state.RemoteEpoch.Store(s.remoteEpoch)
+	state.SetLocalEpoch(s.localEpoch)
+	state.SetRemoteEpoch(s.remoteEpoch)
 	state.SetSRTPProtectionProfile(s.srtpProtectionProfile)
 	state.SetLocalConnectionID(s.localConnectionID)
 


### PR DESCRIPTION
Use typed atomics and idiomatic accessors for scalar connection state. Represent optional remote key shares without pointers to slices.

Remove an internal traffic-secret alias that provided no type distinction.
