### PR TITLE
Collapse duplicated aes_gcm code

### DIFF
--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -59,20 +59,6 @@ type recordProtection13 struct {
 	remote recordTrafficProtection13
 }
 
-func newAES128GCMRecordProtection13(
-	hashFunc func() hash.Hash,
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newAESGCMRecordProtection13(hashFunc, localTrafficSecret, remoteTrafficSecret, tls13AES128GCMKeyLen)
-}
-
-func newAES256GCMRecordProtection13(
-	hashFunc func() hash.Hash,
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newAESGCMRecordProtection13(hashFunc, localTrafficSecret, remoteTrafficSecret, tls13AES256GCMKeyLen)
-}
-
 func newAESGCMRecordProtection13(
 	hashFunc func() hash.Hash,
 	localTrafficSecret, remoteTrafficSecret []byte,

--- a/internal/ciphersuite/tls_aes_128_gcm_sha256.go
+++ b/internal/ciphersuite/tls_aes_128_gcm_sha256.go
@@ -1,52 +1,22 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-//nolint:dupl // AES-128 and AES-256 implementations mirror one another.
 package ciphersuite
 
-import (
-	"crypto/sha256"
-	"hash"
-)
+import "crypto/sha256"
 
 // TLSAes128GcmSha256 represents the TLS_AES_128_GCM_SHA256 CipherSuite.
 type TLSAes128GcmSha256 struct {
-	TLS13CipherSuite
+	tlsAESGCMCipherSuite
 }
 
 // NewTLSAes128GcmSha256 returns the TLS_AES_128_GCM_SHA256 CipherSuite.
 func NewTLSAes128GcmSha256() *TLSAes128GcmSha256 {
-	return &TLSAes128GcmSha256{}
-}
-
-// ID returns the ID of the CipherSuite.
-func (c *TLSAes128GcmSha256) ID() ID {
-	return TLS_AES_128_GCM_SHA256
-}
-
-func (c *TLSAes128GcmSha256) String() string {
-	return "TLS_AES_128_GCM_SHA256"
-}
-
-// HashFunc returns the hashing func for this CipherSuite.
-func (c *TLSAes128GcmSha256) HashFunc() func() hash.Hash {
-	return sha256.New
-}
-
-// NewRecordProtection derives record protection for one DTLS 1.3 traffic
-// direction and generation.
-func (c *TLSAes128GcmSha256) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
-	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, tls13AES128GCMKeyLen)
-}
-
-// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
-// negotiated client and server handshake/application traffic secrets.
-func (c *TLSAes128GcmSha256) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
-	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
-}
-
-func (c *TLSAes128GcmSha256) newRecordProtection(
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newAES128GCMRecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret)
+	return &TLSAes128GcmSha256{
+		tlsAESGCMCipherSuite: newTLSAESGCMCipherSuite(
+			TLS_AES_128_GCM_SHA256,
+			sha256.New,
+			tls13AES128GCMKeyLen,
+		),
+	}
 }

--- a/internal/ciphersuite/tls_aes_256_gcm_sha384.go
+++ b/internal/ciphersuite/tls_aes_256_gcm_sha384.go
@@ -1,52 +1,22 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-//nolint:dupl // AES-128 and AES-256 implementations mirror one another.
 package ciphersuite
 
-import (
-	"crypto/sha512"
-	"hash"
-)
+import "crypto/sha512"
 
 // TLSAes256GcmSha384 represents the TLS_AES_256_GCM_SHA384 CipherSuite.
 type TLSAes256GcmSha384 struct {
-	TLS13CipherSuite
+	tlsAESGCMCipherSuite
 }
 
 // NewTLSAes256GcmSha384 returns the TLS_AES_256_GCM_SHA384 CipherSuite.
 func NewTLSAes256GcmSha384() *TLSAes256GcmSha384 {
-	return &TLSAes256GcmSha384{}
-}
-
-// ID returns the ID of the CipherSuite.
-func (c *TLSAes256GcmSha384) ID() ID {
-	return TLS_AES_256_GCM_SHA384
-}
-
-func (c *TLSAes256GcmSha384) String() string {
-	return "TLS_AES_256_GCM_SHA384"
-}
-
-// HashFunc returns the hashing func for this CipherSuite.
-func (c *TLSAes256GcmSha384) HashFunc() func() hash.Hash {
-	return sha512.New384
-}
-
-// NewRecordProtection derives record protection for one DTLS 1.3 traffic
-// direction and generation.
-func (c *TLSAes256GcmSha384) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
-	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, tls13AES256GCMKeyLen)
-}
-
-// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
-// negotiated client and server handshake/application traffic secrets.
-func (c *TLSAes256GcmSha384) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
-	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
-}
-
-func (c *TLSAes256GcmSha384) newRecordProtection(
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newAES256GCMRecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret)
+	return &TLSAes256GcmSha384{
+		tlsAESGCMCipherSuite: newTLSAESGCMCipherSuite(
+			TLS_AES_256_GCM_SHA384,
+			sha512.New384,
+			tls13AES256GCMKeyLen,
+		),
+	}
 }

--- a/internal/ciphersuite/tls_aes_gcm.go
+++ b/internal/ciphersuite/tls_aes_gcm.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package ciphersuite
+
+import "hash"
+
+// tlsAESGCMCipherSuite provides the common TLS 1.3 AES-GCM cipher suite
+// behavior, parameterized by its identifier, hash, and AES key size.
+type tlsAESGCMCipherSuite struct {
+	TLS13CipherSuite
+
+	id       ID
+	hashFunc func() hash.Hash
+	keyLen   int
+}
+
+func newTLSAESGCMCipherSuite(id ID, hashFunc func() hash.Hash, keyLen int) tlsAESGCMCipherSuite {
+	return tlsAESGCMCipherSuite{
+		id:       id,
+		hashFunc: hashFunc,
+		keyLen:   keyLen,
+	}
+}
+
+// ID returns the ID of the CipherSuite.
+func (c *tlsAESGCMCipherSuite) ID() ID {
+	return c.id
+}
+
+func (c *tlsAESGCMCipherSuite) String() string {
+	return c.id.String()
+}
+
+// HashFunc returns the hashing func for this CipherSuite.
+func (c *tlsAESGCMCipherSuite) HashFunc() func() hash.Hash {
+	return c.hashFunc
+}
+
+// NewRecordProtection derives record protection for one DTLS 1.3 traffic
+// direction and generation.
+func (c *tlsAESGCMCipherSuite) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
+	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, c.keyLen)
+}
+
+// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
+// negotiated client and server handshake/application traffic secrets.
+func (c *tlsAESGCMCipherSuite) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
+	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
+}
+
+func (c *tlsAESGCMCipherSuite) newRecordProtection(
+	localTrafficSecret, remoteTrafficSecret []byte,
+) (*recordProtection13, error) {
+	return newAESGCMRecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret, c.keyLen)
+}


### PR DESCRIPTION
#### Description
Collapses shared aes gcm code between 128 and 256 into a shared base, and remove some redundant helpers.