### PR TITLE
Handle duplicated Flight 4

### DIFF
--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -12,6 +12,7 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
@@ -347,7 +348,7 @@ func (s *fsm13) finish(ctx context.Context, conn Conn) (State, error) {
 	return StateFinished, nil
 }
 
-func (s *fsm13) handleReceivedFlight(
+func (s *fsm13) handleReceivedFlight( //nolint:cyclop
 	ctx context.Context,
 	conn Conn,
 	received RecvHandshakeState,
@@ -361,6 +362,9 @@ func (s *fsm13) handleReceivedFlight(
 	s.applyACKProgress(ackResult)
 	if !received.HasHandshake && len(received.ACKs) != 0 {
 		return s.transitionAfterACK(ackResult, false), nil
+	}
+	if received.HasHandshake && received.IsRetransmit && s.currentFlight.IsLastSendFlight() {
+		return s.handlePreviousFlightRetransmit(ctx, conn, received.RecordsToACK, ackResult)
 	}
 
 	nextFlight, err := s.parseReceivedFlight(ctx, conn, s.currentFlight)
@@ -384,6 +388,23 @@ func (s *fsm13) handleReceivedFlight(
 	}
 
 	return transition, nil
+}
+
+func (s *fsm13) handlePreviousFlightRetransmit(
+	ctx context.Context,
+	conn Conn,
+	recordsToACK []protocol.RecordNumber,
+	ackResult ACKResult,
+) (receivedFlightTransition, error) {
+	// A duplicate peer flight means it didn't receive our response.
+	// ACK the duplicate and retransmit the pending final flight.
+	// check WAIT exit 3:
+	// https://datatracker.ietf.org/doc/html/rfc9147#section-5.8.1
+	if err := sendACK(ctx, conn, s.state.LocalEpoch(), recordsToACK); err != nil {
+		return receivedFlightTransition{}, err
+	}
+
+	return s.transitionAfterACK(ackResult, true), nil
 }
 
 func (s *fsm13) prepareFlightACKTracking(flights []*dtlsflight.Packet, retransmit bool) {

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -894,6 +894,38 @@ func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {
 	assert.Equal(t, dtlsflight13.EpochHandshake, conn.localEpoch)
 }
 
+func TestHandshakeFSM13ClientFlight5HandlesPreviousFlightRetransmit(t *testing.T) {
+	fixture := newNoHRRFlight13Fixture(t)
+	fsm := clientFSMThroughServerFlight13(t, fixture)
+	conn := &flightTestConn{}
+	nextState, err := fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, StateSending, nextState)
+	require.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
+
+	fixture.clientState.SetLocalEpoch(dtlsflight13.EpochHandshake)
+	record := protocol.RecordNumber{Epoch: uint64(dtlsflight13.EpochHandshake), SequenceNumber: 11}
+	retransmit := RecvHandshakeState{
+		Done:         make(chan struct{}),
+		HasHandshake: true,
+		IsRetransmit: true,
+		RecordsToACK: []protocol.RecordNumber{record},
+	}
+	transition, err := fsm.handleReceivedFlight(context.Background(), conn, retransmit)
+	require.NoError(t, err)
+	assert.Equal(t, StateSending, transition.state)
+	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
+	require.Len(t, conn.writtenPackets, 1)
+	ackPacket := conn.writtenPackets[0]
+	assert.True(t, ackPacket.ShouldEncrypt)
+	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Record.Header.Epoch)
+	ack, ok := ackPacket.Record.Content.(*protocol.ACK)
+	require.True(t, ok)
+	assert.Equal(t, []protocol.RecordNumber{record}, ack.Records)
+	fsm.received.release()
+	assertFlight13RecvDoneClosed(t, retransmit)
+}
+
 func TestHandshakeFSM13SendErrorReleasesReader(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
#### Description
Another issue I found while testing against WolfSSL sometimes it's too impatient and retransmit flight4 just before receiving our flight 5. which causes Pion to try to go to the nonexistent flight5 parse (it's a send only flight), so we return "ErrFlightUnimplemented13" we should return unexpected_message there I'll do this as part of #1000. 
This fix makes Pion treats flight4 retransmission as duplicate and retransmit flight 5.  part of #727 