### PR TITLE
Use standard clone and max helpers

### DIFF
--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -4,6 +4,7 @@
 package ciphersuite
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/binary"
@@ -348,7 +349,7 @@ func recordNonce13(iv []byte, sequenceNumber uint64) ([]byte, error) {
 		return nil, dtlserrors.ErrLengthMismatch
 	}
 
-	nonce := append([]byte(nil), iv...)
+	nonce := bytes.Clone(iv)
 	var sequenceNumberBytes [8]byte
 	binary.BigEndian.PutUint64(sequenceNumberBytes[:], sequenceNumber)
 	for i, b := range sequenceNumberBytes {

--- a/internal/flight/flight13/flight5handler.go
+++ b/internal/flight/flight13/flight5handler.go
@@ -4,6 +4,7 @@
 package flight13
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/tls"
 
@@ -175,7 +176,7 @@ func certificateEntries13(certificates [][]byte) []handshake.CertificateEntry13 
 	entries := make([]handshake.CertificateEntry13, 0, len(certificates))
 	for _, certificate := range certificates {
 		entries = append(entries, handshake.CertificateEntry13{
-			CertificateData: append([]byte(nil), certificate...),
+			CertificateData: bytes.Clone(certificate),
 		})
 	}
 

--- a/internal/handshake/protected_flight.go
+++ b/internal/handshake/protected_flight.go
@@ -4,6 +4,7 @@
 package dtlshandshake
 
 import (
+	"bytes"
 	"crypto/x509"
 	"fmt"
 
@@ -229,7 +230,7 @@ func protectedHandshakeMessage13(typ handshake.Type, body []byte) (handshake.Mes
 func rawCertificatesFromCertificate13(certificate *handshake.MessageCertificate13) [][]byte {
 	out := make([][]byte, 0, len(certificate.CertificateList))
 	for _, entry := range certificate.CertificateList {
-		out = append(out, append([]byte(nil), entry.CertificateData...))
+		out = append(out, bytes.Clone(entry.CertificateData))
 	}
 
 	return out

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -5,10 +5,12 @@
 package dtlshandshake
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"hash"
 	"maps"
+	"slices"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite/types"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -136,7 +138,7 @@ func (t *Transcript) appendCanonical(id transcriptMessageID, message []byte) err
 		return dtlserrors.ErrHandshakeTranscriptMessageChanged
 	}
 
-	messageCopy := append([]byte(nil), message...)
+	messageCopy := bytes.Clone(message)
 	t.seen[id] = seenTranscriptMessage13{
 		length:      len(messageCopy),
 		fingerprint: fingerprint,
@@ -282,9 +284,9 @@ func (t *Transcript) clone() (*Transcript, error) {
 	out := &Transcript{
 		newHash:           t.newHash,
 		pending:           util.CloneByteSlices(t.pending),
-		transcript:        append([]byte(nil), t.transcript...),
+		transcript:        bytes.Clone(t.transcript),
 		seen:              make(map[transcriptMessageID]seenTranscriptMessage13, len(t.seen)),
-		order:             append([]transcriptMessage(nil), t.order...),
+		order:             slices.Clone(t.order),
 		helloRetryApplied: t.helloRetryApplied,
 	}
 	maps.Copy(out.seen, t.seen)
@@ -323,7 +325,7 @@ func (t *Transcript) replaceWith(src *Transcript) error {
 
 // Bytes returns the canonical transcript bytes.
 func (t *Transcript) Bytes() []byte {
-	return append([]byte(nil), t.transcript...)
+	return bytes.Clone(t.transcript)
 }
 
 // seedTranscriptFromInitialFlights imports the dual-stack ClientHello generated

--- a/internal/state/clone.go
+++ b/internal/state/clone.go
@@ -5,12 +5,10 @@ package state
 
 import (
 	"bytes"
+	"slices"
 
 	"github.com/pion/dtls/v3/internal/util"
-	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
-	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol"
-	"github.com/pion/dtls/v3/pkg/protocol/extension"
 )
 
 // Clone13ForVerification returns a DTLS 1.3 state snapshot containing the
@@ -24,8 +22,8 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 		return &State13{Common: common}
 	}
 
-	common.LocalSequenceNumber = append([]uint64(nil), state.LocalSequenceNumber...)
-	common.RemoteSequenceNumber = append([]uint64(nil), state.RemoteSequenceNumber...)
+	common.LocalSequenceNumber = slices.Clone(state.LocalSequenceNumber)
+	common.RemoteSequenceNumber = slices.Clone(state.RemoteSequenceNumber)
 	common.LocalRandom = state.LocalRandom
 	common.RemoteRandom = state.RemoteRandom
 	common.CipherSuite = state.CipherSuite
@@ -36,8 +34,8 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 	common.RemoteConnectionID = bytes.Clone(state.RemoteConnectionID)
 	common.IsClient = state.IsClient
 	common.ServerName = state.ServerName
-	common.PeerSupportedProtocols = append([]string(nil), state.PeerSupportedProtocols...)
-	common.RemoteVersions = append([]protocol.Version(nil), state.RemoteVersions...)
+	common.PeerSupportedProtocols = slices.Clone(state.PeerSupportedProtocols)
+	common.RemoteVersions = slices.Clone(state.RemoteVersions)
 	if !state.LocalVersion.Equal(protocol.Version{}) {
 		common.LocalVersion = state.LocalVersion
 	}
@@ -49,23 +47,19 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 	}
 
 	return &State13{
-		Common:                common,
-		KeySchedule:           cloneKeySchedule13(state.KeySchedule),
-		KeyAgreementSecret:    bytes.Clone(state.KeyAgreementSecret),
-		SelectedGroup:         state.SelectedGroup,
-		LocalKeyEntries:       append([]extension.KeyShareEntry(nil), state.LocalKeyEntries...),
-		RemoteKeyEntries:      append([]extension.KeyShareEntry(nil), state.RemoteKeyEntries...),
-		HasRemoteKeyEntries:   state.HasRemoteKeyEntries,
-		RemoteGroups:          append([]elliptic.Curve(nil), state.RemoteGroups...),
-		Cookie:                bytes.Clone(state.Cookie),
-		HandshakeSendSequence: state.HandshakeSendSequence,
-		HandshakeRecvSequence: state.HandshakeRecvSequence,
-		RemoteSignatureSchemes: append(
-			[]signaturehash.Algorithm(nil), state.RemoteSignatureSchemes...,
-		),
-		RemoteCertSignatureSchemes: append(
-			[]signaturehash.Algorithm(nil), state.RemoteCertSignatureSchemes...,
-		),
+		Common:                     common,
+		KeySchedule:                cloneKeySchedule13(state.KeySchedule),
+		KeyAgreementSecret:         bytes.Clone(state.KeyAgreementSecret),
+		SelectedGroup:              state.SelectedGroup,
+		LocalKeyEntries:            slices.Clone(state.LocalKeyEntries),
+		RemoteKeyEntries:           slices.Clone(state.RemoteKeyEntries),
+		HasRemoteKeyEntries:        state.HasRemoteKeyEntries,
+		RemoteGroups:               slices.Clone(state.RemoteGroups),
+		Cookie:                     bytes.Clone(state.Cookie),
+		HandshakeSendSequence:      state.HandshakeSendSequence,
+		HandshakeRecvSequence:      state.HandshakeRecvSequence,
+		RemoteSignatureSchemes:     slices.Clone(state.RemoteSignatureSchemes),
+		RemoteCertSignatureSchemes: slices.Clone(state.RemoteCertSignatureSchemes),
 	}
 }
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -35,15 +35,6 @@ func PutBigEndianUint48(out []byte, in uint64) {
 	copy(out, tmp[2:])
 }
 
-// Max returns the larger value.
-func Max(a, b int) int {
-	if a > b {
-		return a
-	}
-
-	return b
-}
-
 // CloneByteSlices returns a deep copy of in, preserving nil.
 func CloneByteSlices(in [][]byte) [][]byte {
 	if in == nil {

--- a/pkg/crypto/ciphersuite/cbc.go
+++ b/pkg/crypto/ciphersuite/cbc.go
@@ -130,7 +130,7 @@ func (c *CBC) Decrypt(header recordlayer.Header, in []byte) ([]byte, error) {
 	case header.ContentType == protocol.ContentTypeChangeCipherSpec:
 		// Nothing to encrypt with ChangeCipherSpec
 		return in, nil
-	case len(body)%blockSize != 0 || len(body) < blockSize+util.Max(mac.Size()+1, blockSize):
+	case len(body)%blockSize != 0 || len(body) < blockSize+max(mac.Size()+1, blockSize):
 		return nil, dtlserrors.ErrNotEnoughRoomForNonce
 	}
 

--- a/pkg/protocol/extension/certificate_auth.go
+++ b/pkg/protocol/extension/certificate_auth.go
@@ -4,6 +4,8 @@
 package extension
 
 import (
+	"slices"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"golang.org/x/crypto/cryptobyte"
 )
@@ -78,8 +80,7 @@ func (c *CertificateAuthorities) unmarshalPayload(data []byte) error {
 		cauths = append(cauths, ca)
 	}
 
-	c.Authorities = make([][]byte, len(cauths))
-	copy(c.Authorities, cauths)
+	c.Authorities = slices.Clone(cauths)
 
 	return nil
 }

--- a/pkg/protocol/extension/cookie.go
+++ b/pkg/protocol/extension/cookie.go
@@ -4,6 +4,8 @@
 package extension
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"golang.org/x/crypto/cryptobyte"
 )
@@ -60,7 +62,7 @@ func (c *CookieExt) unmarshalPayload(data []byte) error {
 		return dtlserrors.ErrLengthMismatch
 	}
 
-	c.Cookie = append([]byte(nil), cookie...)
+	c.Cookie = bytes.Clone(cookie)
 
 	return nil
 }

--- a/pkg/protocol/extension/key_share.go
+++ b/pkg/protocol/extension/key_share.go
@@ -4,6 +4,8 @@
 package extension
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"golang.org/x/crypto/cryptobyte"
@@ -125,7 +127,7 @@ func (k *KeyShare) unmarshalPayload(data []byte) error { //nolint:cyclop
 			seenGroups[group] = struct{}{}
 
 			entry.Group = group
-			entry.KeyExchange = append([]byte(nil), raw...)
+			entry.KeyExchange = bytes.Clone(raw)
 			k.ClientShares = append(k.ClientShares, entry)
 		}
 
@@ -161,7 +163,7 @@ func (k *KeyShare) unmarshalPayload(data []byte) error { //nolint:cyclop
 	}
 
 	group := elliptic.Curve(groupU16)
-	share := KeyShareEntry{Group: group, KeyExchange: append([]byte(nil), raw...)}
+	share := KeyShareEntry{Group: group, KeyExchange: bytes.Clone(raw)}
 	k.ServerShare = &share
 
 	return nil

--- a/pkg/protocol/extension/oid_filters.go
+++ b/pkg/protocol/extension/oid_filters.go
@@ -4,6 +4,8 @@
 package extension
 
 import (
+	"bytes"
+
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"golang.org/x/crypto/cryptobyte"
 )
@@ -92,15 +94,13 @@ func (o *OIDFilters) unmarshalPayload(data []byte) error {
 		}
 		seen[string(oid)] = struct{}{}
 
-		filter.OID = make([]byte, len(oid))
-		copy(filter.OID, oid)
+		filter.OID = bytes.Clone(oid)
 
 		var values cryptobyte.String
 		if !filterList.ReadUint16LengthPrefixed(&values) {
 			return dtlserrors.ErrOIDFiltersFormat
 		}
-		filter.Values = make([]byte, len(values))
-		copy(filter.Values, values)
+		filter.Values = bytes.Clone(values)
 
 		o.Filters = append(o.Filters, filter)
 	}

--- a/pkg/protocol/handshake/message_certificate_13.go
+++ b/pkg/protocol/handshake/message_certificate_13.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -126,8 +127,7 @@ func parseCertificate13Entry(str *cryptobyte.String) (*CertificateEntry13, error
 	}
 
 	// Copy cert_data to avoid aliasing issues
-	certDataBytes := make([]byte, len(certData))
-	copy(certDataBytes, certData)
+	certDataBytes := bytes.Clone(certData)
 
 	// Validate extensions length (2-byte length prefix + up to 2^16-1 bytes of data)
 	if len(*str) < cert13ExtLengthFieldSize {
@@ -172,8 +172,7 @@ func (m *MessageCertificate13) Unmarshal(data []byte) error {
 	if !str.ReadUint8LengthPrefixed(&contextData) {
 		return dtlserrors.ErrInvalidCertificateRequestContext
 	}
-	m.CertificateRequestContext = make([]byte, len(contextData))
-	copy(m.CertificateRequestContext, contextData)
+	m.CertificateRequestContext = bytes.Clone(contextData)
 
 	// Read certificate_list with 3-byte length prefix
 	var certificateListData cryptobyte.String

--- a/pkg/protocol/handshake/message_certificate_request_13.go
+++ b/pkg/protocol/handshake/message_certificate_request_13.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -98,8 +99,7 @@ func (m *MessageCertificateRequest13) Unmarshal(data []byte) error {
 	if !str.ReadUint8LengthPrefixed(&contextData) {
 		return dtlserrors.ErrInvalidCertificateRequestContext
 	}
-	m.CertificateRequestContext = make([]byte, len(contextData))
-	copy(m.CertificateRequestContext, contextData)
+	m.CertificateRequestContext = bytes.Clone(contextData)
 
 	// Read extensions length (2 bytes)
 	if len(str) < 2 {

--- a/pkg/protocol/handshake/message_new_session_ticket.go
+++ b/pkg/protocol/handshake/message_new_session_ticket.go
@@ -4,6 +4,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -80,7 +81,7 @@ func (m *MessageNewSessionTicket) Unmarshal(data []byte) error {
 	if len(data)-offset < nonceLength+2 {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	ticketNonce := append([]byte(nil), data[offset:offset+nonceLength]...)
+	ticketNonce := bytes.Clone(data[offset : offset+nonceLength])
 	offset += nonceLength
 
 	ticketLength := int(binary.BigEndian.Uint16(data[offset:]))
@@ -91,7 +92,7 @@ func (m *MessageNewSessionTicket) Unmarshal(data []byte) error {
 	if len(data)-offset < ticketLength+2 {
 		return dtlserrors.ErrBufferTooSmall
 	}
-	ticket := append([]byte(nil), data[offset:offset+ticketLength]...)
+	ticket := bytes.Clone(data[offset : offset+ticketLength])
 	offset += ticketLength
 
 	extensions, err := extension.Unmarshal(data[offset:])


### PR DESCRIPTION
Replace hand-written slice copies with bytes.Clone and slices.Clone. Use the built-in max function and remove the redundant utility.