### PR TITLE
Handle flights split across datagrams

### DIFF
--- a/flight_test.go
+++ b/flight_test.go
@@ -1265,9 +1265,23 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	)
 	state.CipherSuite = nil
 	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
+	nextFlight, dtlsAlert, err := flight13ParseForTest(
+		t, dtlsflight13.Flight3, context.Background(), &handshakeTestContext13{
+			state:      state,
+			cache:      cache,
+			cfg:        cfg,
+			transcript: transcript,
+		})
+
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, dtlsflight13.Flight(0), nextFlight)
+	assert.Equal(t, 1, state.HandshakeRecvSequence)
+	assert.Equal(t, dtlsflight13.EpochHandshake, state.RemoteEpoch())
+
 	cache.Push(rawEncryptedExtensions, dtlsflight13.EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
 	cache.Push(rawFinished, dtlsflight13.EpochHandshake, 2, handshake.TypeFinished, false)
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
+	nextFlight, dtlsAlert, err = flight13ParseForTest(
 		t, dtlsflight13.Flight3, context.Background(), &handshakeTestContext13{
 			state:      state,
 			cache:      cache,

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -25,29 +25,39 @@ func flight3Parse(
 	conn dtlsflight.Conn,
 	flightCtx *handshakeContext,
 ) (Flight, *alert.Alert, error) {
-	pull := flight3PullServerHello(flightCtx)
-	if !pull.ready {
-		return 0, nil, nil
-	}
-	if pull.failure != nil {
-		return 0, pull.failure.alert, pull.failure.err
+	nextHandshakeSequence := flightCtx.state.HandshakeRecvSequence
+	if flightCtx.state.RemoteEpoch() < EpochHandshake {
+		pull := flight3PullServerHello(flightCtx)
+		if !pull.ready {
+			return 0, nil, nil
+		}
+		if pull.failure != nil {
+			return 0, pull.failure.alert, pull.failure.err
+		}
+
+		failure := processFlight3ServerHello(flightCtx, pull.serverHello)
+		if failure != nil {
+			return 0, failure.alert, failure.err
+		}
+		failure = initializeFlight3HandshakeProtection(
+			ctx,
+			conn,
+			flightCtx,
+			pull.nextHandshakeSequence,
+			pull.items,
+		)
+		if failure != nil {
+			return 0, failure.alert, failure.err
+		}
+		nextHandshakeSequence = pull.nextHandshakeSequence
 	}
 
-	failure := processFlight3ServerHello(flightCtx, pull.serverHello)
-	if failure != nil {
-		return 0, failure.alert, failure.err
-	}
-	failure = initializeFlight3HandshakeProtection(
-		ctx,
-		conn,
-		flightCtx,
-		pull.nextHandshakeSequence,
-		pull.items,
-	)
-	if failure != nil {
-		return 0, failure.alert, failure.err
-	}
-
+	// A DTLS flight may span multiple datagrams. Once ServerHello installs the
+	// handshake read keys, resume at the first protected message instead of
+	// requiring ServerHello to be pulled again. RFC 9147 Section 5.7,
+	// and 5.8.1:
+	// https://www.rfc-editor.org/rfc/rfc9147.html#section-5.7
+	// https://www.rfc-editor.org/rfc/rfc9147.html#section-5.8.1
 	protectedFlight := pullProtectedHandshakeFlight(
 		flightCtx.cache,
 		[]dtlsflight.HandshakeCachePullRule{
@@ -57,7 +67,7 @@ func flight3Parse(
 			{Typ: handshake.TypeCertificateVerify, Epoch: EpochHandshake, IsClient: false, Optional: true},
 			{Typ: handshake.TypeFinished, Epoch: EpochHandshake, IsClient: false, Optional: false},
 		},
-		pull.nextHandshakeSequence,
+		nextHandshakeSequence,
 	)
 	if !protectedFlight.ready {
 		return 0, nil, nil
@@ -65,7 +75,7 @@ func flight3Parse(
 	if protectedFlight.failure != nil {
 		return 0, protectedFlight.failure.alert, protectedFlight.failure.err
 	}
-	failure = handleFlight3ProtectedHandshake(flightCtx, protectedFlight.items)
+	failure := handleFlight3ProtectedHandshake(flightCtx, protectedFlight.items)
 	if failure != nil {
 		return 0, failure.alert, failure.err
 	}


### PR DESCRIPTION
#### Description
Resume DTLS 1.3 server flight 3 parsing split across datagrams, Found after https://github.com/pion/dtls/pull/978 through tests with small MTU size. Will look for more issues like this in the interop with small MTU sizes.