### PR TITLE
Integrate CID into record-layer and conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1099,6 +1099,10 @@ func (c *Conn) sealRecordContent(
 		SeqBit:         true,
 		LengthBit:      true,
 	}
+	if state13, ok := c.state.(*dtlsstate.State13); ok &&
+		state13.CID.Negotiated && state13.CID.Send.UseCID {
+		header.ConnectionID = bytes.Clone(state13.CID.Send.Active)
+	}
 
 	ciphertext, err := generation.Protection.Seal(
 		header,
@@ -1487,7 +1491,10 @@ func (c *Conn) unpackDatagram(buf []byte) ([][]byte, error) {
 	common := dtlsstate.CommonState(c.state)
 	if common.LocalVersion.Equal(protocol.Version1_3) ||
 		protocol.IsDTLS13Ciphertext(protocol.ContentType(buf[0])) {
-		return recordlayer.UnpackDatagram13(buf, 0, true)
+		cidLength := len(common.LocalConnectionID())
+		state13, is13 := c.state.(*dtlsstate.State13)
+
+		return recordlayer.UnpackDatagram13(buf, cidLength, is13 && state13.CID.Negotiated, true)
 	}
 
 	return recordlayer.ContentAwareUnpackDatagram(buf, len(common.LocalConnectionID()))
@@ -1507,8 +1514,12 @@ func (c *Conn) unmarshalCiphertextRecord(buf []byte) (recordlayer.CiphertextReco
 	record := recordlayer.CiphertextRecord13{}
 	hasCID := buf[0]&recordlayer.UnifiedHeaderCIDBit != 0
 	localCID := dtlsstate.CommonState(c.state).LocalConnectionID()
+	cidExpected, cidAllowed, err := c.ciphertextCIDPolicy(localCID)
+	if err != nil {
+		return record, err
+	}
 	if hasCID {
-		if len(localCID) == 0 {
+		if !cidAllowed {
 			return record, dtlserrors.ErrInvalidCiphertextHeader
 		}
 		record.Header.ConnectionID = make([]byte, len(localCID))
@@ -1517,27 +1528,33 @@ func (c *Conn) unmarshalCiphertextRecord(buf []byte) (recordlayer.CiphertextReco
 	if err := record.Unmarshal(buf); err != nil {
 		return record, err
 	}
-	if len(localCID) > 0 && !hasCID {
+	if cidExpected && !hasCID {
 		return record, dtlserrors.ErrInvalidCiphertextHeader
 	}
 	if hasCID {
 		if !bytes.Equal(localCID, record.Header.ConnectionID) {
 			return record, dtlserrors.ErrInvalidCiphertextHeader
 		}
-
-		return record, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 	}
 
 	return record, nil
 }
 
+func (c *Conn) ciphertextCIDPolicy(localCID []byte) (expected, allowed bool, err error) {
+	state13, ok := c.state.(*dtlsstate.State13)
+	if !ok || !state13.CID.Negotiated {
+		return false, len(localCID) > 0, nil
+	}
+	if state13.CID.Receive.Length != len(localCID) {
+		return false, false, dtlserrors.ErrInvalidCiphertextHeader
+	}
+
+	return state13.CID.Receive.Expected, state13.CID.Receive.Expected, nil
+}
+
 func (c *Conn) openCiphertextRecord(
 	record recordlayer.CiphertextRecord13,
 ) (recordlayer.InnerPlaintext, uint64, uint16, error) {
-	if len(record.Header.ConnectionID) > 0 {
-		return recordlayer.InnerPlaintext{}, 0, 0, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
 	var candidateBuffer [4]*dtlsstate.TrafficGeneration
 	candidates, remoteEpoch, err := c.readTrafficCandidates(record.Header.EpochLow, candidateBuffer[:0])
 	if err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1350,6 +1350,17 @@ func TestClientCertificate(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 	})
 }
 
+func TestShouldWrapConnectionIDUsesOnlyDTLS12(t *testing.T) {
+	state12 := dtlsstate.NewActive(false)
+	assert.False(t, state12.ShouldWrapConnectionID())
+	dtlsstate.CommonState(state12).RemoteConnectionID = []byte{0x01}
+	assert.True(t, state12.ShouldWrapConnectionID())
+
+	state13 := dtlsstate.NewState13(false)
+	state13.RemoteConnectionID = []byte{0x01}
+	assert.False(t, state13.ShouldWrapConnectionID())
+}
+
 func TestConnectionID(t *testing.T) {
 	// Check for leaking routines
 	report := test.CheckRoutines(t)
@@ -4701,6 +4712,74 @@ func TestSealRecordContentUsesWriteTrafficGeneration(t *testing.T) {
 
 	_, err = conn.sealRecordContent(4, 0, protocol.ContentTypeApplicationData, nil)
 	assert.ErrorIs(t, err, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented)
+}
+
+func TestSealRecordContentUsesNegotiatedConnectionID(t *testing.T) {
+	conn, state, suite := newTrafficKeyTestConn(t)
+	secret := trafficKeyTestSecret(suite, 0x23)
+	protection := trafficKeyTestProtection(t, suite, secret)
+	state.TrafficKeys.Install(&dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochApplication,
+		Secret:     secret,
+		Protection: protection,
+	}, nil)
+	state.SetLocalConnectionID([]byte("local-cid"))
+	state.NegotiateConnectionIDs([]byte("remote-cid"))
+
+	rawRecord, err := conn.sealRecordContent(
+		dtlsflight13.EpochApplication, 0, protocol.ContentTypeApplicationData, []byte("application"),
+	)
+	require.NoError(t, err)
+
+	record := recordlayer.CiphertextRecord13{
+		Header: recordlayer.UnifiedHeader{ConnectionID: make([]byte, len("remote-cid"))},
+	}
+	require.NoError(t, record.Unmarshal(rawRecord))
+	assert.Equal(t, []byte("remote-cid"), record.Header.ConnectionID)
+	innerPlaintext, err := protection.Open(record.Header, 0, record.EncryptedRecord)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("application"), innerPlaintext.Content)
+}
+
+func TestOpenCiphertextRecordUsesNegotiatedConnectionID(t *testing.T) {
+	conn, state, suite := newTrafficKeyTestConn(t)
+	secret := trafficKeyTestSecret(suite, 0x34)
+	protection := trafficKeyTestProtection(t, suite, secret)
+	state.TrafficKeys.Install(nil, &dtlsstate.TrafficGeneration{
+		Epoch:      dtlsflight13.EpochApplication,
+		Secret:     secret,
+		Protection: protection,
+	})
+	state.SetRemoteEpoch(dtlsflight13.EpochApplication)
+	state.SetLocalConnectionID([]byte("local-cid"))
+	state.NegotiateConnectionIDs([]byte("remote-cid"))
+
+	sealed, err := protection.Seal(
+		recordlayer.UnifiedHeader{
+			ConnectionID: []byte("local-cid"),
+			EpochLow:     uint8(dtlsflight13.EpochApplication & recordlayer.TwoLowBitsMask),
+		},
+		0,
+		protocol.ContentTypeApplicationData,
+		[]byte("application"),
+	)
+	require.NoError(t, err)
+	rawRecord, err := sealed.Marshal()
+	require.NoError(t, err)
+
+	record, err := conn.unmarshalCiphertextRecord(rawRecord)
+	require.NoError(t, err)
+	innerPlaintext, sequenceNumber, epoch, err := conn.openCiphertextRecord(record)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), sequenceNumber)
+	assert.Equal(t, dtlsflight13.EpochApplication, epoch)
+	assert.Equal(t, []byte("application"), innerPlaintext.Content)
+
+	sealed.Header.ConnectionID = nil
+	rawRecord, err = sealed.Marshal()
+	require.NoError(t, err)
+	_, err = conn.unmarshalCiphertextRecord(rawRecord)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
 }
 
 func TestOpenCiphertextRecordUsesReadTrafficGeneration(t *testing.T) {

--- a/pkg/protocol/recordlayer/recordlayer_13.go
+++ b/pkg/protocol/recordlayer/recordlayer_13.go
@@ -176,7 +176,13 @@ func (r *CiphertextRecord13) RecordHeader() HeaderLike {
 }
 
 // UnpackDatagram13 extracts DTLS 1.3 records from a single datagram.
-func UnpackDatagram13(buf []byte, cidLength int, ciphertextHeadersEnabled bool) ([][]byte, error) {
+// If cidRequired is true, the datagram must contain a CID.
+func UnpackDatagram13(
+	buf []byte,
+	cidLength int,
+	cidRequired bool,
+	ciphertextHeadersEnabled bool,
+) ([][]byte, error) {
 	out := [][]byte{}
 	var firstCiphertextCID []byte
 
@@ -197,7 +203,9 @@ func UnpackDatagram13(buf []byte, cidLength int, ciphertextHeadersEnabled bool) 
 			return nil, dtlserrors.ErrInvalidContentType
 		}
 
-		record, cid, nextOffset, done, err := unpackCiphertextDatagram13Record(buf, offset, cidLength)
+		record, cid, nextOffset, done, err := unpackCiphertextDatagramRecord(
+			buf, offset, cidLength, cidRequired,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -227,8 +235,13 @@ func unpackPlaintextDatagram13Record(buf []byte, offset int) ([]byte, int, error
 	return buf[offset : offset+pktLen], offset + pktLen, nil
 }
 
-func unpackCiphertextDatagram13Record(buf []byte, offset, cidLength int) ([]byte, []byte, int, bool, error) {
-	header, err := unmarshalCiphertextDatagram13Header(buf[offset:], cidLength)
+func unpackCiphertextDatagramRecord(
+	buf []byte,
+	offset int,
+	cidLength int,
+	cidRequired bool,
+) ([]byte, []byte, int, bool, error) {
+	header, err := unmarshalCiphertextDatagramHeader(buf[offset:], cidLength, cidRequired)
 	if err != nil {
 		return nil, nil, 0, false, err
 	}
@@ -254,9 +267,9 @@ func isMismatchedCiphertextCID(firstCID *[]byte, cid []byte, cidLength int) bool
 	return !bytes.Equal(*firstCID, cid)
 }
 
-func unmarshalCiphertextDatagram13Header(data []byte, cidLength int) (UnifiedHeader, error) {
+func unmarshalCiphertextDatagramHeader(data []byte, cidLength int, cidRequired bool) (UnifiedHeader, error) {
 	hasCID := data[0]&UnifiedHeaderCIDBit != 0
-	if err := validateCiphertextCIDBit(hasCID, cidLength); err != nil {
+	if err := validateCiphertextCIDBit(hasCID, cidLength, cidRequired); err != nil {
 		return UnifiedHeader{}, err
 	}
 
@@ -268,9 +281,9 @@ func unmarshalCiphertextDatagram13Header(data []byte, cidLength int) (UnifiedHea
 	return header, header.Unmarshal(data)
 }
 
-func validateCiphertextCIDBit(hasCID bool, cidLength int) error {
+func validateCiphertextCIDBit(hasCID bool, cidLength int, cidRequired bool) error {
 	switch {
-	case cidLength > 0 && !hasCID:
+	case cidRequired && cidLength > 0 && !hasCID:
 		return dtlserrors.ErrInvalidCiphertextHeader
 	case cidLength == 0 && hasCID:
 		return dtlserrors.ErrInvalidCiphertextHeader

--- a/pkg/protocol/recordlayer/recordlayer_13_test.go
+++ b/pkg/protocol/recordlayer/recordlayer_13_test.go
@@ -366,7 +366,7 @@ func TestUnpackDatagram13Plaintext(t *testing.T) {
 	plaintextRaw, err := plaintext.Marshal()
 	require.NoError(t, err)
 
-	records, err := UnpackDatagram13(plaintextRaw, 0, false)
+	records, err := UnpackDatagram13(plaintextRaw, 0, false, true)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{plaintextRaw}, records)
 }
@@ -385,7 +385,7 @@ func TestUnpackDatagram13Ciphertext(t *testing.T) {
 	ciphertextWithoutLengthRaw := append([]byte{0x20, 0x02}, ciphertext13Payload(0xcc)...)
 
 	datagram := append(append([]byte{}, ciphertextWithLengthRaw...), ciphertextWithoutLengthRaw...)
-	records, err := UnpackDatagram13(datagram, 0, true)
+	records, err := UnpackDatagram13(datagram, 0, true, true)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{ciphertextWithLengthRaw, ciphertextWithoutLengthRaw}, records)
 }
@@ -394,7 +394,7 @@ func TestUnpackDatagram13RejectsShortFinalCiphertextRecordWithoutLength(t *testi
 	for recordLen := range minDTLSCiphertextRecordLen {
 		raw := append([]byte{0x20, 0x01}, make([]byte, recordLen)...)
 
-		_, err := UnpackDatagram13(raw, 0, true)
+		_, err := UnpackDatagram13(raw, 0, true, true)
 		require.ErrorIs(t, err, ErrInvalidPacketLength, "record length %d", recordLen)
 	}
 }
@@ -407,7 +407,7 @@ func TestUnpackDatagram13RejectsShortCiphertextRecordWithLength(t *testing.T) {
 		}
 		raw = append(raw, make([]byte, recordLen)...)
 
-		_, err := UnpackDatagram13(raw, 0, true)
+		_, err := UnpackDatagram13(raw, 0, true, true)
 		require.ErrorIs(t, err, ErrInvalidPacketLength, "record length %d", recordLen)
 	}
 }
@@ -430,7 +430,31 @@ func TestUnpackDatagram13MixedPlaintextAndCiphertext(t *testing.T) {
 	require.NoError(t, err)
 
 	datagram := append(append([]byte{}, plaintextRaw...), ciphertextRaw...)
-	records, err := UnpackDatagram13(datagram, 0, true)
+	records, err := UnpackDatagram13(datagram, 0, true, true)
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{plaintextRaw, ciphertextRaw}, records)
+}
+
+func TestUnpackDatagram13WithOptionalCID(t *testing.T) {
+	plaintext := &PlaintextRecord13{
+		Header:  Header{Version: protocol.Version1_2},
+		Content: &alert.Alert{Level: alert.Warning, Description: alert.CloseNotify},
+	}
+	plaintextRaw, err := plaintext.Marshal()
+	require.NoError(t, err)
+
+	ciphertext := &CiphertextRecord13{
+		Header: UnifiedHeader{
+			ConnectionID:   []byte{0x01, 0x02, 0x03, 0x04},
+			SequenceNumber: 0x01,
+		},
+		EncryptedRecord: ciphertext13Payload(0xaa),
+	}
+	ciphertextRaw, err := ciphertext.Marshal()
+	require.NoError(t, err)
+
+	datagram := append(append([]byte{}, plaintextRaw...), ciphertextRaw...)
+	records, err := UnpackDatagram13(datagram, 4, true, true)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{plaintextRaw, ciphertextRaw}, records)
 }
@@ -445,7 +469,7 @@ func TestUnpackDatagram13RejectsCiphertextMissingNegotiatedCID(t *testing.T) {
 	raw, err := ciphertext.Marshal()
 	require.NoError(t, err)
 
-	_, err = UnpackDatagram13(raw, 4, true)
+	_, err = UnpackDatagram13(raw, 4, true, true)
 	require.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
 }
 
@@ -460,12 +484,12 @@ func TestUnpackDatagram13RejectsCiphertextWithUnexpectedCID(t *testing.T) {
 	raw, err := ciphertext.Marshal()
 	require.NoError(t, err)
 
-	_, err = UnpackDatagram13(raw, 0, true)
+	_, err = UnpackDatagram13(raw, 0, true, true)
 	require.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
 }
 
 func TestUnpackDatagram13RejectsTruncatedCID(t *testing.T) {
-	_, err := UnpackDatagram13([]byte{0x30, 0x01, 0x02}, 4, true)
+	_, err := UnpackDatagram13([]byte{0x30, 0x01, 0x02}, 4, true, true)
 	require.ErrorIs(t, err, dtlserrors.ErrInvalidUnifiedHeaderFormat)
 }
 
@@ -490,7 +514,7 @@ func TestUnpackDatagram13DiscardsRemainderOnMismatchedCID(t *testing.T) {
 	secondRaw, err := second.Marshal()
 	require.NoError(t, err)
 
-	records, err := UnpackDatagram13(append(append([]byte{}, firstRaw...), secondRaw...), 4, true)
+	records, err := UnpackDatagram13(append(append([]byte{}, firstRaw...), secondRaw...), 4, true, true)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{firstRaw}, records)
 }
@@ -505,7 +529,7 @@ func TestUnpackDatagram13RejectsLegacyPlaintextWhenCiphertextHeadersEnabled(t *t
 	require.NoError(t, err)
 	raw = append(raw, 0xaa)
 
-	_, err = UnpackDatagram13(raw, 0, true)
+	_, err = UnpackDatagram13(raw, 0, true, true)
 	require.ErrorIs(t, err, dtlserrors.ErrInvalidContentType)
 }
 


### PR DESCRIPTION
#### Description
Follow up on https://github.com/pion/dtls/pull/1004 this finishes the CID integration into record-layer and conn, and makes the CID interop works against WolfSSL. After CID we'll need to do dual-state and single modes hardening as part of  #1005  
The remaining CID work is the post-handshake CID messages.
part of #846  and #775 
I'll rework the exported pkg code as part of #1007 