### PR TITLE
Handle DTLS 1.3 ACK retransmissions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1084,6 +1084,13 @@ func (c *Conn) processProtectedHandshakePacketTracked(
 	rawPackets := make([]preparedRecord, 0, len(handshakeFragments))
 	epoch := pkt.Record.Header.Epoch
 	for _, handshakeFragment := range handshakeFragments {
+		selected, err := selectHandshakeFragment(pkt.HandshakeFragmentOffsets, handshakeFragment)
+		if err != nil {
+			return nil, err
+		}
+		if !selected {
+			continue
+		}
 		seq, err := c.nextLocalSequenceNumber(epoch)
 		if err != nil {
 			return nil, err
@@ -1121,6 +1128,19 @@ func (c *Conn) processProtectedHandshakePacketTracked(
 	}
 
 	return rawPackets, nil
+}
+
+func selectHandshakeFragment(offsets map[uint32]uint32, raw []byte) (bool, error) {
+	if offsets == nil {
+		return true, nil
+	}
+	header := &handshake.Header{}
+	if err := header.Unmarshal(raw); err != nil {
+		return false, err
+	}
+	length, ok := offsets[header.FragmentOffset]
+
+	return ok && length == header.FragmentLength, nil
 }
 
 func (c *Conn) fragmentHandshake(dtlsHandshake *handshake.Handshake) ([][]byte, error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -4303,6 +4303,30 @@ func TestProcessProtectedHandshakePacketWritesDTLS13Fragments(t *testing.T) {
 	assert.Equal(t, expectedPlaintext, innerPlaintext.Content)
 }
 
+func TestProcessProtectedHandshakePacketFiltersACKedFragments(t *testing.T) {
+	conn, _ := newTestConnWithWriteProtection(t)
+	conn.maximumTransmissionUnit = 10
+	dtlsHandshake := &handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: 9},
+		Message: &handshake.MessageCertificate{Certificate: [][]byte{bytes.Repeat([]byte{0xaa}, 24)}},
+	}
+	_, err := dtlsHandshake.Marshal()
+	require.NoError(t, err)
+
+	prepared, err := conn.processProtectedHandshakePacketTracked(&dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: dtlsflight13.EpochHandshake},
+			Content: dtlsHandshake,
+		},
+		ShouldEncrypt:            true,
+		ShouldTrackACK:           true,
+		HandshakeFragmentOffsets: map[uint32]uint32{10: 10},
+	}, dtlsHandshake)
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.Equal(t, uint32(10), prepared[0].tracked.Fragments[0].Offset)
+}
+
 func TestProcessProtectedPacketWritesApplicationData(t *testing.T) {
 	conn, peerCipherSuite := newTestConnWithWriteProtection(t)
 	payload := []byte("application data")

--- a/internal/flight/types.go
+++ b/internal/flight/types.go
@@ -17,10 +17,12 @@ type Conn interface {
 }
 
 type Packet struct {
-	Record                   *recordlayer.RecordLayer
-	ShouldEncrypt            bool
-	ShouldWrapCID            bool
-	ShouldTrackACK           bool
+	Record         *recordlayer.RecordLayer
+	ShouldEncrypt  bool
+	ShouldWrapCID  bool
+	ShouldTrackACK bool
+	// HandshakeFragmentOffsets limits a retransmission to offset:length pairs.
+	HandshakeFragmentOffsets map[uint32]uint32
 	ResetLocalSequenceNumber bool
 
 	// CertificateVerifySigner is local-only metadata used to populate an

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -13,6 +13,7 @@ import (
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 // [RFC9147 Section-5.8.1]
@@ -69,6 +70,7 @@ type fsm13 struct {
 	flights            []*dtlsflight.Packet
 	retransmit         bool
 	retransmitInterval time.Duration
+	flightACK          reliableFlight
 	handshakeContext
 	closed        chan struct{}
 	establishment *Establishment
@@ -123,6 +125,7 @@ func newFSM13WithEstablishment(
 		establishment:      establishment,
 		postHandshake:      newPostHandshake(cfg.InitialRetransmitInterval),
 	}
+	fsm.prepareFlightACKTracking(fsm.flights, fsm.retransmit)
 	if err := fsm.seedInitialFlights(fsm.flights, fsm.retransmit); err != nil {
 		return nil, err
 	}
@@ -184,6 +187,7 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 	}
 
 	s.flights = pkts
+	s.prepareFlightACKTracking(s.flights, s.retransmit)
 	if err := s.commitPreparedFlight(conn, s.currentFlight, s.flights); err != nil {
 		return StateErrored, err
 	}
@@ -194,14 +198,16 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 func (s *fsm13) send(ctx context.Context, conn Conn) (State, error) {
 	defer s.received.release()
 
-	if _, err := conn.WritePackets(ctx, s.flights); err != nil {
+	result, err := conn.WritePackets(ctx, s.flights)
+	if err != nil {
 		return StateErrored, err
 	}
+	s.flightACK.track(result)
 	finished, err := s.afterSend(ctx, conn, s.currentFlight)
 	if err != nil {
 		return StateErrored, err
 	}
-	if finished {
+	if finished && len(s.flightACK.pending) == 0 {
 		return StateFinished, nil
 	}
 
@@ -226,6 +232,8 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) {
 				return StateErrored, err
 			}
 			if transition.state == StateWaiting {
+				s.received.release()
+
 				continue
 			}
 			retainPendingRecv = transition.retainPendingRecv
@@ -244,8 +252,13 @@ func (s *fsm13) finish(ctx context.Context, c Conn) (State, error) {
 	s.postHandshake.initialize(s.state.IsClient)
 
 	select {
-	case state := <-c.RecvHandshake():
-		close(state.Done)
+	case received := <-c.RecvHandshake():
+		if err := sendACK(ctx, c, s.state.LocalEpoch(), received.RecordsToACK); err != nil {
+			close(received.Done)
+
+			return StateErrored, err
+		}
+		close(received.Done)
 
 		// avoid committing a second time.
 		return StateFinished, nil
@@ -264,15 +277,22 @@ func (s *fsm13) handleReceivedFlight(
 	if !received.IsRetransmit {
 		s.retransmitInterval = s.cfg.InitialRetransmitInterval
 	}
+	ackResult := s.flightACK.acknowledge(received.ACKs)
+	s.applyACKProgress(ackResult)
+	if !received.HasHandshake && len(received.ACKs) != 0 {
+		return s.transitionAfterACK(ackResult, false), nil
+	}
 
 	nextFlight, err := s.parseReceivedFlight(ctx, conn, s.currentFlight)
 	if err != nil {
 		return receivedFlightTransition{}, err
 	}
 	if nextFlight == 0 {
-		s.received.release()
+		if ackErr := sendACK(ctx, conn, s.state.LocalEpoch(), received.RecordsToACK); ackErr != nil {
+			return receivedFlightTransition{}, ackErr
+		}
 
-		return receivedFlightTransition{state: StateWaiting}, nil
+		return s.transitionAfterACK(ackResult, received.IsRetransmit), nil
 	}
 
 	transition, err := s.advanceAfterReceivedFlight(ctx, conn, s.currentFlight, nextFlight, received.RecordsToACK)
@@ -284,4 +304,47 @@ func (s *fsm13) handleReceivedFlight(
 	}
 
 	return transition, nil
+}
+
+func (s *fsm13) prepareFlightACKTracking(flights []*dtlsflight.Packet, retransmit bool) {
+	s.flightACK.reset()
+	if retransmit {
+		for _, packet := range flights {
+			_, packet.ShouldTrackACK = packet.Record.Content.(*handshake.Handshake)
+		}
+	}
+}
+
+func (s *fsm13) applyACKProgress(result ACKResult) {
+	for _, progress := range result.Messages {
+		remaining := s.flights[:0]
+		for _, packet := range s.flights {
+			message, ok := packet.Record.Content.(*handshake.Handshake)
+			if !ok || message.Header.MessageSequence != progress.MessageSequence {
+				remaining = append(remaining, packet)
+			} else if !progress.Complete {
+				packet.HandshakeFragmentOffsets = s.flightACK.pendingForMessage(progress.MessageSequence)
+				remaining = append(remaining, packet)
+			}
+		}
+		s.flights = remaining
+	}
+}
+
+func (s *fsm13) transitionAfterACK(result ACKResult, peerRetransmit bool) receivedFlightTransition {
+	if len(result.Messages) != 0 && len(s.flightACK.pending) == 0 {
+		s.retransmit = false
+		if s.currentFlight.IsLastSendFlight() {
+			return receivedFlightTransition{state: StateFinished}
+		}
+
+		return receivedFlightTransition{state: StateWaiting}
+	}
+	if result.Empty || len(result.Messages) != 0 || peerRetransmit {
+		return receivedFlightTransition{
+			state: handleRetransmitTimeout(s.retransmit, &s.retransmitInterval, s.cfg),
+		}
+	}
+
+	return receivedFlightTransition{state: StateWaiting}
 }

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -208,6 +208,33 @@ func TestHandshakeFSM13DoesNotSendEmptyACK(t *testing.T) {
 	assert.Empty(t, conn.writtenPackets)
 }
 
+func TestHandshakeFSM13ACKProgress(t *testing.T) {
+	first := SentHandshakeFragment{MessageSequence: 7, Length: 10}
+	second := SentHandshakeFragment{MessageSequence: 7, Offset: 10, Length: 10}
+	record1 := protocol.RecordNumber{Epoch: 2, SequenceNumber: 1}
+	record2 := protocol.RecordNumber{Epoch: 2, SequenceNumber: 2}
+	record3 := protocol.RecordNumber{Epoch: 2, SequenceNumber: 3}
+
+	var ack reliableFlight
+	ack.reset()
+	ack.track(&WriteResult{TrackedRecords: []SentHandshakeRecord{
+		{Number: record1, Fragments: []SentHandshakeFragment{first}},
+		{Number: record2, Fragments: []SentHandshakeFragment{second}},
+		{Number: record3, Fragments: []SentHandshakeFragment{second}},
+	}})
+
+	partial := ack.acknowledge([]protocol.ACK{{Records: []protocol.RecordNumber{record1}}})
+	require.Equal(t, []MessageACKProgress{{MessageSequence: 7, Changed: true}}, partial.Messages)
+	assert.Equal(t, map[uint32]uint32{10: 10}, ack.pendingForMessage(7))
+	assert.Empty(t, ack.acknowledge([]protocol.ACK{{Records: []protocol.RecordNumber{record1}}}).Messages)
+	assert.Empty(t, ack.acknowledge(nil).Messages)
+
+	reordered := ack.acknowledge([]protocol.ACK{{Records: []protocol.RecordNumber{record2}}})
+	require.Equal(t, []MessageACKProgress{{MessageSequence: 7, Changed: true, Complete: true}}, reordered.Messages)
+	assert.Empty(t, ack.pending)
+	assert.True(t, ack.acknowledge([]protocol.ACK{{}}).Empty)
+}
+
 func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 	state := newTestState13(true)
 	cache := dtlsflight.NewCache()

--- a/internal/handshake/reliable_flight.go
+++ b/internal/handshake/reliable_flight.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtlshandshake
+
+import "github.com/pion/dtls/v3/pkg/protocol"
+
+// reliableFlight tracks one retransmission state machine's logical fragments
+// independently of the record numbers assigned to each transmission.
+type reliableFlight struct {
+	records map[protocol.RecordNumber][]SentHandshakeFragment
+	pending map[SentHandshakeFragment]struct{}
+}
+
+func (f *reliableFlight) reset() {
+	f.records = map[protocol.RecordNumber][]SentHandshakeFragment{}
+	f.pending = map[SentHandshakeFragment]struct{}{}
+}
+
+func (f *reliableFlight) track(result *WriteResult) {
+	if result == nil {
+		return
+	}
+	for _, record := range result.TrackedRecords {
+		f.records[record.Number] = record.Fragments
+		for _, fragment := range record.Fragments {
+			f.pending[fragment] = struct{}{}
+		}
+	}
+}
+
+func (f *reliableFlight) acknowledge(acks []protocol.ACK) ACKResult {
+	result := ACKResult{}
+	changed := map[uint16]struct{}{}
+	for _, ack := range acks {
+		result.Empty = result.Empty || len(ack.Records) == 0
+		for _, number := range ack.Records {
+			for _, fragment := range f.records[number] {
+				if _, ok := f.pending[fragment]; ok {
+					delete(f.pending, fragment)
+					changed[fragment.MessageSequence] = struct{}{}
+				}
+			}
+		}
+	}
+	for sequence := range changed {
+		pending := f.pendingForMessage(sequence)
+		result.Messages = append(result.Messages, MessageACKProgress{
+			MessageSequence: sequence, Changed: true, Complete: len(pending) == 0,
+		})
+	}
+
+	return result
+}
+
+func (f *reliableFlight) pendingForMessage(sequence uint16) map[uint32]uint32 {
+	pending := map[uint32]uint32{}
+	for fragment := range f.pending {
+		if fragment.MessageSequence == sequence {
+			pending[fragment.Offset] = fragment.Length
+		}
+	}
+
+	return pending
+}


### PR DESCRIPTION
Track outbound handshake records by logical fragment and retire them as ACKs arrive. Retransmit only missing fragments, stop completed flights, and cover partial, duplicate, lost, and reordered ACK behavior.

Implements the handshake-scoped portions of #818 without wiring the post-handshake processing tracked by #824.
