### PR TITLE
Remove duplicated errors and aliases

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -9,30 +9,12 @@ import (
 	stderrors "errors"
 )
 
-var ( //nolint:gochecknoglobals,lll
-	errBufferTooSmall              = stderrors.New("buffer is too small")
-	errLengthMismatch              = stderrors.New("data length and declared length do not match")
-	errInvalidContentType          = stderrors.New("invalid content type")
-	errUnsupportedProtocolVersion  = stderrors.New("unsupported protocol version")
-	errSequenceNumberOverflow      = stderrors.New("sequence number overflow")
-	errInvalidPrivateKey           = stderrors.New("invalid private key type")
-	errInvalidSignatureAlgorithm   = stderrors.New("invalid signature algorithm")
-	errNoAvailableSignatureSchemes = stderrors.New("connection can not be created, no SignatureScheme satisfy this Config") //nolint:lll
-	errInvalidNamedCurve           = stderrors.New("invalid named curve")
-	errNoAvailableCipherSuites     = stderrors.New(
-		"connection can not be created, no CipherSuites satisfy this Config",
-	)
-	errNoAvailablePSKCipherSuite      = stderrors.New("connection can not be created, pre-shared key present but no compatible CipherSuite") //nolint:lll
-	errNoAvailableCertificateSuite    = stderrors.New("connection can not be created, certificate present but no compatible CipherSuite")    //nolint:lll
-	errInvalidCertificate             = stderrors.New("no certificate provided")
-	errInvalidCertificateOID          = stderrors.New("certificate OID does not match signature algorithm")
-	errInvalidCertificateSignatureAlg = stderrors.New("certificate uses a signature algorithm that is not allowed")
-
+var (
 	ErrConnClosed = stderrors.New("conn is closed")
 
 	ErrDeadlineExceeded   = context.DeadlineExceeded
-	ErrInvalidContentType = errInvalidContentType
-	ErrBufferTooSmall     = errBufferTooSmall
+	ErrInvalidContentType = stderrors.New("invalid content type")
+	ErrBufferTooSmall     = stderrors.New("buffer is too small")
 	ErrInvalidPacket      = stderrors.New("invalid packet")
 
 	ErrContextUnsupported           = stderrors.New("context is not supported for ExportKeyingMaterial")
@@ -53,31 +35,41 @@ var ( //nolint:gochecknoglobals,lll
 	)
 	ErrCookieMismatch                       = stderrors.New("client+server cookie does not match")
 	ErrIdentityNoPSK                        = stderrors.New("PSK Identity Hint provided but PSK is nil")
-	ErrInvalidCertificate                   = errInvalidCertificate
+	ErrInvalidCertificate                   = stderrors.New("no certificate provided")
 	ErrCertificateVerificationFailed        = stderrors.New("certificate verification failed")
 	ErrInvalidCipherSuite                   = stderrors.New("invalid or unknown cipher suite")
 	ErrInvalidClientAuthType                = stderrors.New("invalid client auth type")
 	ErrInvalidClientHello                   = stderrors.New("invalid ClientHello")
 	ErrMissingClientHelloExtension          = stderrors.New("DTLS 1.3 ClientHello missing mandatory extension")
-	ErrInvalidHelloRetryRequest             = stderrors.New("invalid HelloRetryRequest")                         //nolint:lll
-	ErrInvalidECDSASignature                = stderrors.New("ECDSA signature contained zero or negative values") //nolint:lll
-	ErrInvalidPrivateKey                    = errInvalidPrivateKey                                               //nolint:lll
-	ErrInvalidSignatureAlgorithm            = errInvalidSignatureAlgorithm
+	ErrInvalidHelloRetryRequest             = stderrors.New("invalid HelloRetryRequest")
+	ErrInvalidECDSASignature                = stderrors.New("ECDSA signature contained zero or negative values")
+	ErrInvalidPrivateKey                    = stderrors.New("invalid private key type")
+	ErrInvalidSignatureAlgorithm            = stderrors.New("invalid signature algorithm")
 	ErrInvalidExtendedMasterSecretType      = stderrors.New("invalid extended master secret type")
-	ErrInvalidCertificateSignatureAlgorithm = errInvalidCertificateSignatureAlg
-	ErrKeySignatureMismatch                 = stderrors.New("expected and actual key signature do not match")
-	ErrInvalidCertificateOID                = errInvalidCertificateOID
-	ErrNilNextConn                          = stderrors.New("Conn can not be created with a nil nextConn") //nolint:lll,staticcheck
-	ErrNoAvailableCipherSuites              = errNoAvailableCipherSuites
-	ErrNoAvailablePSKCipherSuite            = errNoAvailablePSKCipherSuite
-	ErrNoAvailableCertificateCipherSuite    = errNoAvailableCertificateSuite
-	ErrNoAvailableSignatureSchemes          = errNoAvailableSignatureSchemes
-	ErrNoCertificates                       = stderrors.New("no certificates configured")
-	ErrNoConfigProvided                     = stderrors.New("no config provided")
-	ErrNoSupportedEllipticCurves            = stderrors.New(
+	ErrInvalidCertificateSignatureAlgorithm = stderrors.New(
+		"certificate uses a signature algorithm that is not allowed",
+	)
+	ErrKeySignatureMismatch    = stderrors.New("expected and actual key signature do not match")
+	ErrInvalidCertificateOID   = stderrors.New("certificate OID does not match signature algorithm")
+	ErrNilNextConn             = stderrors.New("conn can not be created with a nil nextConn")
+	ErrNoAvailableCipherSuites = stderrors.New(
+		"connection can not be created, no CipherSuites satisfy this Config",
+	)
+	ErrNoAvailablePSKCipherSuite = stderrors.New(
+		"connection can not be created, pre-shared key present but no compatible CipherSuite",
+	)
+	ErrNoAvailableCertificateCipherSuite = stderrors.New(
+		"connection can not be created, certificate present but no compatible CipherSuite",
+	)
+	ErrNoAvailableSignatureSchemes = stderrors.New(
+		"connection can not be created, no SignatureScheme satisfy this Config",
+	)
+	ErrNoCertificates            = stderrors.New("no certificates configured")
+	ErrNoConfigProvided          = stderrors.New("no config provided")
+	ErrNoSupportedEllipticCurves = stderrors.New(
 		"client requested zero or more elliptic curves that are not supported by the server",
 	)
-	ErrUnsupportedProtocolVersion        = errUnsupportedProtocolVersion
+	ErrUnsupportedProtocolVersion        = stderrors.New("unsupported protocol version")
 	ErrNoCommonProtocolVersion           = stderrors.New("no common DTLS version between peer and local")
 	ErrInvalidProtocolVersionState       = stderrors.New("invalid protocol version in state")
 	ErrInvalidServerHello                = stderrors.New("invalid ServerHello")
@@ -100,49 +92,91 @@ var ( //nolint:gochecknoglobals,lll
 	ErrInvalidFlight                         = stderrors.New("invalid flight number")
 	ErrFlightUnimplemented13                 = stderrors.New("unimplemented DTLS 1.3 flight")
 	ErrStateUnimplemented13                  = stderrors.New("unimplemented DTLS 1.3 handshake state")
-	ErrHandshakeTranscriptMissingClientHello = stderrors.New("DTLS 1.3 client transcript missing initial ClientHello")
-	ErrKeySignatureGenerateUnimplemented     = stderrors.New("unable to generate key signature, unimplemented")
-	ErrKeySignatureVerifyUnimplemented       = stderrors.New("unable to verify key signature, unimplemented")
-	ErrLengthMismatch                        = errLengthMismatch
-	ErrSequenceNumberOverflow                = errSequenceNumberOverflow
-	ErrInvalidFSMTransition                  = stderrors.New("invalid state machine transition")
-	ErrFailedToAccessPoolReadBuffer          = stderrors.New("failed to access pool read buffer")
-	ErrFragmentBufferOverflow                = stderrors.New("fragment buffer overflow")
-	ErrCipherSuiteNotSet                     = stderrors.New("cipher suite not set")
-	ErrHandshakeSequenceOverflow             = stderrors.New("handshake message sequence overflow")
-	ErrUnexpectedPostHandshakeMessage        = stderrors.New("unexpected DTLS 1.3 post-handshake message")
+	ErrHandshakeTranscriptMissingClientHello = stderrors.New(
+		"DTLS 1.3 client transcript missing initial ClientHello",
+	)
+	ErrKeySignatureGenerateUnimplemented = stderrors.New("unable to generate key signature, unimplemented")
+	ErrKeySignatureVerifyUnimplemented   = stderrors.New("unable to verify key signature, unimplemented")
+	ErrLengthMismatch                    = stderrors.New("data length and declared length do not match")
+	ErrSequenceNumberOverflow            = stderrors.New("sequence number overflow")
+	ErrInvalidFSMTransition              = stderrors.New("invalid state machine transition")
+	ErrFailedToAccessPoolReadBuffer      = stderrors.New("failed to access pool read buffer")
+	ErrFragmentBufferOverflow            = stderrors.New("fragment buffer overflow")
+	ErrCipherSuiteNotSet                 = stderrors.New("cipher suite not set")
+	ErrHandshakeSequenceOverflow         = stderrors.New("handshake message sequence overflow")
+	ErrUnexpectedPostHandshakeMessage    = stderrors.New("unexpected DTLS 1.3 post-handshake message")
 
-	ErrEmptyCertificates                = stderrors.New("certificates option requires at least one certificate")   //nolint:lll
-	ErrEmptyCipherSuites                = stderrors.New("cipher suites option requires at least one cipher suite") //nolint:lll
-	ErrNilCustomCipherSuites            = stderrors.New("custom cipher suites option requires a non-nil function") //nolint:lll
-	ErrEmptySignatureSchemes            = stderrors.New("signature schemes option requires at least one scheme")   //nolint:lll
+	ErrEmptyCertificates = stderrors.New(
+		"certificates option requires at least one certificate",
+	)
+	ErrEmptyCipherSuites = stderrors.New(
+		"cipher suites option requires at least one cipher suite",
+	)
+	ErrNilCustomCipherSuites = stderrors.New(
+		"custom cipher suites option requires a non-nil function",
+	)
+	ErrEmptySignatureSchemes = stderrors.New(
+		"signature schemes option requires at least one scheme",
+	)
 	ErrEmptyCertificateSignatureSchemes = stderrors.New(
 		"certificate signature schemes option requires at least one scheme",
 	)
-	ErrEmptySRTPProtectionProfiles      = stderrors.New("SRTP protection profiles option requires at least one profile")
-	ErrInvalidFlightInterval            = stderrors.New("flight interval must be positive")
-	ErrNilPSKCallback                   = stderrors.New("PSK option requires a non-nil callback")
-	ErrNilVerifyPeerCertificate         = stderrors.New("verify peer certificate option requires a non-nil callback")
-	ErrNilVerifyConnection              = stderrors.New("verify connection option requires a non-nil callback")      //nolint:lll
-	ErrInvalidMTU                       = stderrors.New("MTU must be positive")                                      //nolint:lll
-	ErrInvalidReplayProtectionWindow    = stderrors.New("replay protection window must be non-negative")             //nolint:lll
-	ErrEmptySupportedProtocols          = stderrors.New("supported protocols option requires at least one protocol") //nolint:lll
-	ErrEmptyEllipticCurves              = stderrors.New("elliptic curves option requires at least one curve")        //nolint:lll
-	ErrUnsupportedEllipticCurveVersion  = stderrors.New("elliptic curve is not supported for the configured DTLS version")
-	ErrNilGetClientCertificate          = stderrors.New("get client certificate option requires a non-nil callback")
-	ErrNilConnectionIDGenerator         = stderrors.New("connection ID generator option requires a non-nil function")
-	ErrNilPaddingLengthGenerator        = stderrors.New("padding length generator option requires a non-nil function")
-	ErrNilHelloRandomBytesGenerator     = stderrors.New("hello random bytes generator option requires a non-nil function")
-	ErrNilClientHelloMessageHook        = stderrors.New("client hello message hook option requires a non-nil function")
-	ErrNilGetCertificate                = stderrors.New("get certificate option requires a non-nil callback")
-	ErrNilServerHelloMessageHook        = stderrors.New("server hello message hook option requires a non-nil function")
+	ErrEmptySRTPProtectionProfiles = stderrors.New(
+		"SRTP protection profiles option requires at least one profile",
+	)
+	ErrInvalidFlightInterval    = stderrors.New("flight interval must be positive")
+	ErrNilPSKCallback           = stderrors.New("PSK option requires a non-nil callback")
+	ErrNilVerifyPeerCertificate = stderrors.New(
+		"verify peer certificate option requires a non-nil callback",
+	)
+	ErrNilVerifyConnection = stderrors.New(
+		"verify connection option requires a non-nil callback",
+	)
+	ErrInvalidMTU                    = stderrors.New("MTU must be positive")
+	ErrInvalidReplayProtectionWindow = stderrors.New(
+		"replay protection window must be non-negative",
+	)
+	ErrEmptySupportedProtocols = stderrors.New(
+		"supported protocols option requires at least one protocol",
+	)
+	ErrEmptyEllipticCurves = stderrors.New(
+		"elliptic curves option requires at least one curve",
+	)
+	ErrUnsupportedEllipticCurveVersion = stderrors.New(
+		"elliptic curve is not supported for the configured DTLS version",
+	)
+	ErrNilGetClientCertificate = stderrors.New(
+		"get client certificate option requires a non-nil callback",
+	)
+	ErrNilConnectionIDGenerator = stderrors.New(
+		"connection ID generator option requires a non-nil function",
+	)
+	ErrNilPaddingLengthGenerator = stderrors.New(
+		"padding length generator option requires a non-nil function",
+	)
+	ErrNilHelloRandomBytesGenerator = stderrors.New(
+		"hello random bytes generator option requires a non-nil function",
+	)
+	ErrNilClientHelloMessageHook = stderrors.New(
+		"client hello message hook option requires a non-nil function",
+	)
+	ErrNilGetCertificate = stderrors.New(
+		"get certificate option requires a non-nil callback",
+	)
+	ErrNilServerHelloMessageHook = stderrors.New(
+		"server hello message hook option requires a non-nil function",
+	)
 	ErrNilCertificateRequestMessageHook = stderrors.New(
 		"certificate request message hook option requires a non-nil function",
 	)
-	ErrNilOnConnectionAttempt = stderrors.New("on connection attempt option requires a non-nil callback")
+	ErrNilOnConnectionAttempt = stderrors.New(
+		"on connection attempt option requires a non-nil callback",
+	)
 
-	ErrInvalidHandshakeTranscriptMessage      = stderrors.New("invalid DTLS 1.3 handshake transcript message")
-	ErrHandshakeTranscriptHashNotSelected     = stderrors.New("DTLS 1.3 handshake transcript hash is not selected")
+	ErrInvalidHandshakeTranscriptMessage  = stderrors.New("invalid DTLS 1.3 handshake transcript message")
+	ErrHandshakeTranscriptHashNotSelected = stderrors.New(
+		"DTLS 1.3 handshake transcript hash is not selected",
+	)
 	ErrHandshakeTranscriptHashAlreadySelected = stderrors.New(
 		"DTLS 1.3 handshake transcript hash is already selected",
 	)
@@ -159,49 +193,65 @@ var ( //nolint:gochecknoglobals,lll
 	ErrInvalidCipherSpec = stderrors.New("cipher spec invalid")
 	ErrInvalidACK        = stderrors.New("ack invalid")
 
-	ErrALPNInvalidFormat              = stderrors.New("invalid alpn format")
-	ErrALPNNoAppProto                 = stderrors.New("no application protocol")
-	ErrInvalidExtensionType           = stderrors.New("invalid extension type")
-	ErrInvalidSNIFormat               = stderrors.New("invalid server name format")
-	ErrInvalidCIDFormat               = stderrors.New("invalid connection ID format")
-	ErrMasterKeyIdentifierTooLarge    = stderrors.New("master key identifier is over 255 bytes")
-	ErrUseSRTPDataTooLarge            = stderrors.New("use_srtp extension data exceeds uint16 length")
-	ErrPointFormatsTooLarge           = stderrors.New("point formats must not be longer than 255 ")
-	ErrPreSharedKeyFormat             = stderrors.New("invalid Pre-Shared Key extension format")                     //nolint:lll
-	ErrPskKeyExchangeModesFormat      = stderrors.New("invalid Pre-Shared Key Exchange Modes extension format")      //nolint:lll
-	ErrNoPskKeyExchangeMode           = stderrors.New("no mode set for the Pre-Shared Key Exchange Modes extension") //nolint:lll
-	ErrCookieExtFormat                = stderrors.New("invalid cookie format")                                       //nolint:lll
-	ErrInvalidKeyShareFormat          = stderrors.New("invalid key_share format")                                    //nolint:lll
-	ErrDuplicateKeyShare              = stderrors.New("duplicate key_share group")                                   //nolint:lll
+	ErrALPNInvalidFormat           = stderrors.New("invalid alpn format")
+	ErrALPNNoAppProto              = stderrors.New("no application protocol")
+	ErrInvalidExtensionType        = stderrors.New("invalid extension type")
+	ErrInvalidSNIFormat            = stderrors.New("invalid server name format")
+	ErrInvalidCIDFormat            = stderrors.New("invalid connection ID format")
+	ErrMasterKeyIdentifierTooLarge = stderrors.New("master key identifier is over 255 bytes")
+	ErrUseSRTPDataTooLarge         = stderrors.New("use_srtp extension data exceeds uint16 length")
+	ErrPointFormatsTooLarge        = stderrors.New("point formats must not be longer than 255 ")
+	ErrPreSharedKeyFormat          = stderrors.New("invalid Pre-Shared Key extension format")
+	ErrPskKeyExchangeModesFormat   = stderrors.New(
+		"invalid Pre-Shared Key Exchange Modes extension format",
+	)
+	ErrNoPskKeyExchangeMode = stderrors.New(
+		"no mode set for the Pre-Shared Key Exchange Modes extension",
+	)
+	ErrCookieExtFormat                = stderrors.New("invalid cookie format")
+	ErrInvalidKeyShareFormat          = stderrors.New("invalid key_share format")
+	ErrDuplicateKeyShare              = stderrors.New("duplicate key_share group")
 	ErrInvalidSupportedVersionsFormat = stderrors.New("invalid supported_versions format")
 	ErrInvalidDTLSVersion             = stderrors.New("invalid dtls version was provided")
 	ErrEarlyDataIndicationFormat      = stderrors.New("invalid Early Data Indication extension format")
-	ErrInvalidCertificateAuthFormat   = stderrors.New("invalid Certificate Authorities extension format")
-	ErrEmptyOIDFilter                 = stderrors.New("no oid set for a OID filter")
-	ErrOIDFiltersFormat               = stderrors.New("invalid OID filters extension format")
-	ErrDuplicateOID                   = stderrors.New("duplicate OID filters")
+	ErrInvalidCertificateAuthFormat   = stderrors.New(
+		"invalid Certificate Authorities extension format",
+	)
+	ErrEmptyOIDFilter   = stderrors.New("no oid set for a OID filter")
+	ErrOIDFiltersFormat = stderrors.New("invalid OID filters extension format")
+	ErrDuplicateOID     = stderrors.New("duplicate OID filters")
 
 	ErrUnableToMarshalFragmented = stderrors.New("unable to marshal fragmented handshakes")
 	ErrHandshakeMessageUnset     = stderrors.New("handshake message unset, unable to marshal")
 	ErrInvalidClientKeyExchange  = stderrors.New(
 		"unable to determine if ClientKeyExchange is a public key or PSK Identity",
 	)
-	ErrInvalidSignHashAlgorithm            = stderrors.New("invalid signature/hash algorithm")                      //nolint:lll
-	ErrCookieTooLong                       = stderrors.New("cookie must not be longer than 255 bytes")              //nolint:lll
-	ErrSessionIDTooLong                    = stderrors.New("session ID must not be longer than 255 bytes")          //nolint:lll
-	ErrCertificateTypesTooLong             = stderrors.New("certificate types must not be longer than 255 entries") //nolint:lll
-	ErrCompressionMethodsTooLong           = stderrors.New("compression methods must not be longer than 255 entries")
-	ErrPublicKeyTooLong                    = stderrors.New("public key must not be longer than 255 bytes")                 //nolint:lll
-	ErrInvalidEllipticCurveType            = stderrors.New("invalid or unknown elliptic curve type")                       //nolint:lll
-	ErrInvalidNamedCurveFatal              = errInvalidNamedCurve                                                          //nolint:lll
-	ErrCipherSuiteUnset                    = stderrors.New("server hello can not be created without a cipher suite")       //nolint:lll
-	ErrCompressionMethodUnset              = stderrors.New("server hello can not be created without a compression method") //nolint:lll
-	ErrInvalidCompressionMethod            = stderrors.New("invalid or unknown compression method")
-	ErrNotImplemented                      = stderrors.New("feature has not been implemented yet")
-	ErrInvalidCertificateRequestContext    = stderrors.New("invalid certificate request context")
-	ErrInvalidCertificateEntry             = stderrors.New("invalid certificate entry")
-	ErrCertificateRequestContextTooLong    = stderrors.New("certificate request context must not be longer than 255 bytes")
-	ErrCertificateListTooLong              = stderrors.New("certificate list must not be longer than 2^24-1 bytes") //nolint:lll
+	ErrInvalidSignHashAlgorithm  = stderrors.New("invalid signature/hash algorithm")
+	ErrCookieTooLong             = stderrors.New("cookie must not be longer than 255 bytes")
+	ErrSessionIDTooLong          = stderrors.New("session ID must not be longer than 255 bytes")
+	ErrCertificateTypesTooLong   = stderrors.New("certificate types must not be longer than 255 entries")
+	ErrCompressionMethodsTooLong = stderrors.New(
+		"compression methods must not be longer than 255 entries",
+	)
+	ErrPublicKeyTooLong         = stderrors.New("public key must not be longer than 255 bytes")
+	ErrInvalidEllipticCurveType = stderrors.New("invalid or unknown elliptic curve type")
+	ErrInvalidNamedCurve        = stderrors.New("invalid named curve")
+	ErrCipherSuiteUnset         = stderrors.New(
+		"server hello can not be created without a cipher suite",
+	)
+	ErrCompressionMethodUnset = stderrors.New(
+		"server hello can not be created without a compression method",
+	)
+	ErrInvalidCompressionMethod         = stderrors.New("invalid or unknown compression method")
+	ErrNotImplemented                   = stderrors.New("feature has not been implemented yet")
+	ErrInvalidCertificateRequestContext = stderrors.New("invalid certificate request context")
+	ErrInvalidCertificateEntry          = stderrors.New("invalid certificate entry")
+	ErrCertificateRequestContextTooLong = stderrors.New(
+		"certificate request context must not be longer than 255 bytes",
+	)
+	ErrCertificateListTooLong = stderrors.New(
+		"certificate list must not be longer than 2^24-1 bytes",
+	)
 	ErrInvalidExtensionsLength             = stderrors.New("extensions data must be between 2 and 2^16-1 bytes")
 	ErrMissingSignatureAlgorithmsExtension = stderrors.New(
 		"signature_algorithms extension is required in CertificateRequest",
@@ -234,29 +284,35 @@ var ( //nolint:gochecknoglobals,lll
 	ErrCCMCiphertextTooShort = stderrors.New("ccm: ciphertext too short")
 	ErrCCMCiphertextTooLong  = stderrors.New("ccm: ciphertext too long")
 
-	ErrFingerprintHashUnavailable      = stderrors.New("fingerprint: hash algorithm is not linked into the binary") //nolint:lll
-	ErrFingerprintInvalidLength        = stderrors.New("fingerprint: invalid fingerprint length")                   //nolint:lll
-	ErrFingerprintInvalidHashAlgorithm = stderrors.New(                                                             //nolint:lll
-		"fingerprint: invalid hash algorithm",
+	ErrFingerprintHashUnavailable = stderrors.New(
+		"fingerprint: hash algorithm is not linked into the binary",
+	)
+	ErrFingerprintInvalidLength        = stderrors.New("fingerprint: invalid fingerprint length")
+	ErrFingerprintInvalidHashAlgorithm = stderrors.New("fingerprint: invalid hash algorithm")
+
+	ErrKeyScheduleMissingHashFunction = stderrors.New(
+		"HKDF-Extract expected a non-nil hash function",
+	)
+	ErrKeyScheduleLabelTooSmall = stderrors.New(
+		"HKDF-Expand-Label expected a label with length >= 7",
+	)
+	ErrKeyScheduleLabelTooBig = stderrors.New(
+		"HKDF-Expand-Label expected a label with length <= 255",
+	)
+	ErrKeyScheduleContextTooBig = stderrors.New(
+		"HKDF-Expand-Label expected a context with length <= 255",
+	)
+	ErrKeyScheduleLengthTooBig = stderrors.New(
+		"HKDF-Expand-Label expected a length <= 65535",
 	)
 
-	ErrKeyScheduleMissingHashFunction = stderrors.New("HKDF-Extract expected a non-nil hash function")           //nolint:lll
-	ErrKeyScheduleLabelTooSmall       = stderrors.New("HKDF-Expand-Label expected a label with length >= 7")     //nolint:lll
-	ErrKeyScheduleLabelTooBig         = stderrors.New("HKDF-Expand-Label expected a label with length <= 255")   //nolint:lll
-	ErrKeyScheduleContextTooBig       = stderrors.New("HKDF-Expand-Label expected a context with length <= 255") //nolint:lll
-	ErrKeyScheduleLengthTooBig        = stderrors.New("HKDF-Expand-Label expected a length <= 65535")            //nolint:lll
-
-	ErrInvalidNamedCurve         = errInvalidNamedCurve
 	ErrSelfSignInvalidPrivateKey = stderrors.New("selfsign: invalid private key type")
 
-	ErrSignatureHashNoAvailableSignatureSchemes = errNoAvailableSignatureSchemes
-	ErrSignatureHashInvalidSignatureAlgorithm   = errInvalidSignatureAlgorithm
-	ErrSignatureHashInvalidHashAlgorithm        = stderrors.New("invalid hash algorithm")
-	ErrSignatureHashInvalidPrivateKey           = errInvalidPrivateKey
-	ErrNetBufferTimeout                         = stderrors.New("buffer: i/o timeout")
-	ErrUDPClosedListener                        = stderrors.New("udp: listener closed")
-	ErrUDPListenQueueExceeded                   = stderrors.New("udp: listen queue exceeded")
-	ErrUDPListenPacketNotUDPConn                = stderrors.New(
+	ErrInvalidHashAlgorithm      = stderrors.New("invalid hash algorithm")
+	ErrNetBufferTimeout          = stderrors.New("buffer: i/o timeout")
+	ErrUDPClosedListener         = stderrors.New("udp: listener closed")
+	ErrUDPListenQueueExceeded    = stderrors.New("udp: listen queue exceeded")
+	ErrUDPListenPacketNotUDPConn = stderrors.New(
 		"listen packet not a *net.UDPConn",
 	)
 )

--- a/pkg/crypto/prf/prf.go
+++ b/pkg/crypto/prf/prf.go
@@ -124,7 +124,7 @@ func ecdhPreMasterSecret(publicKey, privateKey []byte, curve elliptic.Curve) ([]
 	case elliptic.P384:
 		ec = ecdh.P384()
 	default:
-		return nil, dtlserrors.ErrInvalidNamedCurveFatal
+		return nil, dtlserrors.ErrInvalidNamedCurve
 	}
 
 	sk, err := ec.NewPrivateKey(privateKey)

--- a/pkg/crypto/prf/prf_test.go
+++ b/pkg/crypto/prf/prf_test.go
@@ -270,13 +270,13 @@ func TestEcdhePSKPreMasterSecret_InvalidCurve(t *testing.T) {
 	invalid := elliptic.Curve(0xFFFF)
 
 	_, err := EcdhePSKPreMasterSecret(psk, pub, priv, invalid)
-	assert.ErrorIs(t, err, dtlserrors.ErrInvalidNamedCurveFatal)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidNamedCurve)
 }
 
 func TestPreMasterSecret_InvalidCurve(t *testing.T) {
 	invalid := elliptic.Curve(0) // not supported
 	_, err := PreMasterSecret(nil, nil, invalid)
-	assert.ErrorIs(t, err, dtlserrors.ErrInvalidNamedCurveFatal)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidNamedCurve)
 }
 
 func TestPreMasterSecret_X25519MLKEM768RejectsBadShareLengths(t *testing.T) {

--- a/pkg/crypto/signaturehash/select_13.go
+++ b/pkg/crypto/signaturehash/select_13.go
@@ -15,7 +15,7 @@ import (
 func selectSignatureScheme13(sigs []Algorithm, privateKey crypto.PrivateKey, is13 bool) (Algorithm, error) {
 	signer, ok := privateKey.(crypto.Signer)
 	if !ok {
-		return Algorithm{}, dtlserrors.ErrSignatureHashInvalidPrivateKey
+		return Algorithm{}, dtlserrors.ErrInvalidPrivateKey
 	}
 	for _, ss := range sigs {
 		// Skip PSS schemes for DTLS 1.2 (PSS is only supported in DTLS 1.3)
@@ -36,5 +36,5 @@ func selectSignatureScheme13(sigs []Algorithm, privateKey crypto.PrivateKey, is1
 		}
 	}
 
-	return Algorithm{}, dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes
+	return Algorithm{}, dtlserrors.ErrNoAvailableSignatureSchemes
 }

--- a/pkg/crypto/signaturehash/signaturehash.go
+++ b/pkg/crypto/signaturehash/signaturehash.go
@@ -116,7 +116,7 @@ func ParseSignatureSchemes(sigs []tls.SignatureScheme, insecureHashes bool) ([]A
 	}
 
 	if len(out) == 0 {
-		return nil, dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes
+		return nil, dtlserrors.ErrNoAvailableSignatureSchemes
 	}
 
 	return out, nil
@@ -156,7 +156,7 @@ func FromCertificate(cert *x509.Certificate) (Algorithm, error) { //nolint:cyclo
 		hashAlg = hash.SHA1
 		sigAlg = signature.ECDSA
 	default:
-		return Algorithm{}, dtlserrors.ErrSignatureHashInvalidSignatureAlgorithm
+		return Algorithm{}, dtlserrors.ErrInvalidSignatureAlgorithm
 	}
 
 	return Algorithm{Hash: hashAlg, Signature: sigAlg}, nil
@@ -171,7 +171,7 @@ func (a *Algorithm) Unmarshal(sigScheme tls.SignatureScheme) error {
 		a.Signature = signature.Algorithm(sigScheme)
 		a.Hash = hash.ExtractHashFromPSS(uint16(sigScheme))
 		if a.Hash == hash.None {
-			return dtlserrors.ErrSignatureHashInvalidHashAlgorithm
+			return dtlserrors.ErrInvalidHashAlgorithm
 		}
 	} else {
 		// TLS 1.2 style - split into hash (high byte) and signature (low byte)
@@ -181,12 +181,12 @@ func (a *Algorithm) Unmarshal(sigScheme tls.SignatureScheme) error {
 
 	// Validate signature algorithm
 	if _, ok := signature.Algorithms()[a.Signature]; !ok {
-		return dtlserrors.ErrSignatureHashInvalidSignatureAlgorithm
+		return dtlserrors.ErrInvalidSignatureAlgorithm
 	}
 
 	// Validate hash algorithm
 	if _, ok := hash.Algorithms()[a.Hash]; !ok || (ok && a.Hash == hash.None) {
-		return dtlserrors.ErrSignatureHashInvalidHashAlgorithm
+		return dtlserrors.ErrInvalidHashAlgorithm
 	}
 
 	return nil

--- a/pkg/crypto/signaturehash/signaturehash_test.go
+++ b/pkg/crypto/signaturehash/signaturehash_test.go
@@ -56,7 +56,7 @@ func TestParseSignatureSchemes(t *testing.T) {
 			},
 			expected:       nil,
 			insecureHashes: false,
-			err:            dtlserrors.ErrSignatureHashInvalidSignatureAlgorithm,
+			err:            dtlserrors.ErrInvalidSignatureAlgorithm,
 		},
 		"InvalidHashAlgorithm": {
 			input: []tls.SignatureScheme{
@@ -65,7 +65,7 @@ func TestParseSignatureSchemes(t *testing.T) {
 			},
 			expected:       nil,
 			insecureHashes: false,
-			err:            dtlserrors.ErrSignatureHashInvalidHashAlgorithm,
+			err:            dtlserrors.ErrInvalidHashAlgorithm,
 		},
 		"InsecureHashAlgorithmDenied": {
 			input: []tls.SignatureScheme{
@@ -95,7 +95,7 @@ func TestParseSignatureSchemes(t *testing.T) {
 				tls.ECDSAWithSHA1, // Insecure
 			},
 			insecureHashes: false,
-			err:            dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes,
+			err:            dtlserrors.ErrNoAvailableSignatureSchemes,
 		},
 		"PSSSchemes": {
 			input: []tls.SignatureScheme{
@@ -175,7 +175,7 @@ func TestParseSignatureSchemes(t *testing.T) {
 			},
 			expected:       nil,
 			insecureHashes: false,
-			err:            dtlserrors.ErrSignatureHashInvalidSignatureAlgorithm,
+			err:            dtlserrors.ErrInvalidSignatureAlgorithm,
 		},
 	}
 
@@ -237,7 +237,7 @@ func TestSelectSignatureScheme13_VersionAware(t *testing.T) {
 			privateKey:     rsaKey,
 			is13:           false,
 			expectedSigAlg: 0,
-			expectedError:  dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes,
+			expectedError:  dtlserrors.ErrNoAvailableSignatureSchemes,
 		},
 		{
 			name: "ECDSA works on both DTLS 1.2 and 1.3",
@@ -271,7 +271,7 @@ func TestSelectSignatureScheme13_VersionAware(t *testing.T) {
 			privateKey:     rsaKey,
 			is13:           true,
 			expectedSigAlg: 0,
-			expectedError:  dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes,
+			expectedError:  dtlserrors.ErrNoAvailableSignatureSchemes,
 		},
 		{
 			name: "DTLS 1.3 with RSA key and only RSA_PSS_PSS schemes fails if no fallback",
@@ -283,7 +283,7 @@ func TestSelectSignatureScheme13_VersionAware(t *testing.T) {
 			privateKey:     rsaKey,
 			is13:           true,
 			expectedSigAlg: 0,
-			expectedError:  dtlserrors.ErrSignatureHashNoAvailableSignatureSchemes,
+			expectedError:  dtlserrors.ErrNoAvailableSignatureSchemes,
 		},
 	}
 
@@ -405,7 +405,7 @@ func TestFromCertificate(t *testing.T) {
 			result, err := FromCertificate(&x509.Certificate{SignatureAlgorithm: tt.sigAlg})
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.ErrorIs(t, err, dtlserrors.ErrSignatureHashInvalidSignatureAlgorithm)
+				assert.ErrorIs(t, err, dtlserrors.ErrInvalidSignatureAlgorithm)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)

--- a/pkg/protocol/handshake/message_server_key_exchange.go
+++ b/pkg/protocol/handshake/message_server_key_exchange.go
@@ -113,7 +113,7 @@ func (m *MessageServerKeyExchange) Unmarshal(data []byte) error { //nolint:cyclo
 	}
 	m.NamedCurve = elliptic.Curve(binary.BigEndian.Uint16(data[1:3]))
 	if _, ok := elliptic.Curves()[m.NamedCurve]; !ok {
-		return dtlserrors.ErrInvalidNamedCurveFatal
+		return dtlserrors.ErrInvalidNamedCurve
 	}
 	if len(data) < 4 {
 		return dtlserrors.ErrBufferTooSmall

--- a/pkg/protocol/handshake/message_server_key_exchange_test.go
+++ b/pkg/protocol/handshake/message_server_key_exchange_test.go
@@ -131,7 +131,7 @@ func TestHandshakeMessageServerKeyExchangeUnmarshalErrors(t *testing.T) {
 			name:                 "InvalidNamedCurve",
 			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
 			data:                 []byte{0x03, 0xFF, 0xFF},
-			expectedErr:          dtlserrors.ErrInvalidNamedCurveFatal,
+			expectedErr:          dtlserrors.ErrInvalidNamedCurve,
 		},
 		{
 			// Valid curve type and named curve but missing the public key length.


### PR DESCRIPTION
#### Description
Many of our errors are aliases to private errors, some are public aliases to other public errors (I renamed them to more common name and de-duplicated names), removed all the no-lints, the diff is positive because of the removal of the LLL nolint.