### PR TITLE
Generalize post-handshake command handler

### DIFF
--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -135,10 +135,15 @@ func newFSM13WithEstablishment(
 	return fsm, nil
 }
 
-func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
+func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) (err error) {
 	defer s.received.release()
+	defer func() {
+		if err != nil {
+			s.postHandshake.fail(err)
+		}
+	}()
 
-	return runHandshakeFSM(
+	err = runHandshakeFSM(
 		ctx,
 		conn,
 		initialState,
@@ -157,6 +162,8 @@ func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) error {
 		s.wait,
 		s.finish,
 	)
+
+	return err
 }
 
 func (s *fsm13) Done() <-chan struct{} {

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -125,6 +125,7 @@ type postHandshakeCommand struct {
 	Kind postHandshakeCommandKind
 
 	KeyUpdate keyUpdateCommand13
+	Canceled  <-chan struct{}
 
 	// Always buffered with capacity one.
 	Result chan error
@@ -179,13 +180,42 @@ func (p *postHandshake) initialize() {
 }
 
 func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn) error {
-	if len(p.flights) != 0 || len(p.queue) == 0 {
-		return nil
+	for len(p.flights) == 0 && len(p.queue) != 0 {
+		command := p.queue[0]
+		p.queue = p.queue[1:]
+		if err, canceled := canceledPostHandshakeCommand(command); canceled {
+			completePostHandshakeResult(command.Result, err)
+
+			continue
+		}
+
+		if err := p.startPostHandshakeCommand(ctx, conn, command); err != nil {
+			completePostHandshakeResult(command.Result, err)
+
+			return err
+		}
 	}
 
-	command := p.queue[0]
-	p.queue = p.queue[1:]
+	return nil
+}
 
+func canceledPostHandshakeCommand(command postHandshakeCommand) (error, bool) {
+	if command.Canceled == nil {
+		return nil, false
+	}
+	select {
+	case <-command.Canceled:
+		return context.Canceled, true
+	default:
+		return nil, false
+	}
+}
+
+func (p *postHandshake) startPostHandshakeCommand(
+	ctx context.Context,
+	conn Conn,
+	command postHandshakeCommand,
+) error {
 	switch command.Kind {
 	case commandSendNewSessionTicket:
 		return p.startNewSessionTicket(ctx, conn, false)
@@ -450,9 +480,25 @@ func (p *postHandshake) completePostHandshakeFlight(id postHandshakeFlightID) {
 		delete(p.recordIndex, number)
 	}
 	delete(p.flights, id)
-	if flight.Result != nil {
-		flight.Result <- nil
+	completePostHandshakeResult(flight.Result, nil)
+}
+
+func completePostHandshakeResult(result chan error, err error) {
+	if result != nil {
+		result <- err
 	}
+}
+
+func (p *postHandshake) fail(err error) {
+	for _, command := range p.queue {
+		completePostHandshakeResult(command.Result, err)
+	}
+	p.queue = nil
+	for id, flight := range p.flights {
+		completePostHandshakeResult(flight.Result, err)
+		delete(p.flights, id)
+	}
+	p.recordIndex = make(map[protocol.RecordNumber]postHandshakeRecord)
 }
 
 func (p *postHandshake) retransmitPostHandshake(
@@ -465,7 +511,7 @@ func (p *postHandshake) retransmitPostHandshake(
 		if flight.NextRetransmit.After(now) {
 			continue
 		}
-		if err := p.retransmitNewSessionTicket(ctx, conn, flight, now, disableRetransmitBackoff); err != nil {
+		if err := p.retransmitPostHandshakeFlight(ctx, conn, flight, now, disableRetransmitBackoff); err != nil {
 			return err
 		}
 	}
@@ -473,7 +519,7 @@ func (p *postHandshake) retransmitPostHandshake(
 	return nil
 }
 
-func (p *postHandshake) retransmitNewSessionTicket(
+func (p *postHandshake) retransmitPostHandshakeFlight(
 	ctx context.Context,
 	conn Conn,
 	flight *reliablePostHandshakeFlight,

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -119,6 +119,29 @@ func TestPostHandshakeACKCompletesReliableFlight(t *testing.T) {
 	assert.True(t, firstStillIndexed)
 }
 
+func TestPostHandshakeSkipsCanceledCommand(t *testing.T) {
+	state := dtlsstate.NewState13(false)
+	post := newPostHandshake(handshakeContext{
+		state: &state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := make(chan error, 1)
+	post.queue = append(post.queue, postHandshakeCommand{
+		Kind:     commandSendNewSessionTicket,
+		Canceled: ctx.Done(),
+		Result:   result,
+	})
+	conn := &postHandshakeWriteConn{result: &WriteResult{}}
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	assert.ErrorIs(t, <-result, context.Canceled)
+	assert.Empty(t, conn.writtenPackets)
+	assert.Empty(t, post.queue)
+	assert.Empty(t, post.flights)
+}
+
 func TestPostHandshakeACKReliability(t *testing.T) {
 	state := dtlsstate.NewState13(false)
 	post := newPostHandshake(handshakeContext{
@@ -154,7 +177,7 @@ func TestPostHandshakeACKReliability(t *testing.T) {
 		Fragments: []SentHandshakeFragment{secondFragment},
 	}}}}
 	now := time.Now()
-	require.NoError(t, post.retransmitNewSessionTicket(context.Background(), conn, flight, now, true))
+	require.NoError(t, post.retransmitPostHandshakeFlight(context.Background(), conn, flight, now, true))
 	require.Len(t, conn.writtenPackets, 1)
 	assert.Equal(t, map[uint32]uint32{10: 10}, conn.writtenPackets[0].HandshakeFragmentOffsets)
 	assert.Equal(t, now.Add(time.Second), flight.NextRetransmit)


### PR DESCRIPTION
#### Description
Refactor post-handshake commands handler so it's not designed around NewSessionTicket, adds fail handling so commands like KeyUpdate can do a cleanup if FSM fails.
part of #824 this allows us to finally add KeyUpdate handling in a clean way.