### PR TITLE
Remove record-protection singleton

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1633,16 +1633,7 @@ func (c *Conn) queueIfCipherSuiteUninitialized(
 	bufferLease *readBufferLease,
 	message string,
 ) bool {
-	common := dtlsstate.CommonState(c.state)
-	initialized := common.CipherSuite != nil && common.CipherSuite.IsInitialized()
-	if state13, ok := c.state.(*dtlsstate.State13); ok && common.LocalVersion.Equal(protocol.Version1_3) {
-		initialized = false
-		if state13.TrafficKeys != nil {
-			generation, found := state13.TrafficKeys.Read(common.RemoteEpoch())
-			initialized = found && generation.Protection != nil
-		}
-	}
-	if initialized {
+	if c.hasInboundRecordProtection() {
 		return false
 	}
 	if bufferLease != nil {
@@ -1652,6 +1643,20 @@ func (c *Conn) queueIfCipherSuiteUninitialized(
 	}
 
 	return true
+}
+
+func (c *Conn) hasInboundRecordProtection() bool {
+	common := dtlsstate.CommonState(c.state)
+	if state13, ok := c.state.(*dtlsstate.State13); ok && common.LocalVersion.Equal(protocol.Version1_3) {
+		if state13.TrafficKeys == nil {
+			return false
+		}
+		generation, found := state13.TrafficKeys.Read(common.RemoteEpoch())
+
+		return found && generation.Protection != nil
+	}
+
+	return common.CipherSuite != nil && common.CipherSuite.IsInitialized()
 }
 
 func (c *Conn) prepareLegacyPacket(
@@ -1897,7 +1902,7 @@ func (c *Conn) handleChangeCipherSpecRecord(
 	bufferLease *readBufferLease,
 ) bool {
 	common := dtlsstate.CommonState(c.state)
-	if common.CipherSuite == nil || !common.CipherSuite.IsInitialized() {
+	if !c.hasInboundRecordProtection() {
 		if bufferLease != nil {
 			if ok := bufferLease.enqueue(addrPkt{rAddr: rAddr, data: prepared.buf}); ok {
 				c.log.Debugf("CipherSuite not initialized, queuing packet")

--- a/conn_test.go
+++ b/conn_test.go
@@ -4029,9 +4029,11 @@ func TestDTLS13ServerSendsFinalACK(t *testing.T) {
 	}
 	var ciphertext recordlayer.CiphertextRecord13
 	require.NoError(t, ciphertext.Unmarshal(rawACK))
-	clientCipherSuite, ok := dtlsstate.CommonState(client.state).CipherSuite.(ciphersuite.CipherSuiteTLS13)
+	clientState, ok := client.state.(*dtlsstate.State13)
 	require.True(t, ok)
-	innerPlaintext, err := clientCipherSuite.Open(ciphertext.Header, 0, ciphertext.EncryptedRecord)
+	readGeneration, ok := clientState.TrafficKeys.Read(dtlsflight13.EpochApplication)
+	require.True(t, ok)
+	innerPlaintext, err := readGeneration.Protection.Open(ciphertext.Header, 0, ciphertext.EncryptedRecord)
 	require.NoError(t, err)
 	require.Equal(t, protocol.ContentTypeACK, innerPlaintext.RealType)
 	var ack protocol.ACK
@@ -4459,50 +4461,104 @@ func TestDTLS13ProtectedHandshakeRecordKeepsEpochAndSequence(t *testing.T) {
 	}
 }
 
-func newTestConnWithWriteProtection(t *testing.T) (*Conn, ciphersuite.CipherSuiteTLS13) {
+func newTestConnWithWriteProtection(t *testing.T) (*Conn, ciphersuite.RecordProtection13) {
 	t.Helper()
 
 	localCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
 	clientSecret := bytes.Repeat([]byte{0x11}, localCipherSuite.HashFunc()().Size())
 	serverSecret := bytes.Repeat([]byte{0x22}, localCipherSuite.HashFunc()().Size())
-	assert.NoError(t, localCipherSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
+	localWriteProtection, err := localCipherSuite.NewRecordProtection(clientSecret)
+	assert.NoError(t, err)
+	localReadProtection, err := localCipherSuite.NewRecordProtection(serverSecret)
+	assert.NoError(t, err)
 
 	peerCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
-	assert.NoError(t, peerCipherSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+	peerReadProtection, err := peerCipherSuite.NewRecordProtection(clientSecret)
+	assert.NoError(t, err)
 
 	commonState := &dtlsstate.Common{
 		IsClient:     true,
 		LocalVersion: protocol.Version1_3,
 		CipherSuite:  localCipherSuite,
 	}
-	state13 := &dtlsstate.State13{Common: commonState}
-	installTestTrafficKeys(t, state13, localCipherSuite, clientSecret, serverSecret)
+	state13 := &dtlsstate.State13{Common: commonState, TrafficKeys: &dtlsstate.TrafficKeyState{}}
+	state13.TrafficKeys.Install(
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochHandshake,
+			Secret:     clientSecret,
+			Protection: localWriteProtection,
+		},
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochHandshake,
+			Secret:     serverSecret,
+			Protection: localReadProtection,
+		},
+	)
+	state13.TrafficKeys.Install(
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochApplication,
+			Secret:     clientSecret,
+			Protection: localWriteProtection,
+		},
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochApplication,
+			Secret:     serverSecret,
+			Protection: localReadProtection,
+		},
+	)
 
 	return &Conn{
 		handshakeCache:          dtlsflight.NewCache(),
 		maximumTransmissionUnit: defaultMTU,
 		state:                   state13,
-	}, peerCipherSuite
+	}, peerReadProtection
 }
 
-func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuiteTLS13) {
+func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.RecordProtection13) {
 	t.Helper()
 
 	localCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
 	clientSecret := bytes.Repeat([]byte{0x11}, localCipherSuite.HashFunc()().Size())
 	serverSecret := bytes.Repeat([]byte{0x22}, localCipherSuite.HashFunc()().Size())
-	assert.NoError(t, localCipherSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
+	localWriteProtection, err := localCipherSuite.NewRecordProtection(clientSecret)
+	assert.NoError(t, err)
+	localReadProtection, err := localCipherSuite.NewRecordProtection(serverSecret)
+	assert.NoError(t, err)
 
 	peerCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
-	assert.NoError(t, peerCipherSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+	peerWriteProtection, err := peerCipherSuite.NewRecordProtection(serverSecret)
+	assert.NoError(t, err)
 
 	commonState := &dtlsstate.Common{
 		IsClient:     true,
 		LocalVersion: protocol.Version1_3,
 		CipherSuite:  localCipherSuite,
 	}
-	state13 := &dtlsstate.State13{Common: commonState}
-	installTestTrafficKeys(t, state13, localCipherSuite, clientSecret, serverSecret)
+	state13 := &dtlsstate.State13{Common: commonState, TrafficKeys: &dtlsstate.TrafficKeyState{}}
+	state13.TrafficKeys.Install(
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochHandshake,
+			Secret:     clientSecret,
+			Protection: localWriteProtection,
+		},
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochHandshake,
+			Secret:     serverSecret,
+			Protection: localReadProtection,
+		},
+	)
+	state13.TrafficKeys.Install(
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochApplication,
+			Secret:     clientSecret,
+			Protection: localWriteProtection,
+		},
+		&dtlsstate.TrafficGeneration{
+			Epoch:      dtlsflight13.EpochApplication,
+			Secret:     serverSecret,
+			Protection: localReadProtection,
+		},
+	)
 
 	conn := &Conn{
 		fragmentBuffer:          dtlsfragmentbuffer.New(),
@@ -4514,37 +4570,7 @@ func newTestConnWithReadProtection(t *testing.T) (*Conn, ciphersuite.CipherSuite
 	}
 	conn.setRemoteEpoch(dtlsflight13.EpochHandshake)
 
-	return conn, peerCipherSuite
-}
-
-func installTestTrafficKeys(
-	t *testing.T,
-	state *dtlsstate.State13,
-	suite ciphersuite.CipherSuiteTLS13,
-	writeSecret, readSecret []byte,
-) {
-	t.Helper()
-
-	writeProtection, err := suite.NewRecordProtection(writeSecret)
-	require.NoError(t, err)
-	readProtection, err := suite.NewRecordProtection(readSecret)
-	require.NoError(t, err)
-
-	state.TrafficKeys = &dtlsstate.TrafficKeyState{}
-	for _, epoch := range []uint16{dtlsflight13.EpochHandshake, dtlsflight13.EpochApplication} {
-		state.TrafficKeys.Install(
-			&dtlsstate.TrafficGeneration{
-				Epoch:      epoch,
-				Secret:     writeSecret,
-				Protection: writeProtection,
-			},
-			&dtlsstate.TrafficGeneration{
-				Epoch:      epoch,
-				Secret:     readSecret,
-				Protection: readProtection,
-			},
-		)
-	}
+	return conn, peerWriteProtection
 }
 
 func encryptedExtensionsHandshake(t *testing.T) []byte {
@@ -4567,23 +4593,23 @@ func encryptedExtensionsHandshakeWithSequence(t *testing.T, messageSequence uint
 
 func sealTestProtectedHandshakeRecord(
 	t *testing.T,
-	cipherSuite ciphersuite.CipherSuiteTLS13,
+	protection ciphersuite.RecordProtection13,
 	plaintext []byte,
 ) recordlayer.CiphertextRecord13 {
 	t.Helper()
 
-	return sealTestProtectedHandshakeRecordWithSequence(t, cipherSuite, plaintext, 0)
+	return sealTestProtectedHandshakeRecordWithSequence(t, protection, plaintext, 0)
 }
 
 func sealTestProtectedHandshakeRecordWithSequence(
 	t *testing.T,
-	cipherSuite ciphersuite.CipherSuiteTLS13,
+	protection ciphersuite.RecordProtection13,
 	plaintext []byte,
 	sequenceNumber uint64,
 ) recordlayer.CiphertextRecord13 {
 	t.Helper()
 
-	record, err := cipherSuite.Seal(
+	record, err := protection.Seal(
 		recordlayer.UnifiedHeader{
 			EpochLow: uint8(dtlsflight13.EpochHandshake & recordlayer.TwoLowBitsMask),
 		},
@@ -4607,7 +4633,7 @@ func appendProtectedRecordHeader(t *testing.T, header *recordlayer.Header, conte
 
 func openTestProtectedRecord(
 	t *testing.T,
-	cipherSuite ciphersuite.CipherSuiteTLS13,
+	protection ciphersuite.RecordProtection13,
 	rawPacket []byte,
 ) recordlayer.InnerPlaintext {
 	t.Helper()
@@ -4615,7 +4641,7 @@ func openTestProtectedRecord(
 	var ciphertext recordlayer.CiphertextRecord13
 	assert.NoError(t, ciphertext.Unmarshal(rawPacket))
 
-	innerPlaintext, err := cipherSuite.Open(
+	innerPlaintext, err := protection.Open(
 		ciphertext.Header,
 		0,
 		ciphertext.EncryptedRecord,

--- a/flight_test.go
+++ b/flight_test.go
@@ -1445,7 +1445,8 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 	)
 	require.NoError(t, err)
 	peerCipherSuite := ciphersuite.NewTLSAes128GcmSha256()
-	require.NoError(t, peerCipherSuite.InitFromTrafficSecrets(secrets.Client, secrets.Server, false))
+	peerWriteProtection, err := peerCipherSuite.NewRecordProtection(secrets.Server)
+	require.NoError(t, err)
 
 	rawEncryptedExtensions, err := (&handshake.Handshake{
 		Header:  handshake.Header{MessageSequence: 1},
@@ -1468,11 +1469,11 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{}
 
 	protectedEncryptedExtensions := sealTestProtectedHandshakeRecordWithSequence(
-		t, peerCipherSuite, rawEncryptedExtensions, 0,
+		t, peerWriteProtection, rawEncryptedExtensions, 0,
 	)
 	protectedEncryptedExtensionsRaw, err := protectedEncryptedExtensions.Marshal()
 	require.NoError(t, err)
-	protectedFinished := sealTestProtectedHandshakeRecordWithSequence(t, peerCipherSuite, rawFinished, 1)
+	protectedFinished := sealTestProtectedHandshakeRecordWithSequence(t, peerWriteProtection, rawFinished, 1)
 	protectedFinishedRaw, err := protectedFinished.Marshal()
 	require.NoError(t, err)
 	conn.encryptedPackets = []addrPkt{{data: protectedEncryptedExtensionsRaw}, {data: protectedFinishedRaw}}

--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -5,7 +5,6 @@ package ciphersuite
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
@@ -16,23 +15,7 @@ import (
 // CipherSuiteTLS13 is the DTLS 1.3-specific cipher suite surface.
 type CipherSuiteTLS13 interface {
 	CipherSuite
-	InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error
 	NewRecordProtection(trafficSecret []byte) (RecordProtection13, error)
-	Seal(
-		header recordlayer.UnifiedHeader,
-		sequenceNumber uint64,
-		contentType protocol.ContentType,
-		plaintext []byte,
-	) (recordlayer.CiphertextRecord13, error)
-	Open(
-		header recordlayer.UnifiedHeader,
-		sequenceNumber uint64,
-		encryptedRecord []byte,
-	) (recordlayer.InnerPlaintext, error)
-	UnmaskSequenceNumber(
-		header recordlayer.UnifiedHeader,
-		encryptedRecord []byte,
-	) (recordlayer.UnifiedHeader, error)
 }
 
 // RecordProtection13 protects records for one DTLS 1.3 traffic direction and
@@ -58,9 +41,7 @@ type RecordProtection13 interface {
 // TLS13CipherSuite provides behavior common to TLS 1.3 cipher suites. TLS 1.3
 // cipher suites only identify the AEAD and hash; authentication and key
 // exchange are negotiated independently.
-type TLS13CipherSuite struct {
-	recordProtection atomic.Value // *recordProtection13
-}
+type TLS13CipherSuite struct{}
 
 func (c *TLS13CipherSuite) CertificateType() clientcertificate.Type {
 	return 0
@@ -78,96 +59,10 @@ func (c *TLS13CipherSuite) AuthenticationType() AuthenticationType {
 	return AuthenticationTypeAnonymous
 }
 
+// IsInitialized satisfies the generic CipherSuite contract. DTLS 1.3 record
+// key readiness is tracked by state.TrafficKeys, not by the cipher suite.
 func (c *TLS13CipherSuite) IsInitialized() bool {
-	return c.recordProtection.Load() != nil
-}
-
-func (c *TLS13CipherSuite) initFromTrafficSecrets13(
-	clientSecret, serverSecret []byte,
-	isClient bool,
-	newRecordProtection func(localTrafficSecret, remoteTrafficSecret []byte) (*recordProtection13, error),
-) error {
-	if newRecordProtection == nil {
-		return dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	localSecret, remoteSecret := localRemoteTrafficSecrets13(clientSecret, serverSecret, isClient)
-	protection, err := newRecordProtection(localSecret, remoteSecret)
-	if err != nil {
-		return err
-	}
-
-	c.recordProtection.Store(protection)
-
-	return nil
-}
-
-func (c *TLS13CipherSuite) getRecordProtection13() (*recordProtection13, bool) {
-	protection, ok := c.recordProtection.Load().(*recordProtection13)
-
-	return protection, ok
-}
-
-func (c *TLS13CipherSuite) Seal(
-	header recordlayer.UnifiedHeader,
-	sequenceNumber uint64,
-	contentType protocol.ContentType,
-	plaintext []byte,
-) (recordlayer.CiphertextRecord13, error) {
-	protection, ok := c.getRecordProtection13()
-	if !ok {
-		return recordlayer.CiphertextRecord13{}, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	header.SequenceNumber = uint16(sequenceNumber & 0xffff)
-	record, err := protection.seal(header, sequenceNumber, contentType, plaintext)
-	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
-	}
-
-	if err = protection.maskLocalSequenceNumber(&record.Header, record.EncryptedRecord); err != nil {
-		return recordlayer.CiphertextRecord13{}, err
-	}
-
-	return record, nil
-}
-
-func (c *TLS13CipherSuite) Open(
-	header recordlayer.UnifiedHeader,
-	sequenceNumber uint64,
-	encryptedRecord []byte,
-) (recordlayer.InnerPlaintext, error) {
-	protection, ok := c.getRecordProtection13()
-	if !ok {
-		return recordlayer.InnerPlaintext{}, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	clearHeader := header
-	if err := protection.unmaskRemoteSequenceNumber(&clearHeader, encryptedRecord); err != nil {
-		return recordlayer.InnerPlaintext{}, err
-	}
-	if err := validateSequenceNumberLowBits13(clearHeader, sequenceNumber); err != nil {
-		return recordlayer.InnerPlaintext{}, err
-	}
-
-	return protection.open(clearHeader, sequenceNumber, encryptedRecord)
-}
-
-func (c *TLS13CipherSuite) UnmaskSequenceNumber(
-	header recordlayer.UnifiedHeader,
-	encryptedRecord []byte,
-) (recordlayer.UnifiedHeader, error) {
-	protection, ok := c.getRecordProtection13()
-	if !ok {
-		return recordlayer.UnifiedHeader{}, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	clearHeader := header
-	if err := protection.unmaskRemoteSequenceNumber(&clearHeader, encryptedRecord); err != nil {
-		return recordlayer.UnifiedHeader{}, err
-	}
-
-	return clearHeader, nil
+	return true
 }
 
 func (c *TLS13CipherSuite) Init(_, _, _ []byte, _ bool) error {
@@ -180,15 +75,4 @@ func (c *TLS13CipherSuite) Encrypt(_ *recordlayer.RecordLayer, _ []byte) ([]byte
 
 func (c *TLS13CipherSuite) Decrypt(_ recordlayer.Header, _ []byte) ([]byte, error) {
 	return nil, fmt.Errorf("%w, unable to decrypt", dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
-}
-
-func localRemoteTrafficSecrets13(
-	clientSecret, serverSecret []byte,
-	isClient bool,
-) (localSecret, remoteSecret []byte) {
-	if isClient {
-		return clientSecret, serverSecret
-	}
-
-	return serverSecret, clientSecret
 }

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -54,53 +54,27 @@ type recordTrafficProtection13 struct {
 	sequenceNumberMaskFn recordSequenceNumberMaskFunc13
 }
 
-type recordProtection13 struct {
-	local  recordTrafficProtection13
-	remote recordTrafficProtection13
-}
-
-func newAESGCMRecordProtection13(
-	hashFunc func() hash.Hash,
-	localTrafficSecret, remoteTrafficSecret []byte,
-	keyLen int,
-) (*recordProtection13, error) {
-	local, err := newAESGCMRecordTrafficProtection13(hashFunc, localTrafficSecret, keyLen)
-	if err != nil {
-		return nil, err
-	}
-
-	remote, err := newAESGCMRecordTrafficProtection13(hashFunc, remoteTrafficSecret, keyLen)
-	if err != nil {
-		return nil, err
-	}
-
-	return &recordProtection13{
-		local:  local,
-		remote: remote,
-	}, nil
-}
-
 func newAESGCMRecordTrafficProtection13(
 	hashFunc func() hash.Hash,
 	trafficSecret []byte,
 	keyLen int,
-) (recordTrafficProtection13, error) {
+) (*recordTrafficProtection13, error) {
 	keys, err := deriveRecordTrafficKeys13(hashFunc, trafficSecret, keyLen)
 	if err != nil {
-		return recordTrafficProtection13{}, err
+		return nil, err
 	}
 
 	block, err := aes.NewCipher(keys.key)
 	if err != nil {
-		return recordTrafficProtection13{}, err
+		return nil, err
 	}
 
 	aead, err := cipher.NewGCM(block)
 	if err != nil {
-		return recordTrafficProtection13{}, err
+		return nil, err
 	}
 
-	return recordTrafficProtection13{
+	return &recordTrafficProtection13{
 		aead:                 aead,
 		iv:                   keys.iv,
 		sequenceNumberKey:    keys.sequenceNumberKey,
@@ -108,41 +82,21 @@ func newAESGCMRecordTrafficProtection13(
 	}, nil
 }
 
-func newChaCha20Poly1305RecordProtection13(
-	hashFunc func() hash.Hash,
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	local, err := newChaCha20Poly1305RecordTrafficProtection13(hashFunc, localTrafficSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	remote, err := newChaCha20Poly1305RecordTrafficProtection13(hashFunc, remoteTrafficSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	return &recordProtection13{
-		local:  local,
-		remote: remote,
-	}, nil
-}
-
 func newChaCha20Poly1305RecordTrafficProtection13(
 	hashFunc func() hash.Hash,
 	trafficSecret []byte,
-) (recordTrafficProtection13, error) {
+) (*recordTrafficProtection13, error) {
 	keys, err := deriveRecordTrafficKeys13(hashFunc, trafficSecret, tls13ChaCha20Poly1305KeyLen)
 	if err != nil {
-		return recordTrafficProtection13{}, err
+		return nil, err
 	}
 
 	aead, err := chacha20poly1305.New(keys.key)
 	if err != nil {
-		return recordTrafficProtection13{}, err
+		return nil, err
 	}
 
-	return recordTrafficProtection13{
+	return &recordTrafficProtection13{
 		aead:                 aead,
 		iv:                   keys.iv,
 		sequenceNumberKey:    keys.sequenceNumberKey,
@@ -150,7 +104,7 @@ func newChaCha20Poly1305RecordTrafficProtection13(
 	}, nil
 }
 
-func (r *recordProtection13) seal(
+func (r *recordTrafficProtection13) seal(
 	header recordlayer.UnifiedHeader,
 	sequenceNumber uint64,
 	contentType protocol.ContentType,
@@ -168,7 +122,7 @@ func (r *recordProtection13) seal(
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
-	ciphertextLen := len(innerPlaintext) + r.local.aead.Overhead()
+	ciphertextLen := len(innerPlaintext) + r.aead.Overhead()
 	if ciphertextLen > maxDTLSCiphertextRecordLen13 {
 		return recordlayer.CiphertextRecord13{}, dtlserrors.ErrInvalidPacketLength
 	}
@@ -181,7 +135,7 @@ func (r *recordProtection13) seal(
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
-	nonce, err := recordNonce13(r.local.iv, sequenceNumber)
+	nonce, err := recordNonce13(r.iv, sequenceNumber)
 	if err != nil {
 		return recordlayer.CiphertextRecord13{}, err
 	}
@@ -189,11 +143,11 @@ func (r *recordProtection13) seal(
 	// Sequence-number masking is kept separate until DTLS 1.3 record writer integration.
 	return recordlayer.CiphertextRecord13{
 		Header:          header,
-		EncryptedRecord: r.local.aead.Seal(nil, nonce, innerPlaintext, additionalData),
+		EncryptedRecord: r.aead.Seal(nil, nonce, innerPlaintext, additionalData),
 	}, nil
 }
 
-func (r *recordProtection13) open(
+func (r *recordTrafficProtection13) open(
 	header recordlayer.UnifiedHeader,
 	sequenceNumber uint64,
 	encryptedRecord []byte,
@@ -203,12 +157,12 @@ func (r *recordProtection13) open(
 		return recordlayer.InnerPlaintext{}, err
 	}
 
-	nonce, err := recordNonce13(r.remote.iv, sequenceNumber)
+	nonce, err := recordNonce13(r.iv, sequenceNumber)
 	if err != nil {
 		return recordlayer.InnerPlaintext{}, err
 	}
 
-	innerPlaintextRaw, err := r.remote.aead.Open(nil, nonce, encryptedRecord, additionalData)
+	innerPlaintextRaw, err := r.aead.Open(nil, nonce, encryptedRecord, additionalData)
 	if err != nil {
 		return recordlayer.InnerPlaintext{}, fmt.Errorf("%w: %v", dtlserrors.ErrDecryptPacket, err) //nolint:errorlint
 	}
@@ -221,15 +175,11 @@ func (r *recordProtection13) open(
 	return innerPlaintext, nil
 }
 
-func (r *recordProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
-	return r.local.sequenceNumberMask(encryptedRecord)
-}
-
-func (r *recordProtection13) maskLocalSequenceNumber(
+func (r *recordTrafficProtection13) maskSequenceNumber(
 	header *recordlayer.UnifiedHeader,
 	encryptedRecord []byte,
 ) error {
-	mask, err := r.local.sequenceNumberMask(encryptedRecord)
+	mask, err := r.sequenceNumberMask(encryptedRecord)
 	if err != nil {
 		return err
 	}
@@ -237,55 +187,39 @@ func (r *recordProtection13) maskLocalSequenceNumber(
 	return applySequenceNumberMask13(header, mask)
 }
 
-func (r *recordProtection13) unmaskRemoteSequenceNumber(
-	header *recordlayer.UnifiedHeader,
-	encryptedRecord []byte,
-) error {
-	mask, err := r.remote.sequenceNumberMask(encryptedRecord)
-	if err != nil {
-		return err
-	}
-
-	return applySequenceNumberMask13(header, mask)
-}
-
-func (p recordTrafficProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
-	if p.sequenceNumberMaskFn == nil {
+func (r recordTrafficProtection13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
+	if r.sequenceNumberMaskFn == nil {
 		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 	}
 
-	return p.sequenceNumberMaskFn(p.sequenceNumberKey, encryptedRecord)
+	return r.sequenceNumberMaskFn(r.sequenceNumberKey, encryptedRecord)
 }
 
-func (p recordTrafficProtection13) Seal(
+func (r *recordTrafficProtection13) Seal(
 	header recordlayer.UnifiedHeader,
 	sequenceNumber uint64,
 	contentType protocol.ContentType,
 	plaintext []byte,
 ) (recordlayer.CiphertextRecord13, error) {
 	header.SequenceNumber = uint16(sequenceNumber & 0xffff)
-	record, err := (&recordProtection13{local: p}).seal(header, sequenceNumber, contentType, plaintext)
+	record, err := r.seal(header, sequenceNumber, contentType, plaintext)
 	if err != nil {
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
-	mask, err := p.sequenceNumberMask(record.EncryptedRecord)
-	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
-	}
-	if err = applySequenceNumberMask13(&record.Header, mask); err != nil {
+	if err = r.maskSequenceNumber(&record.Header, record.EncryptedRecord); err != nil {
 		return recordlayer.CiphertextRecord13{}, err
 	}
 
 	return record, nil
 }
 
-func (p recordTrafficProtection13) Open(
+func (r *recordTrafficProtection13) Open(
 	header recordlayer.UnifiedHeader,
 	sequenceNumber uint64,
 	encryptedRecord []byte,
 ) (recordlayer.InnerPlaintext, error) {
-	clearHeader, err := p.UnmaskSequenceNumber(header, encryptedRecord)
+	clearHeader, err := r.UnmaskSequenceNumber(header, encryptedRecord)
 	if err != nil {
 		return recordlayer.InnerPlaintext{}, err
 	}
@@ -293,19 +227,15 @@ func (p recordTrafficProtection13) Open(
 		return recordlayer.InnerPlaintext{}, err
 	}
 
-	return (&recordProtection13{remote: p}).open(clearHeader, sequenceNumber, encryptedRecord)
+	return r.open(clearHeader, sequenceNumber, encryptedRecord)
 }
 
-func (p recordTrafficProtection13) UnmaskSequenceNumber(
+func (r *recordTrafficProtection13) UnmaskSequenceNumber(
 	header recordlayer.UnifiedHeader,
 	encryptedRecord []byte,
 ) (recordlayer.UnifiedHeader, error) {
-	mask, err := p.sequenceNumberMask(encryptedRecord)
-	if err != nil {
-		return recordlayer.UnifiedHeader{}, err
-	}
 	clearHeader := header
-	if err = applySequenceNumberMask13(&clearHeader, mask); err != nil {
+	if err := r.maskSequenceNumber(&clearHeader, encryptedRecord); err != nil {
 		return recordlayer.UnifiedHeader{}, err
 	}
 

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/aes"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -29,7 +30,81 @@ type recordProtection13TestCase struct {
 
 type tls13RecordProtectionSuite interface {
 	CipherSuiteTLS13
-	newRecordProtection(localTrafficSecret, remoteTrafficSecret []byte) (*recordProtection13, error)
+}
+
+type recordProtectionPair13 struct {
+	local  *recordTrafficProtection13
+	remote *recordTrafficProtection13
+}
+
+func (r *recordProtectionPair13) seal(
+	header recordlayer.UnifiedHeader,
+	sequenceNumber uint64,
+	contentType protocol.ContentType,
+	plaintext []byte,
+) (recordlayer.CiphertextRecord13, error) {
+	return r.local.seal(header, sequenceNumber, contentType, plaintext)
+}
+
+func (r *recordProtectionPair13) open(
+	header recordlayer.UnifiedHeader,
+	sequenceNumber uint64,
+	encryptedRecord []byte,
+) (recordlayer.InnerPlaintext, error) {
+	return r.remote.open(header, sequenceNumber, encryptedRecord)
+}
+
+func (r *recordProtectionPair13) sequenceNumberMask(encryptedRecord []byte) ([]byte, error) {
+	return r.local.sequenceNumberMask(encryptedRecord)
+}
+
+func (r *recordProtectionPair13) maskLocalSequenceNumber(
+	header *recordlayer.UnifiedHeader,
+	encryptedRecord []byte,
+) error {
+	return r.local.maskSequenceNumber(header, encryptedRecord)
+}
+
+func (r *recordProtectionPair13) unmaskRemoteSequenceNumber(
+	header *recordlayer.UnifiedHeader,
+	encryptedRecord []byte,
+) error {
+	return r.remote.maskSequenceNumber(header, encryptedRecord)
+}
+
+func newRecordProtection13ForTest(
+	suite tls13RecordProtectionSuite,
+	localTrafficSecret, remoteTrafficSecret []byte,
+) (*recordProtectionPair13, error) {
+	localProtection, err := suite.NewRecordProtection(localTrafficSecret)
+	if err != nil {
+		return nil, err
+	}
+	remoteProtection, err := suite.NewRecordProtection(remoteTrafficSecret)
+	if err != nil {
+		return nil, err
+	}
+	local, ok := localProtection.(*recordTrafficProtection13)
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: unexpected local type %T",
+			dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented,
+			localProtection,
+		)
+	}
+	remote, ok := remoteProtection.(*recordTrafficProtection13)
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: unexpected remote type %T",
+			dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented,
+			remoteProtection,
+		)
+	}
+
+	return &recordProtectionPair13{
+		local:  local,
+		remote: remote,
+	}, nil
 }
 
 func recordProtection13TestCases() []recordProtection13TestCase {
@@ -159,32 +234,6 @@ func tlsChaCha20Poly1305SHA25613VectorSecrets(t *testing.T) (clientSecret, serve
 	return clientSecret, serverSecret
 }
 
-func requireRecordProtection13(t *testing.T, suite tls13RecordProtectionSuite) *recordProtection13 {
-	t.Helper()
-
-	switch s := suite.(type) {
-	case *TLSAes128GcmSha256:
-		protection, ok := s.getRecordProtection13()
-		require.True(t, ok)
-
-		return protection
-	case *TLSAes256GcmSha384:
-		protection, ok := s.getRecordProtection13()
-		require.True(t, ok)
-
-		return protection
-	case *TLSChacha20Poly1305Sha256:
-		protection, ok := s.getRecordProtection13()
-		require.True(t, ok)
-
-		return protection
-	default:
-		assert.FailNowf(t, "unknown TLS 1.3 test suite", "suite: %T", suite)
-
-		return nil
-	}
-}
-
 type tls13KnownVector struct {
 	name                         string
 	suite                        func() tls13RecordProtectionSuite
@@ -306,9 +355,9 @@ func assertTLS13RecordProtectionKnownVector(t *testing.T, vector tls13KnownVecto
 		vector.expectedServerSequenceNumber,
 	)
 
-	protection, err := suite.newRecordProtection(clientSecret, serverSecret)
+	protection, err := newRecordProtection13ForTest(suite, clientSecret, serverSecret)
 	require.NoError(t, err)
-	peerProtection, err := suite.newRecordProtection(serverSecret, clientSecret)
+	peerProtection, err := newRecordProtection13ForTest(suite, serverSecret, clientSecret)
 	require.NoError(t, err)
 
 	nonce, err := recordNonce13(protection.local.iv, sequenceNumber)
@@ -386,14 +435,16 @@ func assertTLS13SuiteSealOpenKnownVector(t *testing.T, vector tls13KnownVector) 
 
 	clientSuite := vector.suite()
 	serverSuite := vector.suite()
-	clientSecret, serverSecret := vector.secrets(t)
+	clientSecret, _ := vector.secrets(t)
 	sequenceNumber := uint64(0x0001020304050607)
 	plaintext := []byte(vector.plaintext)
 
-	require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
-	require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+	clientProtection, err := clientSuite.NewRecordProtection(clientSecret)
+	require.NoError(t, err)
+	serverProtection, err := serverSuite.NewRecordProtection(clientSecret)
+	require.NoError(t, err)
 
-	record, err := clientSuite.Seal(
+	record, err := clientProtection.Seal(
 		recordlayer.UnifiedHeader{
 			ConnectionID: []byte{0xca, 0xfe, 0xba, 0xbe},
 			EpochLow:     3,
@@ -415,7 +466,7 @@ func assertTLS13SuiteSealOpenKnownVector(t *testing.T, vector tls13KnownVector) 
 	require.NoError(t, err)
 	assert.Equal(t, mustDecodeHex13(t, vector.expectedMaskedRaw), raw)
 
-	innerPlaintext, err := serverSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+	innerPlaintext, err := serverProtection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, innerPlaintext.Content)
 	assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
@@ -436,9 +487,9 @@ func assertTLS13OpenRejectsKnownVectorMutations(t *testing.T, vector tls13KnownV
 	clientSecret, serverSecret := vector.secrets(t)
 	sequenceNumber := uint64(0x0001020304050607)
 
-	protection, err := suite.newRecordProtection(clientSecret, serverSecret)
+	protection, err := newRecordProtection13ForTest(suite, clientSecret, serverSecret)
 	require.NoError(t, err)
-	peerProtection, err := suite.newRecordProtection(serverSecret, clientSecret)
+	peerProtection, err := newRecordProtection13ForTest(suite, serverSecret, clientSecret)
 	require.NoError(t, err)
 
 	record, err := protection.seal(
@@ -570,7 +621,7 @@ func TestTLS13CipherSuiteNewRecordProtectionSuites(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0x5a)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0x6b)
 
-			protection, err := testCase.suite.newRecordProtection(localTrafficSecret, remoteTrafficSecret)
+			protection, err := newRecordProtection13ForTest(testCase.suite, localTrafficSecret, remoteTrafficSecret)
 			require.NoError(t, err)
 			require.NotNil(t, protection.local.aead)
 			require.NotNil(t, protection.remote.aead)
@@ -598,26 +649,16 @@ func TestTLS13CipherSuiteNewRecordProtectionSuites(t *testing.T) {
 	}
 }
 
-func TestTLS13CipherSuiteInitFromTrafficSecrets(t *testing.T) {
+func TestTLS13RecordProtectionCanSealAndOpen(t *testing.T) {
 	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
-			clientSuite := testCase.suite
-			serverSuite := newRecordProtection13TestSuite(t, testCase.name)
+			suite := testCase.suite
 
-			clientSecret := trafficSecret13(testCase.suite, 0xa6)
-			serverSecret := trafficSecret13(testCase.suite, 0xb6)
+			trafficSecret := trafficSecret13(testCase.suite, 0xa6)
 
-			require.False(t, clientSuite.IsInitialized())
-			require.False(t, serverSuite.IsInitialized())
+			protection, err := suite.NewRecordProtection(trafficSecret)
+			require.NoError(t, err)
 
-			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
-			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
-
-			require.True(t, clientSuite.IsInitialized())
-			require.True(t, serverSuite.IsInitialized())
-
-			clientProtection := requireRecordProtection13(t, clientSuite)
-			serverProtection := requireRecordProtection13(t, serverSuite)
 			header := recordlayer.UnifiedHeader{
 				SequenceNumber: 0x1234,
 				EpochLow:       2,
@@ -625,10 +666,10 @@ func TestTLS13CipherSuiteInitFromTrafficSecrets(t *testing.T) {
 			sequenceNumber := uint64(0x0102030405060708)
 			plaintext := []byte("traffic-secret initialized payload")
 
-			record, err := clientProtection.seal(header, sequenceNumber, protocol.ContentTypeApplicationData, plaintext)
+			record, err := protection.Seal(header, sequenceNumber, protocol.ContentTypeApplicationData, plaintext)
 			require.NoError(t, err)
 
-			innerPlaintext, err := serverProtection.open(record.Header, sequenceNumber, record.EncryptedRecord)
+			innerPlaintext, err := protection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 			require.NoError(t, err)
 			assert.Equal(t, plaintext, innerPlaintext.Content)
 			assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
@@ -643,9 +684,10 @@ func TestTLS13CipherSuiteSeal(t *testing.T) {
 			serverSuite := newRecordProtection13TestSuite(t, testCase.name)
 
 			clientSecret := trafficSecret13(testCase.suite, 0xa7)
-			serverSecret := trafficSecret13(testCase.suite, 0xb7)
-			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
-			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+			clientProtection, err := clientSuite.NewRecordProtection(clientSecret)
+			require.NoError(t, err)
+			serverProtection, err := serverSuite.NewRecordProtection(clientSecret)
+			require.NoError(t, err)
 
 			sequenceNumber := uint64(0x0102030405061234)
 			header := recordlayer.UnifiedHeader{
@@ -654,15 +696,16 @@ func TestTLS13CipherSuiteSeal(t *testing.T) {
 			}
 			plaintext := []byte("suite-level seal payload")
 
-			record, err := clientSuite.Seal(header, sequenceNumber, protocol.ContentTypeApplicationData, plaintext)
+			record, err := clientProtection.Seal(header, sequenceNumber, protocol.ContentTypeApplicationData, plaintext)
 			require.NoError(t, err)
 
 			require.True(t, record.Header.SeqBit)
 			require.True(t, record.Header.LengthBit)
 			require.Equal(t, uint16(len(record.EncryptedRecord)), record.Header.Length) //nolint:gosec
 
-			serverProtection := requireRecordProtection13(t, serverSuite)
-			mask, err := serverProtection.remote.sequenceNumberMask(record.EncryptedRecord)
+			serverTrafficProtection, ok := serverProtection.(*recordTrafficProtection13)
+			require.True(t, ok)
+			mask, err := serverTrafficProtection.sequenceNumberMask(record.EncryptedRecord)
 			require.NoError(t, err)
 			expectedHeaderSequenceNumber := uint16(sequenceNumber & 0xffff)
 			expectedMaskedSequenceNumber := expectedHeaderSequenceNumber ^ (uint16(mask[0])<<8 | uint16(mask[1]))
@@ -672,24 +715,12 @@ func TestTLS13CipherSuiteSeal(t *testing.T) {
 			require.NoError(t, applySequenceNumberMask13(&clearHeader, mask))
 			assert.Equal(t, expectedHeaderSequenceNumber, clearHeader.SequenceNumber)
 
-			innerPlaintext, err := serverProtection.open(clearHeader, sequenceNumber, record.EncryptedRecord)
+			innerPlaintext, err := serverTrafficProtection.open(clearHeader, sequenceNumber, record.EncryptedRecord)
 			require.NoError(t, err)
 			assert.Equal(t, plaintext, innerPlaintext.Content)
 			assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
 		})
 	}
-}
-
-func TestTLS13CipherSuiteSealRejectsUninitialized(t *testing.T) {
-	suite := NewTLSAes128GcmSha256()
-
-	_, err := suite.Seal(
-		recordlayer.UnifiedHeader{SequenceNumber: 0x1234, EpochLow: 2},
-		0x0102030405061234,
-		protocol.ContentTypeApplicationData,
-		[]byte("uninitialized"),
-	)
-	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
 }
 
 func TestTLS13CipherSuiteOpen(t *testing.T) {
@@ -699,14 +730,15 @@ func TestTLS13CipherSuiteOpen(t *testing.T) {
 			serverSuite := newRecordProtection13TestSuite(t, testCase.name)
 
 			clientSecret := trafficSecret13(testCase.suite, 0xa8)
-			serverSecret := trafficSecret13(testCase.suite, 0xb8)
-			require.NoError(t, clientSuite.InitFromTrafficSecrets(clientSecret, serverSecret, true))
-			require.NoError(t, serverSuite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
+			clientProtection, err := clientSuite.NewRecordProtection(clientSecret)
+			require.NoError(t, err)
+			serverProtection, err := serverSuite.NewRecordProtection(clientSecret)
+			require.NoError(t, err)
 
 			sequenceNumber := uint64(0x0102030405061234)
 			plaintext := []byte("suite-level open payload")
 
-			record, err := clientSuite.Seal(
+			record, err := clientProtection.Seal(
 				recordlayer.UnifiedHeader{SequenceNumber: 0xbeef, EpochLow: 2},
 				sequenceNumber,
 				protocol.ContentTypeApplicationData,
@@ -714,7 +746,7 @@ func TestTLS13CipherSuiteOpen(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			innerPlaintext, err := serverSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+			innerPlaintext, err := serverProtection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 			require.NoError(t, err)
 			assert.Equal(t, plaintext, innerPlaintext.Content)
 			assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
@@ -722,24 +754,14 @@ func TestTLS13CipherSuiteOpen(t *testing.T) {
 	}
 }
 
-func TestTLS13CipherSuiteOpenRejectsUninitialized(t *testing.T) {
-	suite := NewTLSAes128GcmSha256()
-
-	_, err := suite.Open(
-		recordlayer.UnifiedHeader{SequenceNumber: 0x1234, EpochLow: 2},
-		0x0102030405061234,
-		[]byte("uninitialized"),
-	)
-	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
-}
-
 func TestTLS13CipherSuiteOpenRejectsWrongSequenceNumberLowBits(t *testing.T) {
 	suite := NewTLSAes128GcmSha256()
 	clientSecret := trafficSecret13(suite, 0xc1)
 	serverSecret := trafficSecret13(suite, 0xd1)
-	require.NoError(t, suite.InitFromTrafficSecrets(clientSecret, serverSecret, false))
 
-	protection, err := suite.newRecordProtection(clientSecret, serverSecret)
+	protection, err := newRecordProtection13ForTest(suite, clientSecret, serverSecret)
+	require.NoError(t, err)
+	peerProtection, err := newRecordProtection13ForTest(suite, serverSecret, clientSecret)
 	require.NoError(t, err)
 
 	sequenceNumber := uint64(0x0102030405061234)
@@ -756,7 +778,7 @@ func TestTLS13CipherSuiteOpenRejectsWrongSequenceNumberLowBits(t *testing.T) {
 	maskedHeader := record.Header
 	require.NoError(t, applySequenceNumberMask13(&maskedHeader, mask))
 
-	_, err = suite.Open(maskedHeader, sequenceNumber+1, record.EncryptedRecord)
+	_, err = peerProtection.remote.Open(maskedHeader, sequenceNumber+1, record.EncryptedRecord)
 	assert.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
 }
 
@@ -765,9 +787,9 @@ func TestRecordProtection13SealOpenSyntheticTrafficSecret(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xa6)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xb6)
-			protection, err := testCase.suite.newRecordProtection(localTrafficSecret, remoteTrafficSecret)
+			protection, err := newRecordProtection13ForTest(testCase.suite, localTrafficSecret, remoteTrafficSecret)
 			require.NoError(t, err)
-			peerProtection, err := testCase.suite.newRecordProtection(remoteTrafficSecret, localTrafficSecret)
+			peerProtection, err := newRecordProtection13ForTest(testCase.suite, remoteTrafficSecret, localTrafficSecret)
 			require.NoError(t, err)
 
 			header := recordlayer.UnifiedHeader{
@@ -797,7 +819,7 @@ func TestRecordProtection13SealOpenSyntheticTrafficSecret(t *testing.T) {
 
 func TestRecordProtection13SealRejectsOversizedPlaintext(t *testing.T) {
 	suite := NewTLSAes128GcmSha256()
-	protection, err := suite.newRecordProtection(trafficSecret13(suite, 0xaa), trafficSecret13(suite, 0xab))
+	protection, err := newRecordProtection13ForTest(suite, trafficSecret13(suite, 0xaa), trafficSecret13(suite, 0xab))
 	require.NoError(t, err)
 
 	header := recordlayer.UnifiedHeader{SequenceNumber: 0x1234, EpochLow: 2}
@@ -823,9 +845,9 @@ func TestRecordProtection13OpenRejectsWrongAdditionalData(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xb7)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xc7)
-			protection, err := testCase.suite.newRecordProtection(localTrafficSecret, remoteTrafficSecret)
+			protection, err := newRecordProtection13ForTest(testCase.suite, localTrafficSecret, remoteTrafficSecret)
 			require.NoError(t, err)
-			peerProtection, err := testCase.suite.newRecordProtection(remoteTrafficSecret, localTrafficSecret)
+			peerProtection, err := newRecordProtection13ForTest(testCase.suite, remoteTrafficSecret, localTrafficSecret)
 			require.NoError(t, err)
 
 			record, err := protection.seal(
@@ -848,9 +870,9 @@ func TestRecordProtection13OpenRejectsWrongSequenceNumber(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xbe)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xce)
-			protection, err := testCase.suite.newRecordProtection(localTrafficSecret, remoteTrafficSecret)
+			protection, err := newRecordProtection13ForTest(testCase.suite, localTrafficSecret, remoteTrafficSecret)
 			require.NoError(t, err)
-			peerProtection, err := testCase.suite.newRecordProtection(remoteTrafficSecret, localTrafficSecret)
+			peerProtection, err := newRecordProtection13ForTest(testCase.suite, remoteTrafficSecret, localTrafficSecret)
 			require.NoError(t, err)
 
 			record, err := protection.seal(
@@ -870,7 +892,7 @@ func TestRecordProtection13OpenRejectsWrongSequenceNumber(t *testing.T) {
 func TestRecordProtection13SequenceNumberMaskSyntheticTrafficSecret(t *testing.T) {
 	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
-			protection, err := testCase.suite.newRecordProtection(
+			protection, err := newRecordProtection13ForTest(testCase.suite,
 				trafficSecret13(testCase.suite, 0xc8),
 				trafficSecret13(testCase.suite, 0xc9),
 			)
@@ -909,9 +931,9 @@ func TestRecordProtection13SequenceNumberMaskUnmaskRoundTrip(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			localTrafficSecret := trafficSecret13(testCase.suite, 0xcb)
 			remoteTrafficSecret := trafficSecret13(testCase.suite, 0xdb)
-			protection, err := testCase.suite.newRecordProtection(localTrafficSecret, remoteTrafficSecret)
+			protection, err := newRecordProtection13ForTest(testCase.suite, localTrafficSecret, remoteTrafficSecret)
 			require.NoError(t, err)
-			peerProtection, err := testCase.suite.newRecordProtection(remoteTrafficSecret, localTrafficSecret)
+			peerProtection, err := newRecordProtection13ForTest(testCase.suite, remoteTrafficSecret, localTrafficSecret)
 			require.NoError(t, err)
 
 			sequenceNumber := uint64(0x0102030405062468)
@@ -972,7 +994,7 @@ func TestApplySequenceNumberMask13RejectsInvalidInputs(t *testing.T) {
 func TestRecordProtection13SequenceNumberMaskRejectsShortCiphertext(t *testing.T) {
 	for _, testCase := range recordProtection13TestCases() {
 		t.Run(testCase.name, func(t *testing.T) {
-			protection, err := testCase.suite.newRecordProtection(
+			protection, err := newRecordProtection13ForTest(testCase.suite,
 				trafficSecret13(testCase.suite, 0xd9),
 				trafficSecret13(testCase.suite, 0xda),
 			)
@@ -1014,10 +1036,9 @@ func TestRecordNonce13(t *testing.T) {
 
 func TestNewAESGCMRecordProtection13RejectsInvalidAESKeyLength(t *testing.T) {
 	suite := NewTLSAes256GcmSha384()
-	_, err := newAESGCMRecordProtection13(
+	_, err := newAESGCMRecordTrafficProtection13(
 		suite.HashFunc(),
 		trafficSecret13(suite, 0x5a),
-		trafficSecret13(suite, 0x6a),
 		31,
 	)
 	assert.Error(t, err)

--- a/internal/ciphersuite/tls_aes_gcm.go
+++ b/internal/ciphersuite/tls_aes_gcm.go
@@ -42,15 +42,3 @@ func (c *tlsAESGCMCipherSuite) HashFunc() func() hash.Hash {
 func (c *tlsAESGCMCipherSuite) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
 	return newAESGCMRecordTrafficProtection13(c.HashFunc(), trafficSecret, c.keyLen)
 }
-
-// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
-// negotiated client and server handshake/application traffic secrets.
-func (c *tlsAESGCMCipherSuite) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
-	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
-}
-
-func (c *tlsAESGCMCipherSuite) newRecordProtection(
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newAESGCMRecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret, c.keyLen)
-}

--- a/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
+++ b/internal/ciphersuite/tls_chacha20_poly1305_sha256.go
@@ -37,15 +37,3 @@ func (c *TLSChacha20Poly1305Sha256) HashFunc() func() hash.Hash {
 func (c *TLSChacha20Poly1305Sha256) NewRecordProtection(trafficSecret []byte) (RecordProtection13, error) {
 	return newChaCha20Poly1305RecordTrafficProtection13(c.HashFunc(), trafficSecret)
 }
-
-// InitFromTrafficSecrets initializes DTLS 1.3 record protection from the
-// negotiated client and server handshake/application traffic secrets.
-func (c *TLSChacha20Poly1305Sha256) InitFromTrafficSecrets(clientSecret, serverSecret []byte, isClient bool) error {
-	return c.initFromTrafficSecrets13(clientSecret, serverSecret, isClient, c.newRecordProtection)
-}
-
-func (c *TLSChacha20Poly1305Sha256) newRecordProtection(
-	localTrafficSecret, remoteTrafficSecret []byte,
-) (*recordProtection13, error) {
-	return newChaCha20Poly1305RecordProtection13(c.HashFunc(), localTrafficSecret, remoteTrafficSecret)
-}

--- a/internal/handshake/record_protection.go
+++ b/internal/handshake/record_protection.go
@@ -101,7 +101,7 @@ func initRecordProtectionFromTrafficSecrets(
 		},
 	)
 
-	return tls13CipherSuite.InitFromTrafficSecrets(secrets.Client, secrets.Server, state.IsClient)
+	return nil
 }
 
 func cipherSuite13(state *dtlsstate.State13) (ciphersuite.CipherSuiteTLS13, error) {

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -679,7 +679,6 @@ func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
 	state.KeySchedule.ServerApplicationTrafficSecret0 = applicationSecrets.Server
 
 	require.NoError(t, InitHandshakeRecordProtection(state))
-	require.True(t, state.CipherSuite.IsInitialized())
 	require.NoError(t, InitApplicationRecordProtection(state))
 
 	applicationWrite, ok := state.TrafficKeys.Write(dtlsflight13.EpochApplication)
@@ -695,23 +694,15 @@ func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
 	assert.Equal(t, handshakeSecrets.Client, handshakeWrite.Secret)
 	assert.Equal(t, handshakeSecrets.Server, handshakeRead.Secret)
 
-	clientSuite, ok := state.CipherSuite.(ciphersuite.CipherSuiteTLS13)
-	require.True(t, ok)
 	serverApplicationSuite := ciphersuite.NewTLSAes128GcmSha256()
-	require.NoError(t, serverApplicationSuite.InitFromTrafficSecrets(
-		applicationSecrets.Client,
-		applicationSecrets.Server,
-		false,
-	))
+	serverApplicationProtection, err := serverApplicationSuite.NewRecordProtection(applicationSecrets.Client)
+	require.NoError(t, err)
 	serverHandshakeSuite := ciphersuite.NewTLSAes128GcmSha256()
-	require.NoError(t, serverHandshakeSuite.InitFromTrafficSecrets(
-		handshakeSecrets.Client,
-		handshakeSecrets.Server,
-		false,
-	))
+	serverHandshakeProtection, err := serverHandshakeSuite.NewRecordProtection(handshakeSecrets.Client)
+	require.NoError(t, err)
 
 	sequenceNumber := uint64(0x0102030405061234)
-	record, err := clientSuite.Seal(
+	record, err := applicationWrite.Protection.Seal(
 		recordlayer.UnifiedHeader{SequenceNumber: uint16(sequenceNumber), EpochLow: 2}, //nolint:gosec // G115
 		sequenceNumber,
 		protocol.ContentTypeApplicationData,
@@ -719,12 +710,12 @@ func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	innerPlaintext, err := serverApplicationSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+	innerPlaintext, err := serverApplicationProtection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("application traffic after finished"), innerPlaintext.Content)
 	assert.Equal(t, protocol.ContentTypeApplicationData, innerPlaintext.RealType)
 
-	_, err = serverHandshakeSuite.Open(record.Header, sequenceNumber, record.EncryptedRecord)
+	_, err = serverHandshakeProtection.Open(record.Header, sequenceNumber, record.EncryptedRecord)
 	assert.Error(t, err)
 }
 
@@ -792,7 +783,6 @@ func TestInitApplicationRecordProtection13RejectsInvalidState(t *testing.T) {
 					Server: bytes.Repeat([]byte{0x22}, sha256.Size),
 				}
 				require.NoError(t, InitHandshakeRecordProtection(state))
-				require.True(t, state.CipherSuite.IsInitialized())
 
 				return state
 			}(),


### PR DESCRIPTION
#### Description
This is a cleanup to close #983 removes the record-protection cipher suites singleton, since we now use the epoch aware keyring added in #984 #985 #987 #988