### PR TITLE
Resume and ACK split flights

### DIFF
--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -170,6 +170,14 @@ func flight1Parse(
 	cache := flightCtx.cache
 	cfg := flightCtx.cfg
 
+	if state.RemoteEpoch() >= EpochHandshake {
+		// a direct ServerHello can leave the protected server flight pending,
+		// so resume it instead of pulling ServerHello again.
+		//
+		// https://datatracker.ietf.org/doc/html/rfc9147#section-5.5
+		return flight3Parse(ctx, conn, flightCtx)
+	}
+
 	seq, msgs, items, ok := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
 	)

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -204,6 +204,15 @@ func initializeFlight3HandshakeProtection(
 	if err := flightCtx.handshakeRecordProtectionInitializer(flightCtx.state); err != nil {
 		return newFlightParseFailure(alert.InternalError, err)
 	}
+	// During the handshake, ACK records MUST be sent with an epoch which is equal to or higher
+	// than the record which is being acknowledged.
+	// ....
+	// if the client receives only the ServerHello and Certificate and wishes to ACK them
+	// in a single record, it must do so in epoch 2, as it is required to use an epoch
+	// greater than or equal to 2 and cannot yet send with any greater epoch.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc9147#section-7
+	flightCtx.state.SetLocalEpoch(EpochHandshake)
 	flightCtx.state.SetRemoteEpoch(EpochHandshake)
 	if conn == nil {
 		return nil

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -736,6 +736,49 @@ func TestHandshakeFSM13WaitParsesProtectedEncryptedExtensions(t *testing.T) {
 	assertFlight13RecvDoneClosed(t, recvState)
 }
 
+func TestHandshakeFSM13PartialProtectedServerFlightACKUsesHandshakeEpoch(t *testing.T) {
+	fixture := newNoHRRFlight13Fixture(t)
+	cache := dtlsflight.NewCache()
+	fsm, err := newFSM13(
+		fixture.clientState,
+		cache,
+		fixture.cfg,
+		dtlsflight13.Flight3,
+		nil,
+		fixture.transcript,
+	)
+	require.NoError(t, err)
+	conn := &flightTestConn{}
+
+	pushFlight13HandshakePacketsToCache(t, cache, fixture.serverFlight4[:1], false)
+	first := RecvHandshakeState{Done: make(chan struct{}), HasHandshake: true}
+	transition, err := fsm.handleReceivedFlight(context.Background(), conn, first)
+	require.NoError(t, err)
+	assert.Equal(t, StateWaiting, transition.state)
+	fsm.received.release()
+	assertFlight13RecvDoneClosed(t, first)
+
+	pushFlight13HandshakePacketsToCache(t, cache, fixture.serverFlight4[1:2], false)
+	record := protocol.RecordNumber{Epoch: uint64(dtlsflight13.EpochHandshake), SequenceNumber: 7}
+	second := RecvHandshakeState{
+		Done:         make(chan struct{}),
+		HasHandshake: true,
+		RecordsToACK: []protocol.RecordNumber{record},
+	}
+	transition, err = fsm.handleReceivedFlight(context.Background(), conn, second)
+	require.NoError(t, err)
+	assert.Equal(t, StateWaiting, transition.state)
+	require.Len(t, conn.writtenPackets, 1)
+	ackPacket := conn.writtenPackets[0]
+	assert.True(t, ackPacket.ShouldEncrypt)
+	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Record.Header.Epoch)
+	ack, ok := ackPacket.Record.Content.(*protocol.ACK)
+	require.True(t, ok)
+	assert.Equal(t, []protocol.RecordNumber{record}, ack.Records)
+	fsm.received.release()
+	assertFlight13RecvDoneClosed(t, second)
+}
+
 func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T) {
 	fixture := newNoHRRFlight13Fixture(t)
 	cache := dtlsflight.NewCache()
@@ -764,6 +807,41 @@ func TestHandshakeFSM13NoHRRReachesFlight5AfterEncryptedExtensions(t *testing.T)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
 	fsm.received.release()
 	assertFlight13RecvDoneClosed(t, recvState)
+}
+
+func TestHandshakeFSM13NoHRRSplitServerFlightAcrossReceives(t *testing.T) {
+	fixture := newNoHRRFlight13Fixture(t)
+	cache := dtlsflight.NewCache()
+	fsm, err := newFSM13(
+		fixture.clientState,
+		cache,
+		fixture.cfg,
+		dtlsflight13.Flight1,
+		fixture.clientHello,
+		nil,
+	)
+	require.NoError(t, err)
+	conn := &flightTestConn{}
+
+	pushFlight13HandshakePacketsToCache(t, cache, fixture.serverFlight4[:1], false)
+	first := RecvHandshakeState{Done: make(chan struct{}), HasHandshake: true}
+	transition, err := fsm.handleReceivedFlight(context.Background(), conn, first)
+	require.NoError(t, err)
+	assert.Equal(t, StateWaiting, transition.state)
+	assert.Equal(t, 1, fixture.clientState.HandshakeRecvSequence)
+	assert.Equal(t, dtlsflight13.EpochHandshake, fixture.clientState.RemoteEpoch())
+	fsm.received.release()
+	assertFlight13RecvDoneClosed(t, first)
+
+	pushFlight13HandshakePacketsToCache(t, cache, fixture.serverFlight4[1:], false)
+	second := RecvHandshakeState{Done: make(chan struct{}), HasHandshake: true}
+	transition, err = fsm.handleReceivedFlight(context.Background(), conn, second)
+	require.NoError(t, err)
+	assert.Equal(t, StatePreparing, transition.state)
+	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
+	assert.Equal(t, 5, fixture.clientState.HandshakeRecvSequence)
+	fsm.received.release()
+	assertFlight13RecvDoneClosed(t, second)
 }
 
 func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {


### PR DESCRIPTION
#### Description
WolfSSL sends ServerHello, then protected records in separate UDP datagrams, This breaks Pion server, because it stays in flight 1, even when WolfSSL later datagrams arrived. the handshake ends up timing out. I added the relevant spec references in the code. 

part of #727  