### PR TITLE
Fix a race in TestPSKServerKeyExchange

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -860,6 +860,7 @@ func TestPSKServerKeyExchange(t *testing.T) { //nolint:cyclop
 			expectedServerKeyExchange := testCase.SetIdentity
 
 			clientErr := make(chan error, 1)
+			serverHandshakeDone := make(chan struct{})
 			ca, cb := dpipe.Pipe()
 			cbAnalyzer := &connWithCallback{Conn: cb}
 			cbAnalyzer.onWrite = func(in []byte) {
@@ -906,6 +907,7 @@ func TestPSKServerKeyExchange(t *testing.T) { //nolint:cyclop
 				if client, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, false); err != nil {
 					clientErr <- err
 				} else {
+					<-serverHandshakeDone
 					clientErr <- client.Close() //nolint
 				}
 			}()
@@ -921,6 +923,7 @@ func TestPSKServerKeyExchange(t *testing.T) { //nolint:cyclop
 			}
 
 			server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cbAnalyzer), cbAnalyzer.RemoteAddr(), opts, false)
+			close(serverHandshakeDone)
 			assert.NoError(t, err)
 
 			// Read the value immediately after handshake completes, before closing


### PR DESCRIPTION
#### Description
Wait for the server handshake to finish before sending close_notify, this cases the test to fail sometimes: 

```
--- FAIL: TestPSKServerKeyExchange (0.43s)
    --- FAIL: TestPSKServerKeyExchange/Server_Identity_Set (0.01s)
        conn_test.go:924:
            	Error Trace:	/Users/runner/work/dtls/dtls/conn_test.go:924
            	Error:      	Received unexpected error:
            	            	handshake failed: alert: Alert Warning: CloseNotify
            	Test:       	TestPSKServerKeyExchange/Server_Identity_Set
FAIL
```