### PR TITLE
Per epoch directional traffic keys

### DIFF
--- a/internal/handshake/record_protection.go
+++ b/internal/handshake/record_protection.go
@@ -17,7 +17,12 @@ func InitHandshakeRecordProtection(state *dtlsstate.State13) error {
 		return dtlserrors.ErrCipherSuiteNotSet
 	}
 
-	return initRecordProtectionFromTrafficSecrets(state, state.KeySchedule.HandshakeTraffic, false)
+	return initRecordProtectionFromTrafficSecrets(
+		state,
+		dtlsflight13.EpochHandshake,
+		state.KeySchedule.HandshakeTraffic,
+		false,
+	)
 }
 
 // InitApplicationRecordProtection installs DTLS 1.3 application record
@@ -27,10 +32,15 @@ func InitApplicationRecordProtection(state *dtlsstate.State13) error {
 		return dtlserrors.ErrCipherSuiteNotSet
 	}
 
-	return initRecordProtectionFromTrafficSecrets(state, dtlsstate.TrafficSecrets{
-		Client: state.KeySchedule.ClientApplicationTrafficSecret0,
-		Server: state.KeySchedule.ServerApplicationTrafficSecret0,
-	}, true)
+	return initRecordProtectionFromTrafficSecrets(
+		state,
+		dtlsflight13.EpochApplication,
+		dtlsstate.TrafficSecrets{
+			Client: state.KeySchedule.ClientApplicationTrafficSecret0,
+			Server: state.KeySchedule.ServerApplicationTrafficSecret0,
+		},
+		true,
+	)
 }
 
 func activateApplicationRecordProtection(ctx context.Context, conn Conn, state *dtlsstate.State13) error {
@@ -45,28 +55,78 @@ func activateApplicationRecordProtection(ctx context.Context, conn Conn, state *
 
 func initRecordProtectionFromTrafficSecrets(
 	state *dtlsstate.State13,
+	epoch uint16,
 	secrets dtlsstate.TrafficSecrets,
 	allowReinitialize bool,
 ) error {
+	tls13CipherSuite, err := cipherSuite13(state)
+	if err != nil {
+		return err
+	}
+	if state.TrafficKeys == nil {
+		state.TrafficKeys = &dtlsstate.TrafficKeyState{}
+	}
+	if !allowReinitialize {
+		_, hasWrite := state.TrafficKeys.Write(epoch)
+		_, hasRead := state.TrafficKeys.Read(epoch)
+		if hasWrite && hasRead {
+			return nil
+		}
+	}
+
+	writeSecret, readSecret, err := directionalTrafficSecrets13(secrets, state.IsClient)
+	if err != nil {
+		return err
+	}
+	writeProtection, err := tls13CipherSuite.NewRecordProtection(writeSecret)
+	if err != nil {
+		return err
+	}
+	readProtection, err := tls13CipherSuite.NewRecordProtection(readSecret)
+	if err != nil {
+		return err
+	}
+	state.TrafficKeys.Install(
+		&dtlsstate.TrafficGeneration{
+			Epoch:      epoch,
+			Generation: 0,
+			Secret:     writeSecret,
+			Protection: writeProtection,
+		},
+		&dtlsstate.TrafficGeneration{
+			Epoch:      epoch,
+			Generation: 0,
+			Secret:     readSecret,
+			Protection: readProtection,
+		},
+	)
+
+	return tls13CipherSuite.InitFromTrafficSecrets(secrets.Client, secrets.Server, state.IsClient)
+}
+
+func cipherSuite13(state *dtlsstate.State13) (ciphersuite.CipherSuiteTLS13, error) {
 	if state == nil || state.CipherSuite == nil {
-		return dtlserrors.ErrCipherSuiteNotSet
+		return nil, dtlserrors.ErrCipherSuiteNotSet
 	}
 
 	tls13CipherSuite, ok := state.CipherSuite.(ciphersuite.CipherSuiteTLS13)
 	if !ok {
-		return dtlserrors.ErrInvalidCipherSuite
-	}
-	if !allowReinitialize && tls13CipherSuite.IsInitialized() {
-		return nil
+		return nil, dtlserrors.ErrInvalidCipherSuite
 	}
 
+	return tls13CipherSuite, nil
+}
+
+func directionalTrafficSecrets13(
+	secrets dtlsstate.TrafficSecrets,
+	isClient bool,
+) (write, read []byte, err error) {
 	if len(secrets.Client) == 0 || len(secrets.Server) == 0 {
-		return dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+		return nil, nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+	if isClient {
+		return secrets.Client, secrets.Server, nil
 	}
 
-	return tls13CipherSuite.InitFromTrafficSecrets(
-		secrets.Client,
-		secrets.Server,
-		state.IsClient,
-	)
+	return secrets.Server, secrets.Client, nil
 }

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
@@ -626,20 +627,38 @@ func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
 	assert.NotEmpty(t, state.KeySchedule.MasterSecret)
 }
 
-func TestInitHandshakeRecordProtection13(t *testing.T) {
-	cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
-	secretLen := cipherSuite.HashFunc()().Size()
-	state := newTestState13(true)
-	state.CipherSuite = cipherSuite
-	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
-		Client: bytes.Repeat([]byte{0x11}, secretLen),
-		Server: bytes.Repeat([]byte{0x22}, secretLen),
-	}
+func TestInitHandshakeRecordProtection13InstallsDirectionalKeys(t *testing.T) {
+	for _, testCase := range []struct {
+		name                  string
+		isClient              bool
+		expectedWrite, readID byte
+	}{
+		{name: "client", isClient: true, expectedWrite: 0x11, readID: 0x22},
+		{name: "server", isClient: false, expectedWrite: 0x22, readID: 0x11},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
+			secretLen := cipherSuite.HashFunc()().Size()
+			state := newTestState13(testCase.isClient)
+			state.CipherSuite = cipherSuite
+			state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
+				Client: bytes.Repeat([]byte{0x11}, secretLen),
+				Server: bytes.Repeat([]byte{0x22}, secretLen),
+			}
 
-	require.False(t, state.CipherSuite.IsInitialized())
-	require.NoError(t, InitHandshakeRecordProtection(state))
-	assert.True(t, state.CipherSuite.IsInitialized())
-	require.NoError(t, InitHandshakeRecordProtection(state))
+			require.NoError(t, InitHandshakeRecordProtection(state))
+			write, ok := state.TrafficKeys.Write(dtlsflight13.EpochHandshake)
+			require.True(t, ok)
+			read, ok := state.TrafficKeys.Read(dtlsflight13.EpochHandshake)
+			require.True(t, ok)
+			assert.Equal(t, testCase.expectedWrite, write.Secret[0])
+			assert.Equal(t, testCase.readID, read.Secret[0])
+			assert.NotNil(t, write.Protection)
+			assert.NotNil(t, read.Protection)
+
+			require.NoError(t, InitHandshakeRecordProtection(state))
+		})
+	}
 }
 
 func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
@@ -662,6 +681,19 @@ func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
 	require.NoError(t, InitHandshakeRecordProtection(state))
 	require.True(t, state.CipherSuite.IsInitialized())
 	require.NoError(t, InitApplicationRecordProtection(state))
+
+	applicationWrite, ok := state.TrafficKeys.Write(dtlsflight13.EpochApplication)
+	require.True(t, ok)
+	applicationRead, ok := state.TrafficKeys.Read(dtlsflight13.EpochApplication)
+	require.True(t, ok)
+	handshakeWrite, ok := state.TrafficKeys.Write(dtlsflight13.EpochHandshake)
+	require.True(t, ok)
+	handshakeRead, ok := state.TrafficKeys.Read(dtlsflight13.EpochHandshake)
+	require.True(t, ok)
+	assert.Equal(t, applicationSecrets.Client, applicationWrite.Secret)
+	assert.Equal(t, applicationSecrets.Server, applicationRead.Secret)
+	assert.Equal(t, handshakeSecrets.Client, handshakeWrite.Secret)
+	assert.Equal(t, handshakeSecrets.Server, handshakeRead.Secret)
 
 	clientSuite, ok := state.CipherSuite.(ciphersuite.CipherSuiteTLS13)
 	require.True(t, ok)


### PR DESCRIPTION
#### Description
Adds per-epoch directional traffic keys so that handshake & application records can be protected independently, part of #983 I'll do a cleanup for the old code once it's wired in conn.
Adds "out of scope" tests because this code didn't have direct test coverage.