### PR TITLE
Define versions and settings behavior

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
@@ -48,7 +49,11 @@ type connConfigValues struct {
 }
 
 func newConnConfigValues(config *dtlsConfig) (connConfigValues, error) {
-	minVersion, maxVersion := dtlsconfig.NormalizeProtocolVersionRange(config.MinVersion, config.MaxVersion)
+	minVersion, maxVersion, err := effectiveProtocolVersionRange(config)
+	if err != nil {
+		return connConfigValues{}, err
+	}
+
 	cipherSuites, err := parseCipherSuitesForVersions(
 		config.CipherSuites,
 		config.customCipherSuites,
@@ -356,12 +361,12 @@ func validateConfig(config *dtlsConfig) error { //nolint:cyclop
 		}
 	}
 
-	minVersion, maxVersion := dtlsconfig.NormalizeProtocolVersionRange(config.MinVersion, config.MaxVersion)
-	if err := validateEllipticCurveVersions(config.EllipticCurves, minVersion, maxVersion); err != nil {
+	minVersion, maxVersion, err := effectiveProtocolVersionRange(config)
+	if err != nil {
 		return err
 	}
 
-	_, err := parseCipherSuitesForVersions(
+	_, err = parseCipherSuitesForVersions(
 		config.CipherSuites, config.customCipherSuites, config.includeCertificateSuites(), config.psk != nil,
 		minVersion, maxVersion,
 	)
@@ -369,29 +374,88 @@ func validateConfig(config *dtlsConfig) error { //nolint:cyclop
 	return err
 }
 
-func validateEllipticCurveVersions(
-	curves []elliptic.Curve,
-	minVersion, maxVersion protocol.Version,
-) error {
-	if !slices.Contains(curves, elliptic.X25519MLKEM768) {
-		return nil
-	}
-	if !maxVersion.Equal(protocol.Version1_3) {
-		return dtlserrors.ErrUnsupportedEllipticCurveVersion
-	}
-	if minVersion.Equal(protocol.Version1_3) || hasDTLS12CompatibleCurve(curves) {
-		return nil
+// effectiveProtocolVersionRange restricts a configured version range to the
+// versions supported by explicitly selected cipher suites and curves. This
+// prevents advertising a version for which the local configuration cannot
+// complete a handshake.
+func effectiveProtocolVersionRange(config *dtlsConfig) (protocol.Version, protocol.Version, error) {
+	minVersion, maxVersion := dtlsconfig.NormalizeProtocolVersionRange(config.MinVersion, config.MaxVersion)
+	versions := dtlsconfig.SupportedVersionsRange(minVersion, maxVersion)
+
+	if cipherVersions := supportedCipherSuiteVersions(config.CipherSuites, versions); len(cipherVersions) != 0 {
+		versions = cipherVersions
 	}
 
-	return dtlserrors.ErrUnsupportedEllipticCurveVersion
+	curveVersions := supportedEllipticCurveVersions(
+		config.EllipticCurves,
+		dtlsconfig.SupportedVersionsRange(minVersion, maxVersion),
+	)
+	if len(config.EllipticCurves) != 0 && len(curveVersions) == 0 {
+		return protocol.Version{}, protocol.Version{}, dtlserrors.ErrUnsupportedEllipticCurveVersion
+	}
+	versions = intersectSupportedVersions(versions, curveVersions)
+
+	if len(versions) == 0 {
+		return protocol.Version{}, protocol.Version{}, dtlserrors.ErrNoCommonProtocolVersion
+	}
+
+	return versions[len(versions)-1], versions[0], nil
 }
 
-func hasDTLS12CompatibleCurve(curves []elliptic.Curve) bool {
-	for _, curve := range curves {
-		if curve != elliptic.X25519MLKEM768 {
-			return true
+func supportedCipherSuiteVersions(
+	suites []CipherSuiteID,
+	versions []protocol.Version,
+) []protocol.Version {
+	if suites == nil {
+		return versions
+	}
+
+	for _, suite := range suites {
+		if ciphersuite.ForID(suite, nil) == nil {
+			return versions
 		}
 	}
 
-	return false
+	return filterSupportedVersions(versions, func(version protocol.Version) bool {
+		return slices.ContainsFunc(suites, func(suite CipherSuiteID) bool {
+			return ciphersuite.IDSupportsVersion(suite, version)
+		})
+	})
+}
+
+func supportedEllipticCurveVersions(
+	curves []elliptic.Curve,
+	versions []protocol.Version,
+) []protocol.Version {
+	if len(curves) == 0 {
+		return versions
+	}
+
+	return filterSupportedVersions(versions, func(version protocol.Version) bool {
+		return slices.ContainsFunc(curves, func(curve elliptic.Curve) bool {
+			return curve != elliptic.X25519MLKEM768 || version.Equal(protocol.Version1_3)
+		})
+	})
+}
+
+func filterSupportedVersions(
+	versions []protocol.Version,
+	supports func(protocol.Version) bool,
+) []protocol.Version {
+	filtered := make([]protocol.Version, 0, len(versions))
+	for _, version := range versions {
+		if supports(version) {
+			filtered = append(filtered, version)
+		}
+	}
+
+	return filtered
+}
+
+func intersectSupportedVersions(
+	left, right []protocol.Version,
+) []protocol.Version {
+	return filterSupportedVersions(left, func(version protocol.Version) bool {
+		return slices.ContainsFunc(right, version.Equal)
+	})
 }

--- a/options_test.go
+++ b/options_test.go
@@ -360,19 +360,23 @@ func TestX25519MLKEM768RequiresDTLS13(t *testing.T) {
 	})
 
 	t.Run("DualStackMLKEMOnlyClient", func(t *testing.T) {
-		err := clientOptionsError(t,
+		client, err := newOptionsClient(t,
 			WithMaxVersion(protocol.Version1_3),
 			WithEllipticCurves(elliptic.X25519MLKEM768),
 		)
-		require.ErrorIs(t, err, dtlserrors.ErrUnsupportedEllipticCurveVersion)
+		require.NoError(t, err)
+		require.Equal(t, protocol.Version1_3, client.handshakeConfig.MinVersion)
+		require.Equal(t, protocol.Version1_3, client.handshakeConfig.MaxVersion)
 	})
 
 	t.Run("DualStackMLKEMOnlyServer", func(t *testing.T) {
-		err := serverOptionsError(t,
+		server, err := newOptionsServer(t,
 			WithMaxVersion(protocol.Version1_3),
 			WithEllipticCurves(elliptic.X25519MLKEM768),
 		)
-		require.ErrorIs(t, err, dtlserrors.ErrUnsupportedEllipticCurveVersion)
+		require.NoError(t, err)
+		require.Equal(t, protocol.Version1_3, server.handshakeConfig.MinVersion)
+		require.Equal(t, protocol.Version1_3, server.handshakeConfig.MaxVersion)
 	})
 
 	t.Run("DualStackWithClassicalFallback", func(t *testing.T) {
@@ -405,6 +409,46 @@ func TestX25519MLKEM768RequiresDTLS13(t *testing.T) {
 			WithEllipticCurves(elliptic.X25519MLKEM768),
 		)
 		require.NoError(t, err)
+	})
+}
+
+func TestSelectedCipherSuitesConstrainProtocolVersion(t *testing.T) {
+	t.Run("DTLS13SuitesSelectDTLS13", func(t *testing.T) {
+		client, err := newOptionsClient(t,
+			WithMaxVersion(protocol.Version1_3),
+			WithCipherSuites(TLS_AES_128_GCM_SHA256),
+		)
+		require.NoError(t, err)
+		require.Equal(t, protocol.Version1_3, client.handshakeConfig.MinVersion)
+		require.Equal(t, protocol.Version1_3, client.handshakeConfig.MaxVersion)
+	})
+
+	t.Run("DTLS12SuitesSelectDTLS12", func(t *testing.T) {
+		client, err := newOptionsClient(t,
+			WithMaxVersion(protocol.Version1_3),
+			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+		)
+		require.NoError(t, err)
+		require.Equal(t, protocol.Version1_2, client.handshakeConfig.MinVersion)
+		require.Equal(t, protocol.Version1_2, client.handshakeConfig.MaxVersion)
+	})
+
+	t.Run("DTLS12SuitesAndDTLS13CurvesAreRejected", func(t *testing.T) {
+		err := clientOptionsError(t,
+			WithMaxVersion(protocol.Version1_3),
+			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+			WithEllipticCurves(elliptic.X25519MLKEM768),
+		)
+		require.ErrorIs(t, err, dtlserrors.ErrNoCommonProtocolVersion)
+	})
+
+	t.Run("DTLS12SuitesWithExactDTLS13AreRejected", func(t *testing.T) {
+		err := clientOptionsError(t,
+			WithMinVersion(protocol.Version1_3),
+			WithMaxVersion(protocol.Version1_3),
+			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+		)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
#### Description
When I was think about how we'll eventually enable 1.3 in WebRTC I thought about some edge cases:
1. if the user selects 1.2 only ciphers, and we set the versions range to [1.2, 1.3], we should switch back to 1.2. I think this will be the case for many users who explicitly set target ciphers.
2. ^ Same behavior for dual-range but 1.3 only suites.
3. 1.2 only suites combined with 1.3-only curves should return an error.

(We should pass a logger here in the future and log errors or warnings).