### PR TITLE
Use one-shot completion for post-handshake result

### DIFF
--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -181,18 +181,18 @@ func (s *fsm13) UpdateKeys(ctx context.Context, request handshake.KeyUpdateReque
 		return dtlserrors.ErrInvalidKeyUpdate
 	}
 
-	result := make(chan error, 1)
+	completion, completionCtx := newPostHandshakeCompletion()
 	command := postHandshakeCommand{
-		Kind:      commandSendKeyUpdate,
-		Canceled:  ctx.Done(),
-		KeyUpdate: keyUpdateCommand{Request: request},
-		Result:    result,
+		Kind:       commandSendKeyUpdate,
+		Canceled:   ctx.Done(),
+		KeyUpdate:  keyUpdateCommand{Request: request},
+		Completion: completion,
 	}
 	if err := s.submitKeyUpdateCommand(ctx, command); err != nil {
 		return err
 	}
 
-	return s.waitKeyUpdateResult(ctx, result)
+	return s.waitKeyUpdateCompletion(ctx, completionCtx, completion)
 }
 
 func (s *fsm13) submitKeyUpdateCommand(ctx context.Context, command postHandshakeCommand) error {
@@ -206,16 +206,20 @@ func (s *fsm13) submitKeyUpdateCommand(ctx context.Context, command postHandshak
 	}
 }
 
-func (s *fsm13) waitKeyUpdateResult(ctx context.Context, result <-chan error) error {
+func (s *fsm13) waitKeyUpdateCompletion(
+	ctx context.Context,
+	completionCtx context.Context,
+	completion *postHandshakeCompletion,
+) error {
 	select {
-	case err := <-result:
-		return err
+	case <-completionCtx.Done():
+		return completion.result()
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-s.closed:
 		select {
-		case err := <-result:
-			return err
+		case <-completionCtx.Done():
+			return completion.result()
 		default:
 			return dtlserrors.ErrConnClosed
 		}

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"sync/atomic"
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -82,6 +83,17 @@ type postHandshakeRecord struct {
 	Fragments []postHandshakeFragment
 }
 
+type postHandshakeOutcome struct {
+	err error
+}
+
+// postHandshakeCompletion publishes a one-shot operation result.
+type postHandshakeCompletion struct {
+	signal context.CancelFunc
+
+	outcome atomic.Pointer[postHandshakeOutcome]
+}
+
 type reliablePostHandshakeFlight struct {
 	ID postHandshakeFlightID
 
@@ -103,7 +115,7 @@ type reliablePostHandshakeFlight struct {
 	NextRetransmit     time.Time
 
 	// non-nil for application commands that wait for completion.
-	Result chan error
+	Completion *postHandshakeCompletion
 
 	// non-nil only when acknowledging this flight commits a KeyUpdate.
 	PendingWrite *dtlsstate.TrafficGeneration
@@ -132,8 +144,8 @@ type postHandshakeCommand struct {
 	KeyUpdate keyUpdateCommand
 	Canceled  <-chan struct{}
 
-	// Always buffered with capacity one.
-	Result chan error
+	// non-nil for application commands that wait for completion.
+	Completion *postHandshakeCompletion
 }
 
 type postHandshake struct {
@@ -174,6 +186,28 @@ type pendingACKConn interface {
 	TakePendingACKs() []protocol.RecordNumber
 }
 
+func newPostHandshakeCompletion() (*postHandshakeCompletion, context.Context) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &postHandshakeCompletion{
+		signal: cancel,
+	}, ctx
+}
+
+func (c *postHandshakeCompletion) complete(err error) {
+	if c == nil {
+		return
+	}
+	if c.outcome.CompareAndSwap(nil, &postHandshakeOutcome{err: err}) {
+		c.signal()
+	}
+}
+
+// result must only be called after the paired completion context is done.
+func (c *postHandshakeCompletion) result() error {
+	return c.outcome.Load().err
+}
+
 func newPostHandshake(ctx handshakeContext) *postHandshake {
 	return &postHandshake{
 		commands: make(chan postHandshakeCommand),
@@ -211,14 +245,14 @@ func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn)
 		command := p.queue[0]
 		p.queue = p.queue[1:]
 		if err, canceled := canceledPostHandshakeCommand(command); canceled {
-			completePostHandshakeResult(command.Result, err)
+			command.Completion.complete(err)
 
 			continue
 		}
 
 		err := p.startPostHandshakeCommand(ctx, conn, command)
 		if err != nil {
-			completePostHandshakeResult(command.Result, err)
+			command.Completion.complete(err)
 			p.failRequiredKeyUpdateResponse(conn, command)
 
 			return err
@@ -512,7 +546,7 @@ func (p *postHandshake) startKeyUpdate(
 	conn Conn,
 	command postHandshakeCommand,
 ) error {
-	flight, err := p.buildKeyUpdateFlight(command.KeyUpdate.Request, command.Result)
+	flight, err := p.buildKeyUpdateFlight(command.KeyUpdate.Request, command.Completion)
 	if err != nil {
 		return err
 	}
@@ -546,7 +580,7 @@ func (p *postHandshake) startKeyUpdate(
 
 func (p *postHandshake) buildKeyUpdateFlight(
 	request handshake.KeyUpdateRequest,
-	result chan error,
+	completion *postHandshakeCompletion,
 ) (*reliablePostHandshakeFlight, error) {
 	if p.state.TrafficKeys == nil {
 		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
@@ -605,7 +639,7 @@ func (p *postHandshake) buildKeyUpdateFlight(
 		PendingFragments:   make(map[postHandshakeFragment]struct{}),
 		SentRecords:        make(map[protocol.RecordNumber]struct{}),
 		RetransmitInterval: p.initialRetransmitInterval,
-		Result:             result,
+		Completion:         completion,
 		PendingWrite:       next,
 	}, nil
 }
@@ -730,24 +764,18 @@ func (p *postHandshake) completePostHandshakeFlight(conn Conn, id postHandshakeF
 		delete(p.recordIndex, number)
 	}
 	delete(p.flights, id)
-	completePostHandshakeResult(flight.Result, completionErr)
+	flight.Completion.complete(completionErr)
 
 	return completionErr
 }
 
-func completePostHandshakeResult(result chan error, err error) {
-	if result != nil {
-		result <- err
-	}
-}
-
 func (p *postHandshake) fail(conn Conn, err error) {
 	for _, command := range p.queue {
-		completePostHandshakeResult(command.Result, err)
+		command.Completion.complete(err)
 	}
 	p.queue = nil
 	for id, flight := range p.flights {
-		completePostHandshakeResult(flight.Result, err)
+		flight.Completion.complete(err)
 		delete(p.flights, id)
 	}
 	p.recordIndex = make(map[protocol.RecordNumber]postHandshakeRecord)

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -200,19 +200,46 @@ func TestPostHandshakeSkipsCanceledCommand(t *testing.T) {
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	result := make(chan error, 1)
+	completion, completionCtx := newPostHandshakeCompletion()
 	post.queue = append(post.queue, postHandshakeCommand{
-		Kind:     commandSendNewSessionTicket,
-		Canceled: ctx.Done(),
-		Result:   result,
+		Kind:       commandSendNewSessionTicket,
+		Canceled:   ctx.Done(),
+		Completion: completion,
 	})
 	conn := &postHandshakeWriteConn{result: &WriteResult{}}
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
-	assert.ErrorIs(t, <-result, context.Canceled)
+	<-completionCtx.Done()
+	assert.ErrorIs(t, completion.result(), context.Canceled)
 	assert.Empty(t, conn.writtenPackets)
 	assert.Empty(t, post.queue)
 	assert.Empty(t, post.flights)
+}
+
+func TestPostHandshakeCompletionKeepsFirstOutcome(t *testing.T) {
+	completion, completionCtx := newPostHandshakeCompletion()
+	completion.complete(nil)
+	completion.complete(assert.AnError)
+
+	<-completionCtx.Done()
+	assert.NoError(t, completion.result())
+}
+
+func TestWaitKeyUpdateCompletionKeepsCallerCancellationSeparate(t *testing.T) {
+	completion, completionCtx := newPostHandshakeCompletion()
+	callerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.ErrorIs(t, (&fsm13{}).waitKeyUpdateCompletion(
+		callerCtx,
+		completionCtx,
+		completion,
+	), context.Canceled)
+	assert.NoError(t, completionCtx.Err())
+
+	completion.complete(nil)
+	<-completionCtx.Done()
+	assert.NoError(t, completion.result())
 }
 
 func TestPostHandshakeACKReliability(t *testing.T) {
@@ -468,14 +495,14 @@ func TestKeyUpdateCommitsWriteKeysOnlyAfterACK(t *testing.T) {
 			Number: record, Fragments: []SentHandshakeFragment{fragment},
 		}}},
 	}
-	result := make(chan error, 1)
+	completion, completionCtx := newPostHandshakeCompletion()
 
 	require.NoError(t, post.startKeyUpdate(context.Background(), conn, postHandshakeCommand{
 		Kind: commandSendKeyUpdate,
 		KeyUpdate: keyUpdateCommand{
 			Request: handshake.KeyUpdateRequested,
 		},
-		Result: result,
+		Completion: completion,
 	}))
 	require.Len(t, conn.writtenPackets, 1)
 	packet := conn.writtenPackets[0]
@@ -502,7 +529,8 @@ func TestKeyUpdateCommitsWriteKeysOnlyAfterACK(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, uint64(1), current.Generation)
 	assert.Same(t, current, conn.committed)
-	assert.NoError(t, <-result)
+	<-completionCtx.Done()
+	assert.NoError(t, completion.result())
 }
 
 func TestBuildKeyUpdateFlightRejectsEpochOverflow(t *testing.T) {


### PR DESCRIPTION
#### Description
Refactor post-handshake result to get rid of the channels use https://github.com/pion/dtls/pull/997#discussion_r3750574747