### PR TITLE
Remove timing waits from tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -2185,8 +2185,6 @@ func TestProtocolVersionValidation(t *testing.T) {
 					assert.ErrorIs(t, err, dtlserrors.ErrUnsupportedProtocolVersion)
 				}()
 
-				time.Sleep(50 * time.Millisecond)
-
 				resp := make([]byte, 1024)
 				for _, record := range serverCase.records {
 					packet, err := record.Marshal()
@@ -2267,8 +2265,6 @@ func TestProtocolVersionValidation(t *testing.T) {
 					_, err := testClient(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), clientOpts, true)
 					assert.ErrorIs(t, err, dtlserrors.ErrUnsupportedProtocolVersion)
 				}()
-
-				time.Sleep(50 * time.Millisecond)
 
 				for _, record := range clientCase.records {
 					_, err := ca.Read(make([]byte, 1024))
@@ -2603,8 +2599,6 @@ func TestRenegotationInfo(t *testing.T) {
 				assert.ErrorIs(t, err, context.Canceled)
 			}()
 
-			time.Sleep(50 * time.Millisecond)
-
 			extensions := []extension.Extension{}
 			if test.SendRenegotiationInfoExt {
 				extensions = append(extensions, &extension.RenegotiationInfo{
@@ -2728,7 +2722,7 @@ func TestServerNameIndicationExtension(t *testing.T) {
 	}
 }
 
-func TestALPNExtension(t *testing.T) {
+func TestALPNExtension(t *testing.T) { //nolint:cyclop
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)
 	defer lim.Stop()
@@ -2797,12 +2791,14 @@ func TestALPNExtension(t *testing.T) {
 			defer cancel()
 
 			ca, cb := dpipe.Pipe()
+			clientDone := make(chan error, 1)
 			go func() {
 				var opts []ClientOption
 				if len(test.ClientProtocolNameList) > 0 {
 					opts = append(opts, WithSupportedProtocols(test.ClientProtocolNameList...))
 				}
-				_, _ = testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, false)
+				_, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, false)
+				clientDone <- err
 			}()
 
 			// Receive ClientHello
@@ -2814,18 +2810,15 @@ func TestALPNExtension(t *testing.T) {
 			defer cancel2()
 
 			ca2, cb2 := dpipe.Pipe()
+			serverDone := make(chan error, 1)
 			go func() {
 				var opts []ServerOption
 				if len(test.ServerProtocolNameList) > 0 {
 					opts = append(opts, WithSupportedProtocols(test.ServerProtocolNameList...))
 				}
-				_, err2 := testServer(ctx2, dtlsnet.PacketConnFromConn(cb2), cb2.RemoteAddr(), opts, true)
-				if test.ExpectAlertFromServer {
-					assert.NotErrorIs(t, err2, context.Canceled)
-				}
+				_, serverErr := testServer(ctx2, dtlsnet.PacketConnFromConn(cb2), cb2.RemoteAddr(), opts, true)
+				serverDone <- serverErr
 			}()
-
-			time.Sleep(50 * time.Millisecond)
 
 			// Forward ClientHello
 			_, err = ca2.Write(resp[:n])
@@ -2906,7 +2899,21 @@ func TestALPNExtension(t *testing.T) {
 				}
 			}
 
-			time.Sleep(50 * time.Millisecond) // Give some time for returned errors
+			switch {
+			case test.ExpectAlertFromServer:
+				assert.NotErrorIs(t, <-serverDone, context.Canceled)
+				cancel()
+				<-clientDone
+			case test.ExpectAlertFromClient:
+				<-clientDone
+				cancel2()
+				<-serverDone
+			default:
+				cancel()
+				cancel2()
+				<-clientDone
+				<-serverDone
+			}
 		})
 	}
 }
@@ -2938,8 +2945,6 @@ func TestSupportedGroupsExtension(t *testing.T) {
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}
-
-		time.Sleep(50 * time.Millisecond)
 
 		resp := make([]byte, 1024)
 		err := sendClientHello([]byte{}, ca, 0, extensions)

--- a/e2e/e2e_openssl_test.go
+++ b/e2e/e2e_openssl_test.go
@@ -101,9 +101,6 @@ func serverOpenSSL(c *comm) {
 			return
 		}
 
-		// Ensure that server has started
-		time.Sleep(500 * time.Millisecond)
-
 		c.serverReady <- struct{}{}
 		simpleReadWrite(c.errChan, c.serverChan, c.serverConn, c.messageRecvCount)
 		c.serverDone <- cmd.Process.Kill()

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -461,9 +462,7 @@ func (c *flightTestConn) WritePackets(_ context.Context, pkts []*dtlsflight.Pack
 		case <-c.done:
 		}
 	}()
-
-	// Avoid deadlock on JS/WASM environment due to context switch problem.
-	time.Sleep(10 * time.Millisecond)
+	runtime.Gosched()
 
 	return nil
 }

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -240,9 +240,11 @@ func TestBufferAsync(t *testing.T) {
 
 	// Start up a goroutine to start a blocking read.
 	done := make(chan string)
+	readStarted := make(chan struct{})
 	go func() {
 		packet := make([]byte, 4)
 
+		readStarted <- struct{}{}
 		n, raddr, rErr := buffer.ReadFrom(packet)
 		if rErr != nil {
 			done <- rErr.Error()
@@ -254,6 +256,7 @@ func TestBufferAsync(t *testing.T) {
 		equalBytes(t, []byte{0, 1}, packet[:n])
 		equalUDPAddr(t, addr, raddr)
 
+		readStarted <- struct{}{}
 		_, _, readErr := buffer.ReadFrom(packet)
 		if !errors.Is(readErr, io.EOF) {
 			done <- fmt.Sprintf("Unexpected err %v wanted io.EOF", readErr)
@@ -262,16 +265,14 @@ func TestBufferAsync(t *testing.T) {
 		}
 	}()
 
-	// Wait for the reader to start reading.
-	time.Sleep(time.Millisecond)
+	<-readStarted
 
 	// Write once
 	n, err := buffer.WriteTo([]byte{0, 1}, addr)
 	assert.NoError(t, err)
 	equalInt(t, 2, n)
 
-	// Wait for the reader to start reading again.
-	time.Sleep(time.Millisecond)
+	<-readStarted
 
 	// Close will unblock the reader.
 	assert.NoError(t, buffer.Close())
@@ -384,7 +385,7 @@ func benchmarkBuffer(b *testing.B, size int64) {
 			if !errors.Is(err, bytes.ErrTooLarge) {
 				break
 			}
-			time.Sleep(time.Microsecond)
+			runtime.Gosched()
 		}
 		assert.NoError(b, err)
 	}

--- a/internal/net/udp/packet_conn_test.go
+++ b/internal/net/udp/packet_conn_test.go
@@ -111,8 +111,14 @@ func TestListenerCloseUnaccepted(t *testing.T) {
 	const backlog = 2
 
 	network, addr := getConfig()
+	processed := make(chan struct{}, backlog)
 	listener, err := (&ListenConfig{
 		Backlog: backlog,
+		AcceptFilter: func([]byte) bool {
+			processed <- struct{}{}
+
+			return true
+		},
 	}).Listen(network, addr)
 	assert.NoError(t, err)
 
@@ -130,7 +136,9 @@ func TestListenerCloseUnaccepted(t *testing.T) {
 		assert.NoError(t, conn.Close())
 	}
 
-	time.Sleep(100 * time.Millisecond) // Wait all packets being processed by readLoop
+	for range backlog {
+		<-processed
+	}
 
 	// Unaccepted connections must be closed by listener.Close()
 	assert.NoError(t, listener.Close())
@@ -162,8 +170,11 @@ func TestListenerAcceptFilter(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			network, addr := getConfig()
+			filterCalled := make(chan struct{})
 			listener, err := (&ListenConfig{
 				AcceptFilter: func(pkt []byte) bool {
+					close(filterCalled)
+
 					return pkt[0] == 0xAA
 				},
 			}).Listen(network, addr)
@@ -187,28 +198,28 @@ func TestListenerAcceptFilter(t *testing.T) {
 				assert.NoError(t, conn.Close())
 			}()
 
-			chAccepted := make(chan struct{})
+			acceptResult := make(chan error, 1)
 			go func() {
 				defer wgAcceptLoop.Done()
 
 				conn, _, aArr := listener.Accept()
-				if aArr != nil {
-					assert.ErrorIs(t, aArr, ErrClosedListener)
-
-					return
+				if aArr == nil {
+					aArr = conn.Close()
 				}
-				close(chAccepted)
-				assert.NoError(t, conn.Close())
+				acceptResult <- aArr
 			}()
 
-			var accepted bool
-			select {
-			case <-chAccepted:
-				accepted = true
-			case <-time.After(10 * time.Millisecond):
+			<-filterCalled
+			if !testCase.accept {
+				assert.NoError(t, listener.Close())
 			}
 
-			assert.Equal(t, testCase.accept, accepted)
+			acceptErr := <-acceptResult
+			if testCase.accept {
+				assert.NoError(t, acceptErr)
+			} else {
+				assert.ErrorIs(t, acceptErr, ErrClosedListener)
+			}
 		})
 	}
 }
@@ -225,12 +236,20 @@ func TestListenerConcurrent(t *testing.T) {
 	const backlog = 2
 
 	network, addr := getConfig()
+	processed := make(chan struct{}, backlog+2)
 	listener, err := (&ListenConfig{
 		Backlog: backlog,
+		AcceptFilter: func(packet []byte) bool {
+			processed <- struct{}{}
+
+			// The final packet is a barrier. AcceptFilter runs under connLock,
+			// so reaching it proves the overflow packet was already discarded.
+			return packet[0] != backlog+1
+		},
 	}).Listen(network, addr)
 	assert.NoError(t, err)
 
-	for i := range backlog + 1 {
+	for i := range backlog + 2 {
 		addr, ok := listener.Addr().(*net.UDPAddr)
 		assert.True(t, ok)
 		conn, dErr := net.DialUDP(network, nil, addr)
@@ -244,7 +263,9 @@ func TestListenerConcurrent(t *testing.T) {
 		assert.NoError(t, conn.Close())
 	}
 
-	time.Sleep(100 * time.Millisecond) // Wait all packets being processed by readLoop
+	for range backlog + 2 {
+		<-processed
+	}
 
 	for i := range backlog {
 		conn, _, lErr := listener.Accept()
@@ -261,9 +282,11 @@ func TestListenerConcurrent(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	acceptStarted := make(chan struct{})
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		close(acceptStarted)
 		conn, _, lErr := listener.Accept()
 		assert.ErrorIs(t, lErr, ErrClosedListener)
 		if lErr == nil {
@@ -271,7 +294,7 @@ func TestListenerConcurrent(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(100 * time.Millisecond) // Last Accept should be discarded
+	<-acceptStarted
 	assert.NoError(t, listener.Close())
 
 	wg.Wait()

--- a/replayprotection_test.go
+++ b/replayprotection_test.go
@@ -108,7 +108,6 @@ func TestReplayProtection(t *testing.T) { //nolint:cyclop
 
 	replaySendDone()
 	<-ctxReplayDone.Done()
-	time.Sleep(10 * time.Millisecond) // Ensure all replayed packets are sent
 
 	for i := range 4 {
 		assert.NoError(t, conn[i].Close())


### PR DESCRIPTION
Coordinate tests with observable events instead of fixed sleeps. Keep delays only where timing is the behavior under test.
