### PR TITLE
Add epoch-aware traffic keys state

### DIFF
--- a/internal/state/active_state.go
+++ b/internal/state/active_state.go
@@ -67,6 +67,9 @@ func Activate13(active Active) *State13 {
 	common := CommonState(active)
 	if state, ok := active.(*State13); ok {
 		state.Common = common
+		if state.TrafficKeys == nil {
+			state.TrafficKeys = &TrafficKeyState{}
+		}
 		if state.LocalKeypairs == nil {
 			state.LocalKeypairs = make(map[elliptic.Curve]*elliptic.Keypair)
 		}
@@ -77,6 +80,7 @@ func Activate13(active Active) *State13 {
 	state := &State13{
 		Common:        common,
 		LocalKeypairs: make(map[elliptic.Curve]*elliptic.Keypair),
+		TrafficKeys:   &TrafficKeyState{},
 	}
 	if state12, ok := active.(*State12); ok {
 		state.HandshakeSendSequence = state12.HandshakeSendSequence

--- a/internal/state/clone.go
+++ b/internal/state/clone.go
@@ -49,6 +49,7 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 	return &State13{
 		Common:                     common,
 		KeySchedule:                cloneKeySchedule13(state.KeySchedule),
+		TrafficKeys:                state.TrafficKeys.Clone(),
 		KeyAgreementSecret:         bytes.Clone(state.KeyAgreementSecret),
 		SelectedGroup:              state.SelectedGroup,
 		LocalKeyEntries:            slices.Clone(state.LocalKeyEntries),

--- a/internal/state/common.go
+++ b/internal/state/common.go
@@ -139,5 +139,6 @@ func NewState13(isClient bool) State13 {
 	return State13{
 		Common:        common,
 		LocalKeypairs: make(map[elliptic.Curve]*elliptic.Keypair),
+		TrafficKeys:   &TrafficKeyState{},
 	}
 }

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -36,6 +36,7 @@ type State13 struct {
 	*Common
 
 	KeySchedule KeySchedule
+	TrafficKeys *TrafficKeyState
 
 	// KeyAgreementSecret is the ECDHE or hybrid shared secret that feeds the
 	// TLS 1.3 HKDF key schedule.

--- a/internal/state/traffic_keys.go
+++ b/internal/state/traffic_keys.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/pion/dtls/v3/internal/ciphersuite"
+)
+
+// TrafficGeneration binds an epoch and traffic-secret generation to the
+// record protection derived from that secret.
+// Caller must not modify the secret or protection after creation.
+type TrafficGeneration struct {
+	Epoch      uint16
+	Generation uint64
+	Secret     []byte // nolint:gosec
+	Protection ciphersuite.RecordProtection13
+}
+
+func (g *TrafficGeneration) Clone() *TrafficGeneration {
+	if g == nil {
+		return nil
+	}
+
+	return &TrafficGeneration{
+		Epoch:      g.Epoch,
+		Generation: g.Generation,
+		Secret:     bytes.Clone(g.Secret),
+		Protection: g.Protection,
+	}
+}
+
+// TrafficKeyState owns directional DTLS 1.3 traffic generations.
+type TrafficKeyState struct {
+	mu sync.RWMutex
+
+	writeCurrent *TrafficGeneration
+	writeOld     map[uint16]*TrafficGeneration
+	readCurrent  *TrafficGeneration
+	readOld      map[uint16]*TrafficGeneration
+}
+
+// Install any supplied current write and read generations.
+// Pass nil for a direction that should remain unchanged.
+func (s *TrafficKeyState) Install(write, read *TrafficGeneration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	installTrafficGeneration(&s.writeCurrent, &s.writeOld, write)
+	installTrafficGeneration(&s.readCurrent, &s.readOld, read)
+}
+
+// Write returns the write generation associated with epoch.
+func (s *TrafficKeyState) Write(epoch uint16) (*TrafficGeneration, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.writeCurrent != nil && s.writeCurrent.Epoch == epoch {
+		return s.writeCurrent, true
+	}
+	generation, ok := s.writeOld[epoch]
+
+	return generation, ok
+}
+
+// Read returns the read generation associated with epoch.
+func (s *TrafficKeyState) Read(epoch uint16) (*TrafficGeneration, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.readCurrent != nil && s.readCurrent.Epoch == epoch {
+		return s.readCurrent, true
+	}
+	generation, ok := s.readOld[epoch]
+
+	return generation, ok
+}
+
+// CurrentWrite returns the current write generation.
+func (s *TrafficKeyState) CurrentWrite() (*TrafficGeneration, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.writeCurrent, s.writeCurrent != nil
+}
+
+// CurrentRead returns the current read generation.
+func (s *TrafficKeyState) CurrentRead() (*TrafficGeneration, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.readCurrent, s.readCurrent != nil
+}
+
+func installTrafficGeneration(
+	current **TrafficGeneration,
+	old *map[uint16]*TrafficGeneration,
+	generation *TrafficGeneration,
+) {
+	if generation == nil {
+		return
+	}
+	if previous := *current; previous != nil && previous.Epoch != generation.Epoch {
+		if *old == nil {
+			*old = make(map[uint16]*TrafficGeneration)
+		}
+		(*old)[previous.Epoch] = previous
+	}
+	*current = generation
+}
+
+func (s *TrafficKeyState) Clone() *TrafficKeyState {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return &TrafficKeyState{
+		writeCurrent: s.writeCurrent.Clone(),
+		writeOld:     cloneTrafficGenerations13(s.writeOld),
+		readCurrent:  s.readCurrent.Clone(),
+		readOld:      cloneTrafficGenerations13(s.readOld),
+	}
+}
+
+func cloneTrafficGenerations13(in map[uint16]*TrafficGeneration) map[uint16]*TrafficGeneration {
+	if in == nil {
+		return nil
+	}
+	out := make(map[uint16]*TrafficGeneration, len(in))
+	for epoch, generation := range in {
+		out[epoch] = generation.Clone()
+	}
+
+	return out
+}

--- a/internal/state/traffic_keys_test.go
+++ b/internal/state/traffic_keys_test.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package state
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pion/dtls/v3/internal/ciphersuite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrafficKeyStateAdvancesDirectionsIndependently(t *testing.T) {
+	suite := ciphersuite.NewTLSAes128GcmSha256()
+	secretSize := suite.HashFunc()().Size()
+	writeSecret0 := bytes.Repeat([]byte{0x10}, secretSize)
+	readSecret0 := bytes.Repeat([]byte{0x20}, secretSize)
+	writeSecret1 := bytes.Repeat([]byte{0x11}, secretSize)
+	readSecret1 := bytes.Repeat([]byte{0x21}, secretSize)
+
+	writeProtection0, err := suite.NewRecordProtection(writeSecret0)
+	require.NoError(t, err)
+	readProtection0, err := suite.NewRecordProtection(readSecret0)
+	require.NoError(t, err)
+	writeProtection1, err := suite.NewRecordProtection(writeSecret1)
+	require.NoError(t, err)
+	readProtection1, err := suite.NewRecordProtection(readSecret1)
+	require.NoError(t, err)
+
+	var keys TrafficKeyState
+	keys.Install(
+		&TrafficGeneration{
+			Epoch:      2,
+			Generation: 0,
+			Secret:     writeSecret0,
+			Protection: writeProtection0,
+		},
+		&TrafficGeneration{
+			Epoch:      2,
+			Generation: 0,
+			Secret:     readSecret0,
+			Protection: readProtection0,
+		},
+	)
+	keys.Install(&TrafficGeneration{
+		Epoch:      3,
+		Generation: 1,
+		Secret:     writeSecret1,
+		Protection: writeProtection1,
+	}, nil)
+
+	currentWrite, ok := keys.CurrentWrite()
+	require.True(t, ok)
+	assert.Equal(t, uint16(3), currentWrite.Epoch)
+	assert.Equal(t, uint64(1), currentWrite.Generation)
+	assert.Equal(t, writeSecret1, currentWrite.Secret)
+
+	currentRead, ok := keys.CurrentRead()
+	require.True(t, ok)
+	assert.Equal(t, uint16(2), currentRead.Epoch)
+	assert.Equal(t, readSecret0, currentRead.Secret)
+	_, ok = keys.Read(3)
+	assert.False(t, ok)
+
+	oldWrite, ok := keys.Write(2)
+	require.True(t, ok)
+	assert.Equal(t, writeSecret0, oldWrite.Secret)
+
+	keys.Install(nil, &TrafficGeneration{
+		Epoch:      3,
+		Generation: 1,
+		Secret:     readSecret1,
+		Protection: readProtection1,
+	})
+	currentRead, ok = keys.CurrentRead()
+	require.True(t, ok)
+	assert.Equal(t, uint16(3), currentRead.Epoch)
+	assert.Equal(t, uint64(1), currentRead.Generation)
+	assert.Equal(t, readSecret1, currentRead.Secret)
+	oldRead, ok := keys.Read(2)
+	require.True(t, ok)
+	assert.Equal(t, readSecret0, oldRead.Secret)
+}
+
+func TestTrafficGenerationCloneCopiesSecret(t *testing.T) {
+	suite := ciphersuite.NewTLSAes128GcmSha256()
+	secret := bytes.Repeat([]byte{0x42}, suite.HashFunc()().Size())
+	protection, err := suite.NewRecordProtection(secret)
+	require.NoError(t, err)
+
+	generation := &TrafficGeneration{
+		Epoch:      7,
+		Generation: 3,
+		Secret:     secret,
+		Protection: protection,
+	}
+	clone := generation.Clone()
+	secret[0] ^= 0xff
+	assert.Equal(t, byte(0x42), clone.Secret[0])
+	clone.Secret[0] ^= 0xff
+	assert.Equal(t, byte(0xbd), generation.Secret[0])
+	assert.NotNil(t, clone.Protection)
+}


### PR DESCRIPTION
#### Description
This adds the state and structs needed to bind and hold per-epoch DTLS 1.3, required for #983  