### PR TITLE
Add 1.3 client certificate requests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -3838,6 +3838,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 		dtlsnet.PacketConnFromConn(cb),
 		cb.RemoteAddr(),
 		WithCertificates(serverCert),
+		WithClientAuth(RequireAnyClientCert),
 		WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3),
 		WithMaxVersion(protocol.Version1_3),
@@ -3864,8 +3865,9 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 
 	_, ok = client.ConnectionState()
 	require.True(t, ok)
-	_, ok = server.ConnectionState()
+	serverState, ok := server.ConnectionState()
 	require.True(t, ok)
+	assert.Equal(t, clientCert.Certificate, serverState.PeerCertificates)
 
 	require.NoError(t, client.SetReadDeadline(time.Now().Add(time.Second)))
 	require.NoError(t, server.SetReadDeadline(time.Now().Add(time.Second)))

--- a/flight_test.go
+++ b/flight_test.go
@@ -2895,6 +2895,71 @@ func TestFlight13_2Generate(t *testing.T) {
 }
 
 func TestFlight13_4Generate(t *testing.T) {
+	t.Run("RequestsClientCertificateWhenConfigured", func(t *testing.T) {
+		certificate, err := selfsign.GenerateSelfSigned()
+		require.NoError(t, err)
+		keypair, err := elliptic.GenerateKeypair(testCurves13[0])
+		require.NoError(t, err)
+
+		tests := map[string]struct {
+			clientAuth  dtlsconfig.ClientAuthType
+			wantRequest bool
+		}{
+			"NoClientCert":               {clientAuth: dtlsconfig.NoClientCert},
+			"RequestClientCert":          {clientAuth: dtlsconfig.RequestClientCert, wantRequest: true},
+			"RequireAnyClientCert":       {clientAuth: dtlsconfig.RequireAnyClientCert, wantRequest: true},
+			"VerifyClientCertIfGiven":    {clientAuth: dtlsconfig.VerifyClientCertIfGiven, wantRequest: true},
+			"RequireAndVerifyClientCert": {clientAuth: dtlsconfig.RequireAndVerifyClientCert, wantRequest: true},
+		}
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				cfg := testHandshakeConfig13(t)
+				cfg.LocalCertificates = []tls.Certificate{certificate}
+				cfg.ClientAuth = test.clientAuth
+
+				state := newTestState13(false)
+				state.CipherSuite = cfg.LocalCipherSuites[0]
+				state.LocalKeypair = keypair
+				state.RemoteSignatureSchemes = append([]signaturehash.Algorithm(nil), cfg.LocalSignatureSchemes...)
+
+				pkts, dtlsAlert, err := flight13GenerateForTest(
+					t, dtlsflight13.Flight4, &handshakeTestContext13{state: state, cfg: cfg},
+				)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+
+				var certificateRequest *handshake.MessageCertificateRequest13
+				for _, pkt := range pkts {
+					handshakePacket, ok := pkt.Record.Content.(*handshake.Handshake)
+					if !ok {
+						continue
+					}
+					request, ok := handshakePacket.Message.(*handshake.MessageCertificateRequest13)
+					if !ok {
+						continue
+					}
+					require.Nil(t, certificateRequest, "server flight contains multiple CertificateRequest messages")
+					certificateRequest = request
+					assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
+					assert.True(t, pkt.ShouldEncrypt)
+				}
+
+				if !test.wantRequest {
+					assert.Nil(t, certificateRequest)
+
+					return
+				}
+
+				require.NotNil(t, certificateRequest)
+				assert.Empty(t, certificateRequest.CertificateRequestContext)
+				require.Len(t, certificateRequest.Extensions, 1)
+				signatureAlgorithms, ok := certificateRequest.Extensions[0].(*extension.SupportedSignatureAlgorithms)
+				require.True(t, ok)
+				assert.Equal(t, cfg.LocalSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
+			})
+		}
+	})
+
 	t.Run("GeneratesCertificateAuthenticatedServerFlight", func(t *testing.T) {
 		cfg := testHandshakeConfig13(t)
 		certificate, err := selfsign.GenerateSelfSigned()

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -176,7 +176,7 @@ func needsClientKeypair(state *dtlsstate.State13) bool {
 		state.SelectedGroup == elliptic.X25519MLKEM768
 }
 
-func flight4Generate(
+func flight4Generate( //nolint:cyclop
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
@@ -255,9 +255,32 @@ func flight4Generate(
 	encryptedExtensions := HandshakePacket(&handshake.MessageEncryptedExtensions{})
 	encryptedExtensions.ResetLocalSequenceNumber = true
 
-	return []*dtlsflight.Packet{
+	pkts := []*dtlsflight.Packet{
 		serverHello,
 		encryptedExtensions,
+	}
+	if cfg.ClientAuth > dtlsconfig.NoClientCert {
+		// RFC 8446 Section 4.3.2 requires signature_algorithms in the request.
+		// https://www.rfc-editor.org/rfc/rfc9147.html#section-5.1
+		// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.3.2
+		certificateRequestExtensions := []extension.Extension{
+			&extension.SupportedSignatureAlgorithms{
+				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+			},
+		}
+		if cfg.ClientCAs != nil {
+			certificateRequestExtensions = append(certificateRequestExtensions, &extension.CertificateAuthorities{
+				// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR
+				// because cert does not come from SystemCertPool and it's ok if certificate
+				// authorities is empty.
+				Authorities: cfg.ClientCAs.Subjects(),
+			})
+		}
+		pkts = append(pkts, HandshakePacket(&handshake.MessageCertificateRequest13{
+			Extensions: certificateRequestExtensions,
+		}))
+	}
+	pkts = append(pkts,
 		HandshakePacket(&handshake.MessageCertificate13{
 			CertificateList: certificateEntries13(certificate.Certificate),
 		}),
@@ -269,5 +292,7 @@ func flight4Generate(
 			signer,
 		),
 		HandshakePacket(&handshake.MessageFinished{}),
-	}, nil, nil
+	)
+
+	return pkts, nil, nil
 }


### PR DESCRIPTION
#### Description
Send CertificateRequest during the DTLS 1.3 server handshake when
ClientAuth requires or requests a client certificate. 
I found this issue when i was manually testing against chrome with [sctp-interleaving-inspect/main.go#L236](https://github.com/pion/webrtc/blob/main/examples/sctp-interleaving-inspect/main.go#L236) which have WithClientAuth 