### PR TITLE
Complete DTLS 1.3 ACK reliability

### DIFF
--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -199,14 +199,6 @@ func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn)
 	}
 }
 
-func (p *postHandshake) newTicketNonce() []byte {
-	var nonce [8]byte
-	binary.BigEndian.PutUint64(nonce[:], p.nextTicketNonce)
-	p.nextTicketNonce++
-
-	return nonce[:]
-}
-
 func (p *postHandshake) applyACK(ack protocol.ACK) []postHandshakeFlightID {
 	completed := map[postHandshakeFlightID]struct{}{}
 	for _, number := range ack.Records {
@@ -380,19 +372,24 @@ func (p *postHandshake) prepareNewSessionTicket(isClient bool) (*reliablePostHan
 		return nil, dtlserrors.ErrUnexpectedPostHandshakeMessage
 	}
 
-	identity, err := newTicketIdentity()
-	if err != nil {
-		return nil, err
-	}
-	ageAdd, err := newTicketAgeAdd()
-	if err != nil {
+	identity := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, identity); err != nil {
 		return nil, err
 	}
 
+	var ageAdd [4]byte
+	if _, err := io.ReadFull(rand.Reader, ageAdd[:]); err != nil {
+		return nil, err
+	}
+
+	var nonce [8]byte
+	binary.BigEndian.PutUint64(nonce[:], p.nextTicketNonce)
+	p.nextTicketNonce++
+
 	return p.makeReliableNewSessionTicket(&handshake.MessageNewSessionTicket{
 		TicketLifetime: newSessionTicketLifetime,
-		TicketAgeAdd:   ageAdd,
-		TicketNonce:    p.newTicketNonce(),
+		TicketAgeAdd:   binary.BigEndian.Uint32(ageAdd[:]),
+		TicketNonce:    nonce[:],
 		Ticket:         identity,
 	})
 }
@@ -476,8 +473,6 @@ func (p *postHandshake) retransmitPostHandshake(
 	return nil
 }
 
-// todo: retransmit fragments not just the whole message.
-// nolint:godox
 func (p *postHandshake) retransmitNewSessionTicket(
 	ctx context.Context,
 	conn Conn,
@@ -485,6 +480,19 @@ func (p *postHandshake) retransmitNewSessionTicket(
 	now time.Time,
 	disableRetransmitBackoff bool,
 ) error {
+	for _, packet := range flight.Packets {
+		message, ok := packet.Record.Content.(*handshake.Handshake)
+		if !ok {
+			continue
+		}
+		packet.HandshakeFragmentOffsets = map[uint32]uint32{}
+		for fragment := range flight.PendingFragments {
+			if fragment.MessageSequence == message.Header.MessageSequence {
+				packet.HandshakeFragmentOffsets[fragment.Offset] = fragment.Length
+			}
+		}
+	}
+
 	result, err := conn.WritePackets(ctx, flight.Packets)
 	if err != nil {
 		return err
@@ -499,22 +507,4 @@ func (p *postHandshake) retransmitNewSessionTicket(
 	flight.NextRetransmit = now.Add(flight.RetransmitInterval)
 
 	return nil
-}
-
-func newTicketIdentity() ([]byte, error) {
-	ticket := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, ticket); err != nil {
-		return nil, err
-	}
-
-	return ticket, nil
-}
-
-func newTicketAgeAdd() (uint32, error) {
-	var raw [4]byte
-	if _, err := io.ReadFull(rand.Reader, raw[:]); err != nil {
-		return 0, err
-	}
-
-	return binary.BigEndian.Uint32(raw[:]), nil
 }

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -44,6 +44,20 @@ func (c *postHandshakeAlertConn) Notify(
 	return c.notifyErr
 }
 
+type postHandshakeWriteConn struct {
+	flightTestConn
+	result *WriteResult
+}
+
+func (c *postHandshakeWriteConn) WritePackets(
+	_ context.Context,
+	pkts []*dtlsflight.Packet,
+) (*WriteResult, error) {
+	c.writtenPackets = append(c.writtenPackets, pkts...)
+
+	return c.result, nil
+}
+
 func TestMakeReliableNewSessionTicket(t *testing.T) {
 	state := dtlsstate.NewState13(false)
 	state.SetLocalEpoch(7)
@@ -103,6 +117,62 @@ func TestPostHandshakeACKCompletesReliableFlight(t *testing.T) {
 	assert.Empty(t, flight.PendingFragments)
 	_, firstStillIndexed := post.recordIndex[firstRecord]
 	assert.True(t, firstStillIndexed)
+}
+
+func TestPostHandshakeACKReliability(t *testing.T) {
+	state := dtlsstate.NewState13(false)
+	post := newPostHandshake(handshakeContext{
+		state: &state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	flight, err := post.makeReliableNewSessionTicket(&handshake.MessageNewSessionTicket{
+		TicketLifetime: newSessionTicketLifetime,
+		Ticket:         []byte{1},
+	})
+	require.NoError(t, err)
+
+	messageSequence := flight.ID.MessageSequence
+	firstFragment := SentHandshakeFragment{MessageSequence: messageSequence, Length: 10}
+	secondFragment := SentHandshakeFragment{MessageSequence: messageSequence, Offset: 10, Length: 10}
+	firstRecord := protocol.RecordNumber{Epoch: 3, SequenceNumber: 1}
+	secondRecord := protocol.RecordNumber{Epoch: 3, SequenceNumber: 2}
+	post.flights[flight.ID] = flight
+	post.registerTransmission(flight, []SentHandshakeRecord{
+		{Number: firstRecord, Fragments: []SentHandshakeFragment{firstFragment}},
+		{Number: secondRecord, Fragments: []SentHandshakeFragment{secondFragment}},
+	}, true)
+
+	// A partial ACK retires the first fragment. Receiving it again makes no
+	// further progress.
+	assert.Empty(t, post.applyACK(protocol.ACK{Records: []protocol.RecordNumber{firstRecord}}))
+	assert.Empty(t, post.applyACK(protocol.ACK{Records: []protocol.RecordNumber{firstRecord}}))
+
+	// If the second fragment's ACK is lost, retransmit only that fragment.
+	retransmitRecord := protocol.RecordNumber{Epoch: 3, SequenceNumber: 3}
+	conn := &postHandshakeWriteConn{result: &WriteResult{TrackedRecords: []SentHandshakeRecord{{
+		Number:    retransmitRecord,
+		Fragments: []SentHandshakeFragment{secondFragment},
+	}}}}
+	now := time.Now()
+	require.NoError(t, post.retransmitNewSessionTicket(context.Background(), conn, flight, now, true))
+	require.Len(t, conn.writtenPackets, 1)
+	assert.Equal(t, map[uint32]uint32{10: 10}, conn.writtenPackets[0].HandshakeFragmentOffsets)
+	assert.Equal(t, now.Add(time.Second), flight.NextRetransmit)
+
+	// The original ACK can arrive after the retransmission and still complete
+	// the flight.
+	completed := post.applyACK(protocol.ACK{
+		Records: []protocol.RecordNumber{secondRecord},
+	})
+	assert.Equal(t, []postHandshakeFlightID{flight.ID}, completed)
+	assert.Empty(t, flight.PendingFragments)
+	for _, id := range completed {
+		post.completePostHandshakeFlight(id)
+	}
+
+	// An ACK for a retransmission may arrive after an earlier transmission
+	// already completed the flight.
+	assert.Empty(t, post.applyACK(protocol.ACK{Records: []protocol.RecordNumber{retransmitRecord}}))
 }
 
 func TestPostHandshakeReceiveNewSessionTicket(t *testing.T) {


### PR DESCRIPTION
Retransmit only post-handshake fragments that have not been acknowledged.

Cover partial, duplicate, lost, and reordered ACK handling.

Closes #818.