### PR TITLE
Directional traffic-protection factory

### DIFF
--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -17,6 +17,27 @@ import (
 type CipherSuiteTLS13 interface {
 	CipherSuite
 	InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error
+	NewRecordProtection(trafficSecret []byte) (RecordProtection13, error)
+	Seal(
+		header recordlayer.UnifiedHeader,
+		sequenceNumber uint64,
+		contentType protocol.ContentType,
+		plaintext []byte,
+	) (recordlayer.CiphertextRecord13, error)
+	Open(
+		header recordlayer.UnifiedHeader,
+		sequenceNumber uint64,
+		encryptedRecord []byte,
+	) (recordlayer.InnerPlaintext, error)
+	UnmaskSequenceNumber(
+		header recordlayer.UnifiedHeader,
+		encryptedRecord []byte,
+	) (recordlayer.UnifiedHeader, error)
+}
+
+// RecordProtection13 protects records for one DTLS 1.3 traffic direction and
+// generation.
+type RecordProtection13 interface {
 	Seal(
 		header recordlayer.UnifiedHeader,
 		sequenceNumber uint64,

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -271,6 +271,61 @@ func (p recordTrafficProtection13) sequenceNumberMask(encryptedRecord []byte) ([
 	return p.sequenceNumberMaskFn(p.sequenceNumberKey, encryptedRecord)
 }
 
+func (p recordTrafficProtection13) Seal(
+	header recordlayer.UnifiedHeader,
+	sequenceNumber uint64,
+	contentType protocol.ContentType,
+	plaintext []byte,
+) (recordlayer.CiphertextRecord13, error) {
+	header.SequenceNumber = uint16(sequenceNumber & 0xffff)
+	record, err := (&recordProtection13{local: p}).seal(header, sequenceNumber, contentType, plaintext)
+	if err != nil {
+		return recordlayer.CiphertextRecord13{}, err
+	}
+
+	mask, err := p.sequenceNumberMask(record.EncryptedRecord)
+	if err != nil {
+		return recordlayer.CiphertextRecord13{}, err
+	}
+	if err = applySequenceNumberMask13(&record.Header, mask); err != nil {
+		return recordlayer.CiphertextRecord13{}, err
+	}
+
+	return record, nil
+}
+
+func (p recordTrafficProtection13) Open(
+	header recordlayer.UnifiedHeader,
+	sequenceNumber uint64,
+	encryptedRecord []byte,
+) (recordlayer.InnerPlaintext, error) {
+	clearHeader, err := p.UnmaskSequenceNumber(header, encryptedRecord)
+	if err != nil {
+		return recordlayer.InnerPlaintext{}, err
+	}
+	if err = validateSequenceNumberLowBits13(clearHeader, sequenceNumber); err != nil {
+		return recordlayer.InnerPlaintext{}, err
+	}
+
+	return (&recordProtection13{remote: p}).open(clearHeader, sequenceNumber, encryptedRecord)
+}
+
+func (p recordTrafficProtection13) UnmaskSequenceNumber(
+	header recordlayer.UnifiedHeader,
+	encryptedRecord []byte,
+) (recordlayer.UnifiedHeader, error) {
+	mask, err := p.sequenceNumberMask(encryptedRecord)
+	if err != nil {
+		return recordlayer.UnifiedHeader{}, err
+	}
+	clearHeader := header
+	if err = applySequenceNumberMask13(&clearHeader, mask); err != nil {
+		return recordlayer.UnifiedHeader{}, err
+	}
+
+	return clearHeader, nil
+}
+
 func applySequenceNumberMask13(header *recordlayer.UnifiedHeader, mask []byte) error {
 	if header == nil {
 		return dtlserrors.ErrInvalidCiphertextHeader

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -1028,3 +1028,37 @@ func TestDeriveRecordTrafficKeys13RejectsInvalidKeyLength(t *testing.T) {
 	_, err := deriveRecordTrafficKeys13(suite.HashFunc(), trafficSecret13(suite, 0x3c), 0)
 	assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
 }
+
+func TestTLS13CipherSuiteNewRecordProtection(t *testing.T) {
+	tests := []struct {
+		name  string
+		suite CipherSuiteTLS13
+	}{
+		{name: "AES-128-GCM", suite: NewTLSAes128GcmSha256()},
+		{name: "AES-256-GCM", suite: NewTLSAes256GcmSha384()},
+		{name: "ChaCha20-Poly1305", suite: NewTLSChacha20Poly1305Sha256()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			secret := bytes.Repeat([]byte{0x5a}, test.suite.HashFunc()().Size())
+			writer, err := test.suite.NewRecordProtection(secret)
+			require.NoError(t, err)
+			reader, err := test.suite.NewRecordProtection(secret)
+			require.NoError(t, err)
+
+			record, err := writer.Seal(
+				recordlayer.UnifiedHeader{EpochLow: 2},
+				0x0102030405060708,
+				protocol.ContentTypeApplicationData,
+				[]byte("directional record protection"),
+			)
+			require.NoError(t, err)
+
+			innerPlaintext, err := reader.Open(record.Header, 0x0102030405060708, record.EncryptedRecord)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("directional record protection"), innerPlaintext.Content)
+			assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
+		})
+	}
+}

--- a/internal/ciphersuite/tls_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_aes_128_gcm_sha256.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
+//nolint:dupl // AES-128 and AES-256 implementations mirror one another.
 package ciphersuite
 
 import (
@@ -30,6 +31,12 @@ func (c *TLSAes128GcmSha256) String() string {
 // HashFunc returns the hashing func for this CipherSuite.
 func (c *TLSAes128GcmSha256) HashFunc() func() hash.Hash {
 	return sha256.New
+}
+
+// NewRecordProtection derives record protection for one DTLS 1.3 traffic
+// direction and generation.
+func (c *TLSAes128GcmSha256) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
+	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, tls13AES128GCMKeyLen)
 }
 
 // InitFromTrafficSecrets initializes DTLS 1.3 record protection from the

--- a/internal/ciphersuite/tls_aes_256_gcm_sha384.go
+++ b/internal/ciphersuite/tls_aes_256_gcm_sha384.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
+//nolint:dupl // AES-128 and AES-256 implementations mirror one another.
 package ciphersuite
 
 import (
@@ -30,6 +31,12 @@ func (c *TLSAes256GcmSha384) String() string {
 // HashFunc returns the hashing func for this CipherSuite.
 func (c *TLSAes256GcmSha384) HashFunc() func() hash.Hash {
 	return sha512.New384
+}
+
+// NewRecordProtection derives record protection for one DTLS 1.3 traffic
+// direction and generation.
+func (c *TLSAes256GcmSha384) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
+	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, tls13AES256GCMKeyLen)
 }
 
 // InitFromTrafficSecrets initializes DTLS 1.3 record protection from the

--- a/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
+++ b/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
@@ -32,6 +32,12 @@ func (c *TLSChacha20Poly1305Sha256) HashFunc() func() hash.Hash {
 	return sha256.New
 }
 
+// NewRecordProtection derives record protection for one DTLS 1.3 traffic
+// direction and generation.
+func (c *TLSChacha20Poly1305Sha256) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
+	return newChaCha20Poly1305RecordTrafficProtection13(c.HashFunc(), trafficSecret)
+}
+
 // InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
 // negotiated client and server handshake/application traffic secrets.
 func (c *TLSChacha20Poly1305Sha256) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {


### PR DESCRIPTION
#### Description
This adds directional traffic-protection factory required for directional per-epoch record-protection state in #984 required for #983  

(I saw a few issues with this cipher code and I'll do a quick follow-up cleanup after this).
