### PR TITLE
Route record-protection through traffic-keys

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -14,7 +14,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pion/dtls/v3/internal/ciphersuite"
 	"github.com/pion/dtls/v3/internal/closer"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -935,9 +934,9 @@ func (c *Conn) sealRecordContent(
 	contentType protocol.ContentType,
 	plaintext []byte,
 ) ([]byte, error) {
-	tls13CipherSuite, ok := dtlsstate.CommonState(c.state).CipherSuite.(ciphersuite.CipherSuiteTLS13)
-	if !ok || !tls13CipherSuite.IsInitialized() {
-		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	generation, err := c.writeTrafficGeneration(epoch)
+	if err != nil {
+		return nil, err
 	}
 
 	header := recordlayer.UnifiedHeader{
@@ -947,7 +946,7 @@ func (c *Conn) sealRecordContent(
 		LengthBit:      true,
 	}
 
-	ciphertext, err := tls13CipherSuite.Seal(
+	ciphertext, err := generation.Protection.Seal(
 		header,
 		seq,
 		contentType,
@@ -958,6 +957,19 @@ func (c *Conn) sealRecordContent(
 	}
 
 	return ciphertext.Marshal()
+}
+
+func (c *Conn) writeTrafficGeneration(epoch uint16) (*dtlsstate.TrafficGeneration, error) {
+	state13, ok := c.state.(*dtlsstate.State13)
+	if !ok || state13.TrafficKeys == nil {
+		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+	generation, ok := state13.TrafficKeys.Write(epoch)
+	if !ok || generation.Protection == nil {
+		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+
+	return generation, nil
 }
 
 //nolint:cyclop
@@ -1377,12 +1389,13 @@ func (c *Conn) openCiphertextRecord(
 		return recordlayer.InnerPlaintext{}, 0, dtlserrors.ErrInvalidEpoch
 	}
 
-	tls13CipherSuite, ok := dtlsstate.CommonState(c.state).CipherSuite.(ciphersuite.CipherSuiteTLS13)
-	if !ok || !tls13CipherSuite.IsInitialized() {
-		return recordlayer.InnerPlaintext{}, 0, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	generation, err := c.readTrafficGeneration(remoteEpoch)
+	if err != nil {
+		return recordlayer.InnerPlaintext{}, 0, err
 	}
 
-	clearHeader, err := tls13CipherSuite.UnmaskSequenceNumber(record.Header, record.EncryptedRecord)
+	protection := generation.Protection
+	clearHeader, err := protection.UnmaskSequenceNumber(record.Header, record.EncryptedRecord)
 	if err != nil {
 		return recordlayer.InnerPlaintext{}, 0, err
 	}
@@ -1392,7 +1405,7 @@ func (c *Conn) openCiphertextRecord(
 		clearHeader.SeqBit,
 		c.highestRemoteSequenceNumber(remoteEpoch),
 	)
-	innerPlaintext, err := tls13CipherSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+	innerPlaintext, err := protection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 	if err != nil {
 		return recordlayer.InnerPlaintext{}, 0, err
 	}
@@ -1407,6 +1420,19 @@ func (c *Conn) openCiphertextRecord(
 	}
 
 	return innerPlaintext, sequenceNumber, nil
+}
+
+func (c *Conn) readTrafficGeneration(epoch uint16) (*dtlsstate.TrafficGeneration, error) {
+	state13, ok := c.state.(*dtlsstate.State13)
+	if !ok || state13.TrafficKeys == nil {
+		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+	generation, ok := state13.TrafficKeys.Read(epoch)
+	if !ok || generation.Protection == nil {
+		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+
+	return generation, nil
 }
 
 func reconstructSequenceNumber(partial uint16, seqBit bool, highest uint64) uint64 {
@@ -1608,7 +1634,15 @@ func (c *Conn) queueIfCipherSuiteUninitialized(
 	message string,
 ) bool {
 	common := dtlsstate.CommonState(c.state)
-	if common.CipherSuite != nil && common.CipherSuite.IsInitialized() {
+	initialized := common.CipherSuite != nil && common.CipherSuite.IsInitialized()
+	if state13, ok := c.state.(*dtlsstate.State13); ok && common.LocalVersion.Equal(protocol.Version1_3) {
+		initialized = false
+		if state13.TrafficKeys != nil {
+			generation, found := state13.TrafficKeys.Read(common.RemoteEpoch())
+			initialized = found && generation.Protection != nil
+		}
+	}
+	if initialized {
 		return false
 	}
 	if bufferLease != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -4475,11 +4475,13 @@ func newTestConnWithWriteProtection(t *testing.T) (*Conn, ciphersuite.CipherSuit
 		LocalVersion: protocol.Version1_3,
 		CipherSuite:  localCipherSuite,
 	}
+	state13 := &dtlsstate.State13{Common: commonState}
+	installTestTrafficKeys(t, state13, localCipherSuite, clientSecret, serverSecret)
 
 	return &Conn{
 		handshakeCache:          dtlsflight.NewCache(),
 		maximumTransmissionUnit: defaultMTU,
-		state:                   &dtlsstate.State13{Common: commonState},
+		state:                   state13,
 	}, peerCipherSuite
 }
 
@@ -4499,6 +4501,8 @@ func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuite
 		LocalVersion: protocol.Version1_3,
 		CipherSuite:  localCipherSuite,
 	}
+	state13 := &dtlsstate.State13{Common: commonState}
+	installTestTrafficKeys(t, state13, localCipherSuite, clientSecret, serverSecret)
 
 	conn := &Conn{
 		fragmentBuffer:          dtlsfragmentbuffer.New(),
@@ -4506,11 +4510,41 @@ func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuite
 		maximumTransmissionUnit: defaultMTU,
 		replayProtectionWindow:  defaultReplayProtectionWindow,
 		log:                     logging.NewDefaultLoggerFactory().NewLogger("dtls"),
-		state:                   &dtlsstate.State13{Common: commonState},
+		state:                   state13,
 	}
 	conn.setRemoteEpoch(dtlsflight13.EpochHandshake)
 
 	return conn, peerCipherSuite
+}
+
+func installTestTrafficKeys(
+	t *testing.T,
+	state *dtlsstate.State13,
+	suite ciphersuite.CipherSuiteTLS13,
+	writeSecret, readSecret []byte,
+) {
+	t.Helper()
+
+	writeProtection, err := suite.NewRecordProtection(writeSecret)
+	require.NoError(t, err)
+	readProtection, err := suite.NewRecordProtection(readSecret)
+	require.NoError(t, err)
+
+	state.TrafficKeys = &dtlsstate.TrafficKeyState{}
+	for _, epoch := range []uint16{dtlsflight13.EpochHandshake, dtlsflight13.EpochApplication} {
+		state.TrafficKeys.Install(
+			&dtlsstate.TrafficGeneration{
+				Epoch:      epoch,
+				Secret:     writeSecret,
+				Protection: writeProtection,
+			},
+			&dtlsstate.TrafficGeneration{
+				Epoch:      epoch,
+				Secret:     readSecret,
+				Protection: readProtection,
+			},
+		)
+	}
 }
 
 func encryptedExtensionsHandshake(t *testing.T) []byte {
@@ -4589,4 +4623,168 @@ func openTestProtectedRecord(
 	assert.NoError(t, err)
 
 	return innerPlaintext
+}
+
+func TestSealRecordContentUsesWriteTrafficGeneration(t *testing.T) {
+	conn, state, suite := newTrafficKeyTestConn(t)
+	handshakeSecret := trafficKeyTestSecret(suite, 0x11)
+	applicationSecret := trafficKeyTestSecret(suite, 0x22)
+	handshakeProtection := trafficKeyTestProtection(t, suite, handshakeSecret)
+	applicationProtection := trafficKeyTestProtection(t, suite, applicationSecret)
+
+	state.TrafficKeys.Install(&dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochHandshake,
+		Secret:     handshakeSecret,
+		Protection: handshakeProtection,
+	}, nil)
+	state.TrafficKeys.Install(&dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochApplication,
+		Secret:     applicationSecret,
+		Protection: applicationProtection,
+	}, nil)
+
+	applicationRecord, err := conn.sealRecordContent(
+		dtlsflight13.EpochApplication, 0, protocol.ContentTypeApplicationData, []byte("application"),
+	)
+	require.NoError(t, err)
+	assertTrafficKeyTestRecord(t, applicationProtection, applicationRecord, []byte("application"))
+
+	handshakeRecord, err := conn.sealRecordContent(
+		dtlsflight13.EpochHandshake, 0, protocol.ContentTypeHandshake, []byte("handshake"),
+	)
+	require.NoError(t, err)
+	assertTrafficKeyTestRecord(t, handshakeProtection, handshakeRecord, []byte("handshake"))
+
+	_, err = conn.sealRecordContent(4, 0, protocol.ContentTypeApplicationData, nil)
+	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
+}
+
+func TestOpenCiphertextRecordUsesReadTrafficGeneration(t *testing.T) {
+	conn, state, suite := newTrafficKeyTestConn(t)
+	handshakeSecret := trafficKeyTestSecret(suite, 0x31)
+	applicationSecret := trafficKeyTestSecret(suite, 0x32)
+	handshakeProtection := trafficKeyTestProtection(t, suite, handshakeSecret)
+	applicationProtection := trafficKeyTestProtection(t, suite, applicationSecret)
+
+	state.TrafficKeys.Install(nil, &dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochHandshake,
+		Secret:     handshakeSecret,
+		Protection: handshakeProtection,
+	})
+	state.TrafficKeys.Install(nil, &dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochApplication,
+		Secret:     applicationSecret,
+		Protection: applicationProtection,
+	})
+
+	state.SetRemoteEpoch(dtlsflight13.EpochHandshake)
+	handshakeRecord := sealTrafficKeyTestRecord(
+		t, handshakeProtection, dtlsflight13.EpochHandshake, protocol.ContentTypeHandshake, []byte("handshake"),
+	)
+	innerPlaintext, _, err := conn.openCiphertextRecord(handshakeRecord)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("handshake"), innerPlaintext.Content)
+
+	state.SetRemoteEpoch(dtlsflight13.EpochApplication)
+	applicationRecord := sealTrafficKeyTestRecord(
+		t, applicationProtection, dtlsflight13.EpochApplication, protocol.ContentTypeApplicationData, []byte("application"),
+	)
+	innerPlaintext, _, err = conn.openCiphertextRecord(applicationRecord)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("application"), innerPlaintext.Content)
+
+	wrongDirection := trafficKeyTestProtection(t, suite, trafficKeyTestSecret(suite, 0x33))
+	state.TrafficKeys.Install(nil, &dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochApplication,
+		Secret:     trafficKeyTestSecret(suite, 0x33),
+		Protection: wrongDirection,
+	})
+	_, _, err = conn.openCiphertextRecord(applicationRecord)
+	assert.ErrorIs(t, err, dtlserrors.ErrDecryptPacket)
+
+	state.SetRemoteEpoch(4)
+	applicationRecord.Header.EpochLow = 0
+	_, _, err = conn.openCiphertextRecord(applicationRecord)
+	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
+}
+
+func TestQueueIfCipherSuiteUninitializedUsesReadTrafficGeneration(t *testing.T) {
+	conn, state, suite := newTrafficKeyTestConn(t)
+	for _, epoch := range []uint16{dtlsflight13.EpochHandshake, dtlsflight13.EpochApplication} {
+		state.TrafficKeys.Install(nil, &dtlsstate.TrafficGeneration{
+			Epoch:      epoch,
+			Secret:     trafficKeyTestSecret(suite, byte(epoch)),
+			Protection: trafficKeyTestProtection(t, suite, trafficKeyTestSecret(suite, byte(epoch))),
+		})
+		state.SetRemoteEpoch(epoch)
+		assert.False(t, conn.queueIfCipherSuiteUninitialized(nil, nil, nil, "traffic key available"))
+	}
+}
+
+func newTrafficKeyTestConn(t *testing.T) (*Conn, *dtlsstate.State13, ciphersuite.CipherSuiteTLS13) {
+	t.Helper()
+
+	suite := ciphersuite.NewTLSAes128GcmSha256()
+	state := &dtlsstate.State13{
+		Common: &dtlsstate.Common{
+			IsClient:     true,
+			LocalVersion: protocol.Version1_3,
+			CipherSuite:  suite,
+		},
+		TrafficKeys: &dtlsstate.TrafficKeyState{},
+	}
+
+	return &Conn{state: state}, state, suite
+}
+
+func trafficKeyTestSecret(suite ciphersuite.CipherSuiteTLS13, value byte) []byte {
+	return bytes.Repeat([]byte{value}, suite.HashFunc()().Size())
+}
+
+func trafficKeyTestProtection(
+	t *testing.T,
+	suite ciphersuite.CipherSuiteTLS13,
+	secret []byte,
+) ciphersuite.RecordProtection13 {
+	t.Helper()
+
+	protection, err := suite.NewRecordProtection(secret)
+	require.NoError(t, err)
+
+	return protection
+}
+
+func sealTrafficKeyTestRecord(
+	t *testing.T,
+	protection ciphersuite.RecordProtection13,
+	epoch uint16,
+	contentType protocol.ContentType,
+	plaintext []byte,
+) recordlayer.CiphertextRecord13 {
+	t.Helper()
+
+	record, err := protection.Seal(
+		recordlayer.UnifiedHeader{EpochLow: uint8(epoch & recordlayer.TwoLowBitsMask), SeqBit: true},
+		0,
+		contentType,
+		plaintext,
+	)
+	require.NoError(t, err)
+
+	return record
+}
+
+func assertTrafficKeyTestRecord(
+	t *testing.T,
+	protection ciphersuite.RecordProtection13,
+	rawRecord []byte,
+	want []byte,
+) {
+	t.Helper()
+
+	var record recordlayer.CiphertextRecord13
+	require.NoError(t, record.Unmarshal(rawRecord))
+	innerPlaintext, err := protection.Open(record.Header, 0, record.EncryptedRecord)
+	require.NoError(t, err)
+	assert.Equal(t, want, innerPlaintext.Content)
 }


### PR DESCRIPTION
#### Description
forward record writes and reads through the new epoch-aware directional TrafficSecert state added in #984 this is the last functional work of #983 I just need to do a cleanup after this.
