### PR TITLE
Polish test contexts and spelling

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -2551,7 +2551,7 @@ func TestMultipleHelloVerifyRequest(t *testing.T) {
 
 // Assert that a DTLS Server only responds with RenegotiationInfo if a ClientHello contained that
 // extension according to RFC5746 section 3.6, RFC5246 section 7.4.1.4 and RFC5746 section 4.2.
-func TestRenegotationInfo(t *testing.T) {
+func TestRenegotiationInfo(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(10 * time.Second)
 	defer lim.Stop()
@@ -3167,7 +3167,7 @@ func TestCipherSuiteMatchesCertificateType(t *testing.T) {
 
 			ca, cb := dpipe.Pipe()
 			go func() {
-				c, err := testClient(context.TODO(), dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), []ClientOption{
+				c, err := testClient(t.Context(), dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), []ClientOption{
 					WithCipherSuites(test.cipherList...),
 				}, false)
 				clientErr <- err
@@ -3190,7 +3190,7 @@ func TestCipherSuiteMatchesCertificateType(t *testing.T) {
 			serverCert, err := selfsign.SelfSign(signer)
 			assert.NoError(t, err)
 
-			s, err := testServer(context.TODO(), dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), []ServerOption{
+			s, err := testServer(t.Context(), dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), []ServerOption{
 				WithCipherSuites(test.cipherList...),
 				WithCertificates(serverCert),
 			}, false)
@@ -3246,7 +3246,7 @@ func TestMultipleServerCertificates(t *testing.T) {
 
 			ca, cb := dpipe.Pipe()
 			go func() {
-				clientConn, err := testClient(context.TODO(), dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), []ClientOption{
+				clientConn, err := testClient(t.Context(), dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), []ClientOption{
 					WithRootCAs(caPool),
 					WithServerName(test.RequestServerName),
 					WithVerifyPeerCertificate(func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
@@ -3266,7 +3266,7 @@ func TestMultipleServerCertificates(t *testing.T) {
 				client <- clientConn
 			}()
 
-			s, err := testServer(context.TODO(), dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), []ServerOption{
+			s, err := testServer(t.Context(), dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), []ServerOption{
 				WithCertificates(fooCert, barCert),
 			}, false)
 			assert.NoError(t, err)

--- a/internal/flight/flight12/flight1handler_test.go
+++ b/internal/flight/flight12/flight1handler_test.go
@@ -269,13 +269,13 @@ func TestFlight1_Process_ServerHelloLateArrival(t *testing.T) { //nolint:maintid
 	cache.Push(certificateRequest, 0, 4, handshake.TypeCertificateRequest, false)
 	cache.Push(serverHelloDone, 0, 5, handshake.TypeServerHelloDone, false)
 
-	_, alt, err := parseForTest(t, Flight1, context.TODO(), mockConn, state, cache, cfg)
+	_, alt, err := parseForTest(t, Flight1, t.Context(), mockConn, state, cache, cfg)
 	assert.NoError(t, err)
 	assert.Nil(t, alt)
 
 	cache.Push(serverHello, 0, 0, handshake.TypeServerHello, false)
 	cache.Push(certificate1, 0, 1, handshake.TypeCertificate, false)
-	_, alt, err = parseForTest(t, Flight1, context.TODO(), mockConn, state, cache, cfg)
+	_, alt, err = parseForTest(t, Flight1, t.Context(), mockConn, state, cache, cfg)
 	assert.NoError(t, err)
 	assert.Nil(t, alt)
 }

--- a/internal/flight/flight12/flight4handler_test.go
+++ b/internal/flight/flight12/flight4handler_test.go
@@ -116,7 +116,7 @@ func TestFlight4_Process_CertificateVerify(t *testing.T) {
 	cache.Push(rawCertificate, 0, 0, handshake.TypeCertificate, true)
 	cache.Push(rawClientKeyExchange, 0, 1, handshake.TypeClientKeyExchange, true)
 
-	_, _, err := parseForTest(t, Flight4, context.TODO(), mockConn, state, cache, cfg)
+	_, _, err := parseForTest(t, Flight4, t.Context(), mockConn, state, cache, cfg)
 	assert.NoError(t, err)
 }
 

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Package net implements DTLS specific networking primitives.
-// NOTE: this package is an adaption of pion/transport/packetio that allows for
+// NOTE: this package is an adaptation of pion/transport/packetio that allows for
 // storing a remote address alongside each packet in the buffer and implements
 // relevant methods of net.PacketConn. If possible, the updates made in this
 // repository will be reflected back upstream. If not, it is likely that this

--- a/internal/net/udp/packet_conn.go
+++ b/internal/net/udp/packet_conn.go
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 // Package udp implements DTLS specific UDP networking primitives.
-// NOTE: this package is an adaption of pion/transport/udp that allows for
+// NOTE: this package is an adaptation of pion/transport/udp that allows for
 // routing datagrams based on identifiers other than the remote address. The
 // primary use case for this functionality is routing based on DTLS connection
 // IDs. In order to allow for consumers of this package to treat connections as
-// generic net.PackageConn, routing and identitier establishment is based on
-// custom introspecion of datagrams, rather than direct intervention by
+// generic net.PacketConn, routing and identifier establishment is based on
+// custom introspection of datagrams, rather than direct intervention by
 // consumers. If possible, the updates made in this repository will be reflected
 // back upstream. If not, it is likely that this will be moved to a public
 // package in this repository.
@@ -150,7 +150,7 @@ type ListenConfig struct {
 	AcceptFilter func([]byte) bool
 
 	// DatagramRouter routes an incoming datagram to a connection by extracting
-	// an identifier from the its paylod
+	// an identifier from its payload.
 	DatagramRouter func([]byte) (string, bool)
 
 	// ConnectionIdentifier extracts an identifier from an outgoing packet. If

--- a/options.go
+++ b/options.go
@@ -506,7 +506,7 @@ func WithMinVersion(version protocol.Version) Option {
 	})
 }
 
-// WithMaxVersion sets the maxiumum TLS version that is acceptable.
+// WithMaxVersion sets the maximum TLS version that is acceptable.
 // By default, DTLS 1.2 is currently used as the minimum as it's the only supported version.
 func WithMaxVersion(version protocol.Version) Option {
 	return sharedOption(func(c *dtlsConfig) error {

--- a/resume_test.go
+++ b/resume_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	errMessageMissmatch       = errors.New("messages missmatch")
+	errMessageMismatch        = errors.New("messages mismatch")
 	errInvalidConnectionState = errors.New("failed to get connection state")
 )
 
@@ -136,7 +136,7 @@ func DoTestResume(
 	}
 
 	if !bytes.Equal(message, recv[:n]) {
-		fatal(t, errChan, fmt.Errorf("%w: %s != %s", errMessageMissmatch, message, recv[:n]))
+		fatal(t, errChan, fmt.Errorf("%w: %s != %s", errMessageMismatch, message, recv[:n]))
 	}
 
 	if err = localConn1.Close(); err != nil {
@@ -185,7 +185,7 @@ func DoTestResume(
 	}
 
 	if !bytes.Equal(message, recv[:n]) {
-		fatal(t, errChan, fmt.Errorf("%w: %s != %s", errMessageMissmatch, message, recv[:n]))
+		fatal(t, errChan, fmt.Errorf("%w: %s != %s", errMessageMismatch, message, recv[:n]))
 	}
 }
 


### PR DESCRIPTION
Use testing contexts where tests previously used context.TODO. Correct internal names and comments without changing protocol text.