### PR TITLE
Add public UpdateKeys API

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -617,6 +617,70 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	return len(payload), err
 }
 
+// KeyUpdateOptions controls a DTLS 1.3 application traffic-key update.
+type KeyUpdateOptions struct {
+	// RequestPeerUpdate asks the peer to update its sending keys in response.
+	RequestPeerUpdate bool
+}
+
+// UpdateKeys requests a DTLS 1.3 application traffic-key update. It returns
+// only after the peer acknowledges the KeyUpdate and the next local write
+// generation has been committed.
+func (c *Conn) UpdateKeys(ctx context.Context, options KeyUpdateOptions) error {
+	updater, err := c.keyUpdateFSM(ctx)
+	if err != nil {
+		return err
+	}
+	request := handshake.KeyUpdateNotRequested
+	if options.RequestPeerUpdate {
+		request = handshake.KeyUpdateRequested
+	}
+
+	operationCtx, cancel := c.contextWithCloseAndWriteDeadline(ctx)
+	defer cancel()
+
+	return c.normalizeKeyUpdateError(ctx, operationCtx, updater.UpdateKeys(operationCtx, request))
+}
+
+func (c *Conn) keyUpdateFSM(ctx context.Context) (dtlshandshake.KeyUpdater, error) {
+	if c.isConnectionClosed() {
+		return nil, ErrConnClosed
+	}
+	select {
+	case <-c.writeDeadline.Done():
+		return nil, dtlserrors.ErrDeadlineExceeded
+	default:
+	}
+	if err := c.HandshakeContext(ctx); err != nil {
+		return nil, err
+	}
+	if !dtlsstate.CommonState(c.state).LocalVersion.Equal(protocol.Version1_3) {
+		return nil, dtlserrors.ErrUnsupportedProtocolVersion
+	}
+
+	updater, ok := c.fsm.(dtlshandshake.KeyUpdater)
+	if !ok {
+		return nil, dtlserrors.ErrNotImplemented
+	}
+
+	return updater, nil
+}
+
+func (c *Conn) normalizeKeyUpdateError(ctx, operationCtx context.Context, err error) error {
+	if errors.Is(err, context.Canceled) {
+		switch {
+		case c.isConnectionClosed():
+			return ErrConnClosed
+		case errors.Is(context.Cause(operationCtx), context.DeadlineExceeded):
+			return dtlserrors.ErrDeadlineExceeded
+		case ctx.Err() != nil:
+			return ctx.Err()
+		}
+	}
+
+	return err
+}
+
 func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Packet) error {
 	for {
 		c.writeLock.Lock()
@@ -864,6 +928,25 @@ func (c *Conn) contextWithClose(ctx context.Context) (context.Context, context.C
 	}()
 
 	return closeCtx, func() {
+		cancel(context.Canceled)
+	}
+}
+
+func (c *Conn) contextWithCloseAndWriteDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	operationCtx, cancel := context.WithCancelCause(context.Background())
+	go func() {
+		select {
+		case <-c.closed.Done():
+			cancel(context.Canceled)
+		case <-c.writeDeadline.Done():
+			cancel(context.DeadlineExceeded)
+		case <-ctx.Done():
+			cancel(ctx.Err())
+		case <-operationCtx.Done():
+		}
+	}()
+
+	return operationCtx, func() {
 		cancel(context.Canceled)
 	}
 }

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -170,6 +170,58 @@ func (s *fsm13) Done() <-chan struct{} {
 	return s.closed
 }
 
+type KeyUpdater interface {
+	UpdateKeys(context.Context, handshake.KeyUpdateRequest) error
+}
+
+// UpdateKeys queues a reliable DTLS 1.3 KeyUpdate and waits until its ACK has
+// committed the next local write generation.
+func (s *fsm13) UpdateKeys(ctx context.Context, request handshake.KeyUpdateRequest) error {
+	if request != handshake.KeyUpdateNotRequested && request != handshake.KeyUpdateRequested {
+		return dtlserrors.ErrInvalidKeyUpdate
+	}
+
+	result := make(chan error, 1)
+	command := postHandshakeCommand{
+		Kind:      commandSendKeyUpdate,
+		Canceled:  ctx.Done(),
+		KeyUpdate: keyUpdateCommand{Request: request},
+		Result:    result,
+	}
+	if err := s.submitKeyUpdateCommand(ctx, command); err != nil {
+		return err
+	}
+
+	return s.waitKeyUpdateResult(ctx, result)
+}
+
+func (s *fsm13) submitKeyUpdateCommand(ctx context.Context, command postHandshakeCommand) error {
+	select {
+	case s.postHandshake.commands <- command:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.closed:
+		return dtlserrors.ErrConnClosed
+	}
+}
+
+func (s *fsm13) waitKeyUpdateResult(ctx context.Context, result <-chan error) error {
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.closed:
+		select {
+		case err := <-result:
+			return err
+		default:
+			return dtlserrors.ErrConnClosed
+		}
+	}
+}
+
 func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err error) {
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
#### Description
This is the last PR for post-handshake key-update before I'll start refactoring and cleaning the implementation for example #996  I'll also check edge cases in the spec and our implementation. 

This API adds a blocking sync UpdateKeys that returns when flight was ACKed and when we commit the next write generation. Or if a failure happened.

The other option we can consider for this API is to break it into a non-blocking Start + Wait this will be similar to BoringSSL https://boringssl.googlesource.com/boringssl/+/HEAD/include/openssl/ssl.h?pli=1#327 but it will be a bit complex to use and for our side to add and maintain.

@Sean-Der what do you think?