### PR TITLE
Enable X25519MLKEM768 by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,12 @@ import (
 
 const defaultMTU = 1200 // bytes
 
-var defaultCurves = []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384} //nolint:gochecknoglobals
+var defaultCurves = []elliptic.Curve{ //nolint:gochecknoglobals
+	elliptic.X25519MLKEM768,
+	elliptic.X25519,
+	elliptic.P256,
+	elliptic.P384,
+}
 
 type connConfigValues struct {
 	logger                      logging.LeveledLogger

--- a/supported_elliptic_curves_test.go
+++ b/supported_elliptic_curves_test.go
@@ -33,7 +33,16 @@ func TestSupportedEllipticCurves(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	expectedCurves := append([]elliptic.Curve(nil), defaultCurves...)
+	// This test configures only a DTLS 1.2 cipher suite. X25519MLKEM768 is a
+	// DTLS 1.3-only group.
+	// todo: handle cases like this when configured by end user.
+	// nolint:godox
+	expectedCurves := make([]elliptic.Curve, 0, len(defaultCurves))
+	for _, curve := range defaultCurves {
+		if curve != elliptic.X25519MLKEM768 {
+			expectedCurves = append(expectedCurves, curve)
+		}
+	}
 	var actualCurves []elliptic.Curve
 
 	rand.Shuffle(len(expectedCurves), func(i, j int) {


### PR DESCRIPTION
#### Description
Enable and prioritize X25519MLKEM768, this matches Chrome / BoringSSL, I tested against chrome and firefox manually and didn't see any regressions https://boringssl.googlesource.com/boringssl/%2B/HEAD/ssl/ssl_key_share.cc#366

Will add different interop cases for all the supported groups.