### PR TITLE
Implement inbound key update

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -157,6 +157,18 @@ func (c handshakeConn) CommitLocalKeyUpdate(generation *dtlsstate.TrafficGenerat
 	return c.conn.commitLocalKeyUpdate(generation)
 }
 
+func (c handshakeConn) PauseApplicationData() {
+	c.conn.pauseApplicationData()
+}
+
+func (c handshakeConn) ResumeApplicationData() {
+	c.conn.resumeApplicationData()
+}
+
+func (c handshakeConn) TakePendingACKs() []protocol.RecordNumber {
+	return c.conn.takePendingACKs()
+}
+
 func (c handshakeConn) HandleQueuedPackets(ctx context.Context) error {
 	return c.conn.handleQueuedPackets(ctx)
 }
@@ -195,10 +207,11 @@ type Conn struct {
 	maximumTransmissionUnit int
 	paddingLengthGenerator  func(uint) uint
 
-	handshakeEstablished *dtlshandshake.Establishment
-	handshakeMutex       sync.Mutex
-	handshakeDone        chan struct{}
-	writeLock            sync.Mutex
+	handshakeEstablished  *dtlshandshake.Establishment
+	handshakeMutex        sync.Mutex
+	handshakeDone         chan struct{}
+	writeLock             sync.Mutex
+	applicationDataResume chan struct{} // guarded by writeLock; nil while writes may proceed
 
 	encryptedPackets []addrPkt
 
@@ -583,11 +596,10 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	ctx, cancel := c.contextWithClose(c.writeDeadline)
 	defer cancel()
 
-	err := c.writePackets(ctx, []*dtlsflight.Packet{
+	err := c.writeApplicationData(ctx, []*dtlsflight.Packet{
 		{
 			Record: &recordlayer.RecordLayer{
 				Header: recordlayer.Header{
-					Epoch:   dtlsstate.CommonState(c.state).LocalEpoch(),
 					Version: protocol.Version1_2,
 				},
 				Content: &protocol.ApplicationData{
@@ -603,6 +615,56 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	}
 
 	return len(payload), err
+}
+
+func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Packet) error {
+	for {
+		c.writeLock.Lock()
+		resume := c.applicationDataResume
+		if resume == nil {
+			epoch := dtlsstate.CommonState(c.state).LocalEpoch()
+			for _, pkt := range pkts {
+				pkt.Record.Header.Epoch = epoch
+			}
+			_, err := c.writePacketsWithResultLocked(ctx, pkts)
+			c.writeLock.Unlock()
+
+			return err
+		}
+		c.writeLock.Unlock()
+
+		select {
+		case <-resume:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.closed.Done():
+			return dtlserrors.ErrConnClosed
+		}
+	}
+}
+
+func (c *Conn) pauseApplicationData() {
+	// Serialize pausing with application record preparation.
+	// TODO: Replace this pause gate with unified serialization of application
+	// and post-handshake writes.
+	// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.6.3
+	// https://www.rfc-editor.org/rfc/rfc9147.html#section-4.2.1
+	// https://www.rfc-editor.org/rfc/rfc9147.html#section-8
+	//nolint:godox
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	if c.applicationDataResume == nil {
+		c.applicationDataResume = make(chan struct{})
+	}
+}
+
+func (c *Conn) resumeApplicationData() {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	if c.applicationDataResume != nil {
+		close(c.applicationDataResume)
+		c.applicationDataResume = nil
+	}
 }
 
 // Close closes the connection.
@@ -664,6 +726,13 @@ func (c *Conn) writePacketsWithResult(
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()
 
+	return c.writePacketsWithResultLocked(ctx, pkts)
+}
+
+func (c *Conn) writePacketsWithResultLocked(
+	ctx context.Context,
+	pkts []*dtlsflight.Packet,
+) (*dtlshandshake.WriteResult, error) {
 	datagrams, rAddr, err := c.prepareRawPacketsTracked(pkts)
 	if err != nil {
 		return nil, err

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -139,7 +139,7 @@ func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) (err err
 	defer s.received.release()
 	defer func() {
 		if err != nil {
-			s.postHandshake.fail(err)
+			s.postHandshake.fail(conn, err)
 		}
 	}()
 

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"io"
 	"math"
 	"time"
@@ -147,12 +148,30 @@ type postHandshake struct {
 	// Reverse lookup for received ACK record numbers.
 	recordIndex map[protocol.RecordNumber]postHandshakeRecord
 
+	pendingRequiredKeyUpdateResponses int
+
 	initialRetransmitInterval time.Duration
 	handshakeContext
 }
 
 type keyUpdateCommitConn interface {
 	CommitLocalKeyUpdate(*dtlsstate.TrafficGeneration) error
+}
+
+// TODO: Replace this pause gate with unified serialization of application
+// and post-handshake writes.
+// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.6.3
+// https://www.rfc-editor.org/rfc/rfc9147.html#section-4.2.1
+// https://www.rfc-editor.org/rfc/rfc9147.html#section-8
+//
+//nolint:godox
+type applicationDataPauser interface {
+	PauseApplicationData()
+	ResumeApplicationData()
+}
+
+type pendingACKConn interface {
+	TakePendingACKs() []protocol.RecordNumber
 }
 
 func newPostHandshake(ctx handshakeContext) *postHandshake {
@@ -197,8 +216,10 @@ func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn)
 			continue
 		}
 
-		if err := p.startPostHandshakeCommand(ctx, conn, command); err != nil {
+		err := p.startPostHandshakeCommand(ctx, conn, command)
+		if err != nil {
 			completePostHandshakeResult(command.Result, err)
+			p.failRequiredKeyUpdateResponse(conn, command)
 
 			return err
 		}
@@ -227,13 +248,23 @@ func (p *postHandshake) startPostHandshakeCommand(
 	switch command.Kind {
 	case commandSendNewSessionTicket:
 		return p.startNewSessionTicket(ctx, conn, false)
-	case commandSendKeyUpdate,
-		commandSendNewConnectionID,
+	case commandSendKeyUpdate:
+		return p.startKeyUpdate(ctx, conn, command)
+	case commandSendNewConnectionID,
 		commandSendRequestConnectionID:
-
 		return dtlserrors.ErrNotImplemented
 	default:
 		return dtlserrors.ErrUnexpectedPostHandshakeMessage
+	}
+}
+
+func (p *postHandshake) failRequiredKeyUpdateResponse(conn Conn, command postHandshakeCommand) {
+	if !command.KeyUpdate.RequiredResponse {
+		return
+	}
+	p.pendingRequiredKeyUpdateResponses = 0
+	if pauser, ok := conn.(applicationDataPauser); ok {
+		pauser.ResumeApplicationData()
 	}
 }
 
@@ -327,6 +358,9 @@ func (p *postHandshake) handlePostHandshakeReceive(
 			return err
 		}
 	}
+	if pendingConn, ok := conn.(pendingACKConn); ok {
+		received.RecordsToACK = append(received.RecordsToACK, pendingConn.TakePendingACKs()...)
+	}
 
 	return sendACK(ctx, conn, p.state.LocalEpoch(), received.RecordsToACK)
 }
@@ -343,13 +377,17 @@ func (p *postHandshake) processPostHandshakeMessages(ctx context.Context, conn C
 
 		message := &handshake.Handshake{}
 		if err := message.Unmarshal(item.Data); err != nil {
-			if alertErr := conn.Notify(ctx, alert.Fatal, alert.DecodeError); alertErr != nil {
+			description := alert.DecodeError
+			if errors.Is(err, dtlserrors.ErrInvalidKeyUpdate) {
+				description = alert.IllegalParameter
+			}
+			if alertErr := conn.Notify(ctx, alert.Fatal, description); alertErr != nil {
 				return alertErr
 			}
 
 			return err
 		}
-		if err := p.handlePostHandshakeMessage(ctx, conn, message); err != nil {
+		if err := p.handlePostHandshakeMessage(ctx, conn, message, item.Epoch); err != nil {
 			return err
 		}
 	}
@@ -361,13 +399,75 @@ func (p *postHandshake) handlePostHandshakeMessage(
 	ctx context.Context,
 	conn Conn,
 	message *handshake.Handshake,
+	epoch uint16,
 ) error {
 	switch body := message.Message.(type) {
 	case *handshake.MessageNewSessionTicket:
 		return p.handleNewSessionTicket(ctx, conn, body)
+	case *handshake.MessageKeyUpdate:
+		return p.handleKeyUpdate(ctx, conn, body, epoch)
 	default:
 		return conn.Notify(ctx, alert.Fatal, alert.UnexpectedMessage)
 	}
+}
+
+func (p *postHandshake) handleKeyUpdate(
+	ctx context.Context,
+	conn Conn,
+	message *handshake.MessageKeyUpdate,
+	epoch uint16,
+) error {
+	if p.state.TrafficKeys == nil {
+		return dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+	current, ok := p.state.TrafficKeys.CurrentRead()
+	if !ok || current.Protection == nil {
+		return dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
+	}
+	if current.Epoch != epoch || p.state.RemoteEpoch() != epoch {
+		return conn.Notify(ctx, alert.Fatal, alert.UnexpectedMessage)
+	}
+	next, err := p.nextTrafficGeneration(current)
+	if err != nil {
+		return err
+	}
+
+	if err = p.queueRequiredKeyUpdateResponse(conn, message.RequestUpdate); err != nil {
+		return err
+	}
+
+	p.state.TrafficKeys.Install(nil, next)
+	p.state.SetRemoteEpoch(next.Epoch)
+	p.state.HandshakeRecvSequence++
+
+	return conn.HandleQueuedPackets(ctx)
+}
+
+func (p *postHandshake) queueRequiredKeyUpdateResponse(
+	conn Conn,
+	request handshake.KeyUpdateRequest,
+) error {
+	if request != handshake.KeyUpdateRequested {
+		return nil
+	}
+	pauser, ok := conn.(applicationDataPauser)
+	if !ok {
+		return dtlserrors.ErrNotImplemented
+	}
+	if p.pendingRequiredKeyUpdateResponses == 0 {
+		pauser.PauseApplicationData()
+	}
+	p.pendingRequiredKeyUpdateResponses++
+	command := postHandshakeCommand{
+		Kind: commandSendKeyUpdate,
+		KeyUpdate: keyUpdateCommand{
+			Request:          handshake.KeyUpdateNotRequested,
+			RequiredResponse: true,
+		},
+	}
+	p.queue = append(p.queue, command)
+
+	return nil
 }
 
 func (p *postHandshake) handleNewSessionTicket(
@@ -424,6 +524,22 @@ func (p *postHandshake) startKeyUpdate(
 	p.flights[flight.ID] = flight
 	p.registerTransmission(flight, result.TrackedRecords, true)
 	flight.NextRetransmit = time.Now().Add(flight.RetransmitInterval)
+
+	if command.KeyUpdate.RequiredResponse {
+		pauser, ok := conn.(applicationDataPauser)
+		if !ok {
+			return dtlserrors.ErrNotImplemented
+		}
+		p.pendingRequiredKeyUpdateResponses--
+		// RFC 8446 4.6.3 requires this response before the next Application Data
+		// record,
+		// and RFC 9147 8 defers using the next write keys until it is ACKed.
+		// https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
+		// https://datatracker.ietf.org/doc/html/rfc9147#section-8
+		if p.pendingRequiredKeyUpdateResponses == 0 {
+			pauser.ResumeApplicationData()
+		}
+	}
 
 	return nil
 }
@@ -625,7 +741,7 @@ func completePostHandshakeResult(result chan error, err error) {
 	}
 }
 
-func (p *postHandshake) fail(err error) {
+func (p *postHandshake) fail(conn Conn, err error) {
 	for _, command := range p.queue {
 		completePostHandshakeResult(command.Result, err)
 	}
@@ -635,6 +751,12 @@ func (p *postHandshake) fail(err error) {
 		delete(p.flights, id)
 	}
 	p.recordIndex = make(map[protocol.RecordNumber]postHandshakeRecord)
+	if p.pendingRequiredKeyUpdateResponses != 0 {
+		p.pendingRequiredKeyUpdateResponses = 0
+		if pauser, ok := conn.(applicationDataPauser); ok {
+			pauser.ResumeApplicationData()
+		}
+	}
 }
 
 func (p *postHandshake) retransmitPostHandshake(

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -54,9 +54,12 @@ type postHandshakeWriteConn struct {
 
 type postHandshakeKeyUpdateConn struct {
 	flightTestConn
-	state     *dtlsstate.State13
-	result    *WriteResult
-	committed *dtlsstate.TrafficGeneration
+	state        *dtlsstate.State13
+	result       *WriteResult
+	committed    *dtlsstate.TrafficGeneration
+	blocked      bool
+	blockCount   int
+	unblockCount int
 }
 
 func (c *postHandshakeKeyUpdateConn) WritePackets(
@@ -77,6 +80,16 @@ func (c *postHandshakeKeyUpdateConn) CommitLocalKeyUpdate(generation *dtlsstate.
 	c.state.SetLocalEpoch(generation.Epoch)
 
 	return nil
+}
+
+func (c *postHandshakeKeyUpdateConn) PauseApplicationData() {
+	c.blocked = true
+	c.blockCount++
+}
+
+func (c *postHandshakeKeyUpdateConn) ResumeApplicationData() {
+	c.blocked = false
+	c.unblockCount++
 }
 
 func newPostHandshakeKeyUpdateTestState(t *testing.T, isClient bool) *dtlsstate.State13 {
@@ -368,7 +381,7 @@ func TestHandleUnexpectedPostHandshakeMessageAlert(t *testing.T) {
 
 	err := post.handlePostHandshakeMessage(context.Background(), conn, &handshake.Handshake{
 		Message: &handshake.MessageFinished{},
-	})
+	}, 0)
 	require.NoError(t, err)
 	assert.Equal(t, []postHandshakeAlert{{
 		level:       alert.Fatal,
@@ -507,4 +520,137 @@ func TestBuildKeyUpdateFlightRejectsEpochOverflow(t *testing.T) {
 
 	_, err := post.buildKeyUpdateFlight(handshake.KeyUpdateNotRequested, nil)
 	assert.ErrorIs(t, err, dtlserrors.ErrEpochOverflow)
+}
+
+func TestRequestedKeyUpdateInstallsReadKeysAndQueuesResponse(t *testing.T) {
+	state := newPostHandshakeKeyUpdateTestState(t, false)
+	state.HandshakeRecvSequence = 7
+	state.HandshakeSendSequence = 11
+	post := newPostHandshake(handshakeContext{
+		state: state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	conn := &postHandshakeKeyUpdateConn{state: state}
+
+	require.NoError(t, post.handleKeyUpdate(
+		context.Background(), conn,
+		&handshake.MessageKeyUpdate{RequestUpdate: handshake.KeyUpdateRequested},
+		dtlsflight13.EpochApplication,
+	))
+	assert.Equal(t, 8, state.HandshakeRecvSequence)
+	assert.Equal(t, dtlsflight13.EpochApplication+1, state.RemoteEpoch())
+	currentRead, ok := state.TrafficKeys.CurrentRead()
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), currentRead.Generation)
+	_, oldReadRetained := state.TrafficKeys.Read(dtlsflight13.EpochApplication)
+	assert.True(t, oldReadRetained)
+	assert.True(t, conn.blocked)
+	assert.Equal(t, 1, conn.blockCount)
+	require.Len(t, post.queue, 1)
+	assert.True(t, post.queue[0].KeyUpdate.RequiredResponse)
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	assert.False(t, conn.blocked)
+	assert.Equal(t, 1, conn.unblockCount)
+	require.Len(t, conn.writtenPackets, 1)
+	responseHandshake, ok := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	response, ok := responseHandshake.Message.(*handshake.MessageKeyUpdate)
+	require.True(t, ok)
+	assert.Equal(t, handshake.KeyUpdateNotRequested, response.RequestUpdate)
+	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Record.Header.Epoch)
+	assert.Equal(t, dtlsflight13.EpochApplication, state.LocalEpoch())
+}
+
+func TestRequiredKeyUpdateResponsesKeepApplicationDataBlockedUntilEmitted(t *testing.T) {
+	state := newPostHandshakeKeyUpdateTestState(t, false)
+	post := newPostHandshake(handshakeContext{
+		state: state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	conn := &postHandshakeKeyUpdateConn{state: state}
+	request := &handshake.MessageKeyUpdate{RequestUpdate: handshake.KeyUpdateRequested}
+
+	require.NoError(t, post.handleKeyUpdate(
+		context.Background(), conn, request, dtlsflight13.EpochApplication,
+	))
+	require.NoError(t, post.handleKeyUpdate(
+		context.Background(), conn, request, dtlsflight13.EpochApplication+1,
+	))
+	assert.True(t, conn.blocked)
+	assert.Equal(t, 1, conn.blockCount)
+	assert.Equal(t, 2, post.pendingRequiredKeyUpdateResponses)
+	require.Len(t, post.queue, 2)
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	assert.True(t, conn.blocked)
+	assert.Equal(t, 1, post.pendingRequiredKeyUpdateResponses)
+	require.Len(t, conn.writtenPackets, 1)
+	require.Len(t, post.flights, 1)
+	for id := range post.flights {
+		require.NoError(t, post.completePostHandshakeFlight(conn, id))
+	}
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	assert.False(t, conn.blocked)
+	assert.Equal(t, 1, conn.unblockCount)
+	assert.Zero(t, post.pendingRequiredKeyUpdateResponses)
+	assert.Len(t, conn.writtenPackets, 2)
+}
+
+func TestRetransmittedKeyUpdateDoesNotRatchetReadKeysTwice(t *testing.T) {
+	const messageSequence = uint16(5)
+	state := newPostHandshakeKeyUpdateTestState(t, true)
+	state.HandshakeRecvSequence = int(messageSequence)
+	wire, err := (&handshake.Handshake{
+		Header: handshake.Header{
+			Type:            handshake.TypeKeyUpdate,
+			MessageSequence: messageSequence,
+		},
+		Message: &handshake.MessageKeyUpdate{RequestUpdate: handshake.KeyUpdateNotRequested},
+	}).Marshal()
+	require.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(wire, dtlsflight13.EpochApplication, messageSequence, handshake.TypeKeyUpdate, false)
+	post := newPostHandshake(handshakeContext{
+		state: state,
+		cache: cache,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	conn := &postHandshakeKeyUpdateConn{state: state}
+	record := protocol.RecordNumber{Epoch: uint64(dtlsflight13.EpochApplication), SequenceNumber: 3}
+	receive := func() error {
+		return post.handlePostHandshakeReceive(context.Background(), conn, RecvHandshakeState{
+			HasHandshake: true,
+			RecordsToACK: []protocol.RecordNumber{record},
+		})
+	}
+
+	require.NoError(t, receive())
+	require.NoError(t, receive())
+	assert.Equal(t, int(messageSequence)+1, state.HandshakeRecvSequence)
+	currentRead, ok := state.TrafficKeys.CurrentRead()
+	require.True(t, ok)
+	assert.Equal(t, uint64(1), currentRead.Generation)
+	assert.Len(t, conn.writtenPackets, 2, "both copies must be acknowledged")
+}
+
+func TestInvalidKeyUpdateUsesIllegalParameterAlert(t *testing.T) {
+	state := newPostHandshakeKeyUpdateTestState(t, true)
+	cache := dtlsflight.NewCache()
+	header, err := (&handshake.Header{
+		Type:           handshake.TypeKeyUpdate,
+		Length:         1,
+		FragmentLength: 1,
+	}).Marshal()
+	require.NoError(t, err)
+	cache.Push(append(header, 2), dtlsflight13.EpochApplication, 0, handshake.TypeKeyUpdate, false)
+	post := newPostHandshake(handshakeContext{state: state, cache: cache, cfg: &dtlsconfig.HandshakeConfig{}})
+	conn := &postHandshakeAlertConn{}
+
+	err = post.processPostHandshakeMessages(context.Background(), conn)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidKeyUpdate)
+	assert.Equal(t, []postHandshakeAlert{{
+		level: alert.Fatal, description: alert.IllegalParameter,
+	}}, conn.notifications)
 }


### PR DESCRIPTION
#### Description
Implements the inbound side of keyUpdate, this PR is based on #994 part of part of #824, after both are merged, I'm going to do small follow ups to wire them through conn and fsm.
I added a todo list for redoing the serialization properly, it will be kinda a big refactor, This is currently doing the keyUpdate orders using `PauseApplicationData` / `ResumeApplicationData`. (~~I'll create an issue~~ #996).