### PR TITLE
Extension framing api, split by version

### DIFF
--- a/pkg/protocol/extension/connection_id.go
+++ b/pkg/protocol/extension/connection_id.go
@@ -24,6 +24,24 @@ func (c ConnectionID) TypeValue() TypeValue {
 	return ConnectionIDTypeValue
 }
 
+// ExtensionType returns the IANA extension type for the payload-oriented API.
+func (c ConnectionID) ExtensionType() Type {
+	return TypeConnectionID
+}
+
+// MarshalData encodes extension_data without the extension header.
+func (c ConnectionID) MarshalData() ([]byte, error) {
+	if len(c.CID) > 255 {
+		return nil, dtlserrors.ErrInvalidCIDFormat
+	}
+
+	out := make([]byte, 1, 1+len(c.CID))
+	out[0] = byte(len(c.CID)) //nolint:gosec // length is bounded above.
+	out = append(out, c.CID...)
+
+	return out, nil
+}
+
 // Marshal encodes the extension.
 func (c *ConnectionID) Marshal() ([]byte, error) {
 	var b cryptobyte.Builder
@@ -65,4 +83,9 @@ func (c *ConnectionID) unmarshalPayload(data []byte) error {
 	}
 
 	return nil
+}
+
+// UnmarshalData decodes extension_data without the extension header.
+func (c *ConnectionID) UnmarshalData(data []byte) error {
+	return c.unmarshalPayload(data)
 }

--- a/pkg/protocol/extension/contextual.go
+++ b/pkg/protocol/extension/contextual.go
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+)
+
+// ServerNameOffer is the ClientHello server_name payload.
+type ServerNameOffer struct {
+	ServerName string
+}
+
+func (ServerNameOffer) ExtensionType() Type { return TypeServerName }
+
+func (s ServerNameOffer) MarshalData() ([]byte, error) {
+	name := []byte(s.ServerName)
+	if len(name) == 0 || len(name) > 0xffff-3 || strings.HasSuffix(s.ServerName, ".") {
+		return nil, dtlserrors.ErrInvalidSNIFormat
+	}
+
+	out := make([]byte, 5, 5+len(name))
+	binary.BigEndian.PutUint16(out, uint16(3+len(name))) //nolint:gosec // length is bounded above.
+	out[2] = serverNameTypeDNSHostName
+	binary.BigEndian.PutUint16(out[3:], uint16(len(name))) //nolint:gosec // length is bounded above.
+	out = append(out, name...)
+
+	return out, nil
+}
+
+func (s *ServerNameOffer) UnmarshalData(data []byte) error { //nolint:cyclop
+	if len(data) < 2 || int(binary.BigEndian.Uint16(data)) != len(data)-2 || len(data) == 2 {
+		return dtlserrors.ErrInvalidSNIFormat
+	}
+	data = data[2:]
+
+	name := ""
+	for len(data) > 0 {
+		if len(data) < 3 {
+			return dtlserrors.ErrInvalidSNIFormat
+		}
+		nameType := data[0]
+		nameLen := int(binary.BigEndian.Uint16(data[1:]))
+		data = data[3:]
+		if nameLen == 0 || nameLen > len(data) {
+			return dtlserrors.ErrInvalidSNIFormat
+		}
+		if nameType == serverNameTypeDNSHostName {
+			if name != "" {
+				return dtlserrors.ErrInvalidSNIFormat
+			}
+			name = string(data[:nameLen])
+			if strings.HasSuffix(name, ".") {
+				return dtlserrors.ErrInvalidSNIFormat
+			}
+		}
+		data = data[nameLen:]
+	}
+	if name == "" {
+		return dtlserrors.ErrInvalidSNIFormat
+	}
+	s.ServerName = name
+
+	return nil
+}
+
+// ServerNameAck is the empty server acknowledgement payload.
+type ServerNameAck struct{}
+
+func (ServerNameAck) ExtensionType() Type              { return TypeServerName }
+func (ServerNameAck) MarshalData() ([]byte, error)     { return []byte{}, nil }
+func (*ServerNameAck) UnmarshalData(data []byte) error { return requireEmptyPayload(data) }
+
+// ALPNOffer is the ClientHello application_layer_protocol_negotiation payload.
+type ALPNOffer struct {
+	Protocols []string
+}
+
+func (ALPNOffer) ExtensionType() Type { return TypeALPN }
+
+func (a ALPNOffer) MarshalData() ([]byte, error) { return marshalALPNProtocols(a.Protocols) }
+
+func (a *ALPNOffer) UnmarshalData(data []byte) error {
+	protocols, err := unmarshalALPNProtocols(data)
+	if err != nil {
+		return err
+	}
+	a.Protocols = protocols
+
+	return nil
+}
+
+// ALPNSelection is the server's single selected ALPN protocol.
+type ALPNSelection struct {
+	Protocol string
+}
+
+func (ALPNSelection) ExtensionType() Type { return TypeALPN }
+
+func (a ALPNSelection) MarshalData() ([]byte, error) {
+	return marshalALPNProtocols([]string{a.Protocol})
+}
+
+func (a *ALPNSelection) UnmarshalData(data []byte) error {
+	protocols, err := unmarshalALPNProtocols(data)
+	if err != nil || len(protocols) != 1 {
+		return ErrALPNInvalidFormat
+	}
+	a.Protocol = protocols[0]
+
+	return nil
+}
+
+func marshalALPNProtocols(protocols []string) ([]byte, error) {
+	if len(protocols) == 0 {
+		return nil, ErrALPNInvalidFormat
+	}
+
+	list := make([]byte, 0)
+	for _, protocol := range protocols {
+		if len(protocol) == 0 || len(protocol) > 255 || len(list) > 0xffff-1-len(protocol) {
+			return nil, ErrALPNInvalidFormat
+		}
+		list = append(list, byte(len(protocol))) //nolint:gosec // length is bounded above.
+		list = append(list, protocol...)
+	}
+
+	out := make([]byte, 2, 2+len(list))
+	binary.BigEndian.PutUint16(out, uint16(len(list))) //nolint:gosec // length is bounded above.
+	out = append(out, list...)
+
+	return out, nil
+}
+
+func unmarshalALPNProtocols(data []byte) ([]string, error) {
+	if len(data) < 2 || int(binary.BigEndian.Uint16(data)) != len(data)-2 || len(data) == 2 {
+		return nil, ErrALPNInvalidFormat
+	}
+	data = data[2:]
+
+	protocols := make([]string, 0)
+	for len(data) > 0 {
+		length := int(data[0])
+		data = data[1:]
+		if length == 0 || length > len(data) {
+			return nil, ErrALPNInvalidFormat
+		}
+		protocols = append(protocols, string(data[:length]))
+		data = data[length:]
+	}
+
+	return protocols, nil
+}
+
+// SRTPOffer is the ClientHello use_srtp payload.
+type SRTPOffer struct {
+	ProtectionProfiles  []SRTPProtectionProfile
+	MasterKeyIdentifier []byte
+}
+
+func (SRTPOffer) ExtensionType() Type { return TypeUseSRTP }
+
+func (s SRTPOffer) MarshalData() ([]byte, error) {
+	return marshalSRTPPayload(s.ProtectionProfiles, s.MasterKeyIdentifier)
+}
+
+func (s *SRTPOffer) UnmarshalData(data []byte) error {
+	profiles, mki, err := unmarshalSRTPPayload(data)
+	if err != nil {
+		return err
+	}
+	s.ProtectionProfiles, s.MasterKeyIdentifier = profiles, mki
+
+	return nil
+}
+
+// SRTPSelection is the server's single selected SRTP profile.
+type SRTPSelection struct {
+	ProtectionProfile   SRTPProtectionProfile
+	MasterKeyIdentifier []byte
+}
+
+func (SRTPSelection) ExtensionType() Type { return TypeUseSRTP }
+
+func (s SRTPSelection) MarshalData() ([]byte, error) {
+	return marshalSRTPPayload([]SRTPProtectionProfile{s.ProtectionProfile}, s.MasterKeyIdentifier)
+}
+
+func (s *SRTPSelection) UnmarshalData(data []byte) error {
+	profiles, mki, err := unmarshalSRTPPayload(data)
+	if err != nil || len(profiles) != 1 {
+		return dtlserrors.ErrLengthMismatch
+	}
+	s.ProtectionProfile, s.MasterKeyIdentifier = profiles[0], mki
+
+	return nil
+}
+
+func marshalSRTPPayload(profiles []SRTPProtectionProfile, mki []byte) ([]byte, error) {
+	if len(profiles) == 0 || len(profiles) > 0x7fff {
+		return nil, dtlserrors.ErrUseSRTPDataTooLarge
+	}
+	if len(mki) > 255 {
+		return nil, dtlserrors.ErrMasterKeyIdentifierTooLarge
+	}
+
+	out := make([]byte, 2, 3+(len(profiles)*2)+len(mki))
+	binary.BigEndian.PutUint16(out, uint16(len(profiles)*2)) //nolint:gosec // profile count is bounded above.
+	for _, profile := range profiles {
+		out = binary.BigEndian.AppendUint16(out, uint16(profile))
+	}
+	out = append(out, byte(len(mki))) //nolint:gosec // length is bounded above.
+	out = append(out, mki...)
+
+	return out, nil
+}
+
+func unmarshalSRTPPayload(data []byte) ([]SRTPProtectionProfile, []byte, error) {
+	if len(data) < 3 {
+		return nil, nil, dtlserrors.ErrBufferTooSmall
+	}
+	profilesLen := int(binary.BigEndian.Uint16(data))
+	if profilesLen == 0 || profilesLen%2 != 0 || 2+profilesLen >= len(data) {
+		return nil, nil, dtlserrors.ErrLengthMismatch
+	}
+	mkiLen := int(data[2+profilesLen])
+	if 3+profilesLen+mkiLen != len(data) {
+		return nil, nil, dtlserrors.ErrLengthMismatch
+	}
+
+	profiles := make([]SRTPProtectionProfile, 0, profilesLen/2)
+	for offset := 2; offset < 2+profilesLen; offset += 2 {
+		profiles = append(profiles, SRTPProtectionProfile(binary.BigEndian.Uint16(data[offset:])))
+	}
+
+	return profiles, bytes.Clone(data[3+profilesLen:]), nil
+}
+
+// SupportedGroups is the supported_groups payload.
+type SupportedGroups struct {
+	Groups []elliptic.Curve
+}
+
+func (SupportedGroups) ExtensionType() Type { return TypeSupportedGroups }
+
+func (s SupportedGroups) MarshalData() ([]byte, error) {
+	if len(s.Groups) == 0 || len(s.Groups) > 0x7fff {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+	out := make([]byte, 2, 2+(len(s.Groups)*2))
+	binary.BigEndian.PutUint16(out, uint16(len(s.Groups)*2)) //nolint:gosec // group count is bounded above.
+	for _, group := range s.Groups {
+		out = binary.BigEndian.AppendUint16(out, uint16(group))
+	}
+
+	return out, nil
+}
+
+func (s *SupportedGroups) UnmarshalData(data []byte) error {
+	if len(data) < 4 || int(binary.BigEndian.Uint16(data)) != len(data)-2 || (len(data)-2)%2 != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
+	s.Groups = s.Groups[:0]
+	for offset := 2; offset < len(data); offset += 2 {
+		s.Groups = append(s.Groups, elliptic.Curve(binary.BigEndian.Uint16(data[offset:])))
+	}
+
+	return nil
+}
+
+// SignatureAlgorithms is the signature_algorithms payload. Scheme values are
+// kept as wire identifiers so unknown values are not discarded by framing.
+type SignatureAlgorithms struct {
+	Schemes []uint16
+}
+
+func (SignatureAlgorithms) ExtensionType() Type            { return TypeSignatureAlgorithms }
+func (s SignatureAlgorithms) MarshalData() ([]byte, error) { return marshalUint16List(s.Schemes) }
+func (s *SignatureAlgorithms) UnmarshalData(data []byte) error {
+	schemes, err := unmarshalUint16List(data)
+	if err == nil {
+		s.Schemes = schemes
+	}
+
+	return err
+}
+
+// CertificateSignatureAlgorithms is the signature_algorithms_cert payload.
+type CertificateSignatureAlgorithms struct {
+	Schemes []uint16
+}
+
+func (CertificateSignatureAlgorithms) ExtensionType() Type { return TypeSignatureAlgorithmsCert }
+func (s CertificateSignatureAlgorithms) MarshalData() ([]byte, error) {
+	return marshalUint16List(s.Schemes)
+}
+
+func (s *CertificateSignatureAlgorithms) UnmarshalData(data []byte) error {
+	schemes, err := unmarshalUint16List(data)
+	if err == nil {
+		s.Schemes = schemes
+	}
+
+	return err
+}
+
+func marshalUint16List(values []uint16) ([]byte, error) {
+	if len(values) == 0 || len(values) > 0x7fff {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+	out := make([]byte, 2, 2+(len(values)*2))
+	binary.BigEndian.PutUint16(out, uint16(len(values)*2)) //nolint:gosec // count is bounded above.
+	for _, value := range values {
+		out = binary.BigEndian.AppendUint16(out, value)
+	}
+
+	return out, nil
+}
+
+func unmarshalUint16List(data []byte) ([]uint16, error) {
+	if len(data) < 4 || int(binary.BigEndian.Uint16(data)) != len(data)-2 || (len(data)-2)%2 != 0 {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+	values := make([]uint16, 0, (len(data)-2)/2)
+	for offset := 2; offset < len(data); offset += 2 {
+		values = append(values, binary.BigEndian.Uint16(data[offset:]))
+	}
+
+	return values, nil
+}
+
+func requireEmptyPayload(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/contextual_test.go
+++ b/pkg/protocol/extension/contextual_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextualPayloads(t *testing.T) {
+	tests := []struct {
+		name  string
+		value Value
+		out   interface {
+			Value
+			PayloadUnmarshaller
+		}
+	}{
+		{name: "server name offer", value: ServerNameOffer{ServerName: "example.com"}, out: &ServerNameOffer{}},
+		{name: "server name ack", value: ServerNameAck{}, out: &ServerNameAck{}},
+		{name: "alpn offer", value: ALPNOffer{Protocols: []string{"h2", "http/1.1"}}, out: &ALPNOffer{}},
+		{name: "alpn selection", value: ALPNSelection{Protocol: "h2"}, out: &ALPNSelection{}},
+		{
+			name: "srtp offer",
+			value: SRTPOffer{
+				ProtectionProfiles:  []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80, SRTP_AEAD_AES_128_GCM},
+				MasterKeyIdentifier: []byte{1, 2},
+			},
+			out: &SRTPOffer{},
+		},
+		{
+			name: "srtp selection",
+			value: SRTPSelection{
+				ProtectionProfile:   SRTP_AES128_CM_HMAC_SHA1_80,
+				MasterKeyIdentifier: []byte{3},
+			},
+			out: &SRTPSelection{},
+		},
+		{
+			name:  "supported groups preserve unknown",
+			value: SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519, elliptic.Curve(0xfafa)}},
+			out:   &SupportedGroups{},
+		},
+		{
+			name:  "signature algorithms preserve unknown",
+			value: SignatureAlgorithms{Schemes: []uint16{0x0403, 0xfafa}},
+			out:   &SignatureAlgorithms{},
+		},
+		{
+			name:  "certificate signature algorithms",
+			value: CertificateSignatureAlgorithms{Schemes: []uint16{0x0804}},
+			out:   &CertificateSignatureAlgorithms{},
+		},
+		{name: "connection id", value: ConnectionID{CID: []byte{4, 5, 6}}, out: &ConnectionID{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := test.value.MarshalData()
+			require.NoError(t, err)
+			require.NoError(t, test.out.UnmarshalData(data))
+
+			roundTrip, err := test.out.MarshalData()
+			require.NoError(t, err)
+			assert.Equal(t, data, roundTrip)
+		})
+	}
+}
+
+func TestContextualFormValidation(t *testing.T) {
+	assert.ErrorIs(t, (&ServerNameAck{}).UnmarshalData([]byte{0}), dtlserrors.ErrLengthMismatch)
+	assert.ErrorIs(t, (&ServerNameOffer{}).UnmarshalData(nil), dtlserrors.ErrInvalidSNIFormat)
+	assert.ErrorIs(t, (&ALPNSelection{}).UnmarshalData([]byte{0, 4, 1, 'a', 1, 'b'}), ErrALPNInvalidFormat)
+	assert.ErrorIs(t, (&SRTPSelection{}).UnmarshalData([]byte{0, 4, 0, 1, 0, 2, 0}), dtlserrors.ErrLengthMismatch)
+	assert.ErrorIs(t, (&SupportedGroups{}).UnmarshalData([]byte{0, 1, 0}), dtlserrors.ErrLengthMismatch)
+}
+
+func FuzzContextualPayloadUnmarshal(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0, 0})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_ = (&ServerNameOffer{}).UnmarshalData(data)
+		_ = (&ServerNameAck{}).UnmarshalData(data)
+		_ = (&ALPNOffer{}).UnmarshalData(data)
+		_ = (&ALPNSelection{}).UnmarshalData(data)
+		_ = (&SRTPOffer{}).UnmarshalData(data)
+		_ = (&SRTPSelection{}).UnmarshalData(data)
+		_ = (&SupportedGroups{}).UnmarshalData(data)
+		_ = (&SignatureAlgorithms{}).UnmarshalData(data)
+		_ = (&CertificateSignatureAlgorithms{}).UnmarshalData(data)
+		_ = (&ConnectionID{}).UnmarshalData(data)
+	})
+}

--- a/pkg/protocol/extension/dtls12/extended_master_secret.go
+++ b/pkg/protocol/extension/dtls12/extended_master_secret.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls12
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// ExtendedMasterSecret represents the presence of the empty
+// extended_master_secret extension.
+type ExtendedMasterSecret struct{}
+
+// ExtensionType returns the IANA extension type.
+func (ExtendedMasterSecret) ExtensionType() extension.Type {
+	return extension.TypeExtendedMasterSecret
+}
+
+// MarshalData encodes extension_data.
+func (ExtendedMasterSecret) MarshalData() ([]byte, error) { return []byte{}, nil }
+
+// UnmarshalData decodes extension_data.
+func (*ExtendedMasterSecret) UnmarshalData(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls12/extensions_test.go
+++ b/pkg/protocol/extension/dtls12/extensions_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls12
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionPayloads(t *testing.T) {
+	tests := []struct {
+		name  string
+		value extension.Value
+		wire  []byte
+		out   extension.PayloadUnmarshaller
+	}{
+		{
+			name: "point formats",
+			value: SupportedPointFormats{PointFormats: []elliptic.CurvePointFormat{
+				elliptic.CurvePointFormatUncompressed,
+			}},
+			wire: []byte{0x01, 0x00},
+			out:  &SupportedPointFormats{},
+		},
+		{name: "extended master secret", value: ExtendedMasterSecret{}, wire: []byte{}, out: &ExtendedMasterSecret{}},
+		{
+			name:  "renegotiation info",
+			value: RenegotiationInfo{RenegotiatedConnection: 7},
+			wire:  []byte{7},
+			out:   &RenegotiationInfo{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := test.value.MarshalData()
+			require.NoError(t, err)
+			assert.Equal(t, test.wire, data)
+			require.NoError(t, test.out.UnmarshalData(data))
+		})
+	}
+}
+
+func TestExtensionPayloadErrors(t *testing.T) {
+	assert.ErrorIs(t, (&SupportedPointFormats{}).UnmarshalData(nil), dtlserrors.ErrBufferTooSmall)
+	assert.ErrorIs(t, (&SupportedPointFormats{}).UnmarshalData([]byte{2, 0}), dtlserrors.ErrLengthMismatch)
+	assert.ErrorIs(t, (&ExtendedMasterSecret{}).UnmarshalData([]byte{0}), dtlserrors.ErrLengthMismatch)
+	assert.ErrorIs(t, (&RenegotiationInfo{}).UnmarshalData(nil), dtlserrors.ErrLengthMismatch)
+
+	_, err := (SupportedPointFormats{PointFormats: make([]elliptic.CurvePointFormat, 256)}).MarshalData()
+	assert.ErrorIs(t, err, dtlserrors.ErrPointFormatsTooLarge)
+}
+
+func FuzzPayloadUnmarshal(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1, 0})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_ = (&SupportedPointFormats{}).UnmarshalData(data)
+		_ = (&ExtendedMasterSecret{}).UnmarshalData(data)
+		_ = (&RenegotiationInfo{}).UnmarshalData(data)
+	})
+}

--- a/pkg/protocol/extension/dtls12/renegotiation_info.go
+++ b/pkg/protocol/extension/dtls12/renegotiation_info.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls12
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// RenegotiationInfo communicates secure renegotiation support.
+type RenegotiationInfo struct {
+	RenegotiatedConnection uint8
+}
+
+// ExtensionType returns the IANA extension type.
+func (RenegotiationInfo) ExtensionType() extension.Type {
+	return extension.TypeRenegotiationInfo
+}
+
+// MarshalData encodes extension_data.
+func (r RenegotiationInfo) MarshalData() ([]byte, error) {
+	return []byte{r.RenegotiatedConnection}, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (r *RenegotiationInfo) UnmarshalData(data []byte) error {
+	if len(data) != 1 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	r.RenegotiatedConnection = data[0]
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls12/supported_point_formats.go
+++ b/pkg/protocol/extension/dtls12/supported_point_formats.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package dtls12 implements extension payloads specific to DTLS 1.2.
+package dtls12
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// SupportedPointFormats is the ec_point_formats extension payload.
+type SupportedPointFormats struct {
+	PointFormats []elliptic.CurvePointFormat
+}
+
+// ExtensionType returns the IANA extension type.
+func (SupportedPointFormats) ExtensionType() extension.Type {
+	return extension.TypeSupportedPointFormats
+}
+
+// MarshalData encodes extension_data.
+func (s SupportedPointFormats) MarshalData() ([]byte, error) {
+	if len(s.PointFormats) > 255 {
+		return nil, dtlserrors.ErrPointFormatsTooLarge
+	}
+
+	out := make([]byte, 1, 1+len(s.PointFormats))
+	out[0] = byte(len(s.PointFormats)) //nolint:gosec // length is bounded above.
+	for _, format := range s.PointFormats {
+		out = append(out, byte(format))
+	}
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (s *SupportedPointFormats) UnmarshalData(data []byte) error {
+	if len(data) == 0 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+	if int(data[0])+1 != len(data) {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	s.PointFormats = s.PointFormats[:0]
+	for _, value := range data[1:] {
+		format := elliptic.CurvePointFormat(value)
+		if format == elliptic.CurvePointFormatUncompressed {
+			s.PointFormats = append(s.PointFormats, format)
+		}
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/certificate_authorities.go
+++ b/pkg/protocol/extension/dtls13/certificate_authorities.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// CertificateAuthorities is the certificate_authorities payload.
+type CertificateAuthorities struct {
+	Authorities [][]byte
+}
+
+// ExtensionType returns the IANA extension type.
+func (CertificateAuthorities) ExtensionType() extension.Type {
+	return extension.TypeCertificateAuthorities
+}
+
+// MarshalData encodes extension_data.
+func (c CertificateAuthorities) MarshalData() ([]byte, error) {
+	if len(c.Authorities) == 0 {
+		return nil, dtlserrors.ErrInvalidCertificateAuthFormat
+	}
+
+	authorities := make([]byte, 0)
+	for _, authority := range c.Authorities {
+		if len(authority) == 0 || len(authority) > 0xffff || len(authorities) > 0xffff-2-len(authority) {
+			return nil, dtlserrors.ErrInvalidCertificateAuthFormat
+		}
+		authorities = binary.BigEndian.AppendUint16(authorities, uint16(len(authority))) //nolint:gosec // bounded above.
+		authorities = append(authorities, authority...)
+	}
+
+	out := make([]byte, 2, 2+len(authorities))
+	binary.BigEndian.PutUint16(out, uint16(len(authorities))) //nolint:gosec // bounded above.
+	out = append(out, authorities...)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (c *CertificateAuthorities) UnmarshalData(data []byte) error {
+	if len(data) < 2 {
+		return dtlserrors.ErrInvalidCertificateAuthFormat
+	}
+	length := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if length == 0 || length != len(data) {
+		return dtlserrors.ErrInvalidCertificateAuthFormat
+	}
+
+	authorities := make([][]byte, 0)
+	for len(data) > 0 {
+		if len(data) < 2 {
+			return dtlserrors.ErrInvalidCertificateAuthFormat
+		}
+		authorityLen := int(binary.BigEndian.Uint16(data))
+		data = data[2:]
+		if authorityLen == 0 || authorityLen > len(data) {
+			return dtlserrors.ErrInvalidCertificateAuthFormat
+		}
+		authorities = append(authorities, bytes.Clone(data[:authorityLen]))
+		data = data[authorityLen:]
+	}
+
+	c.Authorities = authorities
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/cookie.go
+++ b/pkg/protocol/extension/dtls13/cookie.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+const maxCookieSize = 0xffff - 2
+
+// Cookie is the cookie extension payload used in HelloRetryRequest and the
+// subsequent ClientHello.
+type Cookie struct {
+	Cookie []byte
+}
+
+// ExtensionType returns the IANA extension type.
+func (Cookie) ExtensionType() extension.Type { return extension.TypeCookie }
+
+// MarshalData encodes extension_data.
+func (c Cookie) MarshalData() ([]byte, error) {
+	if len(c.Cookie) == 0 || len(c.Cookie) > maxCookieSize {
+		return nil, dtlserrors.ErrCookieExtFormat
+	}
+
+	out := make([]byte, 2, 2+len(c.Cookie))
+	binary.BigEndian.PutUint16(out, uint16(len(c.Cookie))) //nolint:gosec // length is bounded above.
+	out = append(out, c.Cookie...)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (c *Cookie) UnmarshalData(data []byte) error {
+	if len(data) < 2 {
+		return dtlserrors.ErrCookieExtFormat
+	}
+
+	length := int(binary.BigEndian.Uint16(data))
+	if length == 0 || length > maxCookieSize || length != len(data)-2 {
+		return dtlserrors.ErrCookieExtFormat
+	}
+
+	c.Cookie = bytes.Clone(data[2:])
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/early_data.go
+++ b/pkg/protocol/extension/dtls13/early_data.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// EarlyData is the empty early_data payload in ClientHello and
+// EncryptedExtensions.
+type EarlyData struct{}
+
+// ExtensionType returns the IANA extension type.
+func (EarlyData) ExtensionType() extension.Type { return extension.TypeEarlyData }
+
+// MarshalData encodes extension_data.
+func (EarlyData) MarshalData() ([]byte, error) { return []byte{}, nil }
+
+// UnmarshalData decodes extension_data.
+func (*EarlyData) UnmarshalData(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrEarlyDataIndicationFormat
+	}
+
+	return nil
+}
+
+// MaxEarlyData is the NewSessionTicket early_data payload.
+type MaxEarlyData struct {
+	Size uint32
+}
+
+// ExtensionType returns the IANA extension type.
+func (MaxEarlyData) ExtensionType() extension.Type { return extension.TypeEarlyData }
+
+// MarshalData encodes extension_data.
+func (m MaxEarlyData) MarshalData() ([]byte, error) {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, m.Size)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (m *MaxEarlyData) UnmarshalData(data []byte) error {
+	if len(data) != 4 {
+		return dtlserrors.ErrEarlyDataIndicationFormat
+	}
+	m.Size = binary.BigEndian.Uint32(data)
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/extensions_test.go
+++ b/pkg/protocol/extension/dtls13/extensions_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionPayloadRoundTrips(t *testing.T) {
+	binder := make([]byte, minPSKBinderSize)
+	tests := []struct {
+		name  string
+		value extension.Value
+		out   interface {
+			extension.Value
+			extension.PayloadUnmarshaller
+		}
+	}{
+		{
+			name: "offered versions preserve unknown",
+			value: OfferedVersions{Versions: []protocol.Version{
+				protocol.Version1_3,
+				{Major: 0xfa, Minor: 0xfa},
+			}},
+			out: &OfferedVersions{},
+		},
+		{name: "selected version", value: SelectedVersion{Version: protocol.Version1_3}, out: &SelectedVersion{}},
+		{name: "cookie", value: Cookie{Cookie: []byte("cookie")}, out: &Cookie{}},
+		{name: "empty client key share", value: ClientKeyShare{Shares: []KeyShareEntry{}}, out: &ClientKeyShare{}},
+		{
+			name: "client key share preserves unknown group",
+			value: ClientKeyShare{Shares: []KeyShareEntry{
+				{Group: elliptic.X25519, KeyExchange: []byte{1, 2}},
+				{Group: elliptic.Curve(0xfafa), KeyExchange: []byte{3}},
+			}},
+			out: &ClientKeyShare{},
+		},
+		{
+			name:  "server key share",
+			value: ServerKeyShare{Share: KeyShareEntry{Group: elliptic.X25519, KeyExchange: []byte{4, 5}}},
+			out:   &ServerKeyShare{},
+		},
+		{
+			name:  "retry key share preserves unknown group",
+			value: RetryKeyShare{SelectedGroup: elliptic.Curve(0xfafa)},
+			out:   &RetryKeyShare{},
+		},
+		{
+			name: "offered psks",
+			value: OfferedPSKs{
+				Identities: []PSKIdentity{{Identity: []byte("identity"), ObfuscatedTicketAge: 42}},
+				Binders:    []PSKBinder{binder},
+			},
+			out: &OfferedPSKs{},
+		},
+		{name: "selected psk zero", value: SelectedPSK{Identity: 0}, out: &SelectedPSK{}},
+		{
+			name:  "psk modes preserve unknown",
+			value: PSKKeyExchangeModes{Modes: []PSKKeyExchangeMode{PSKDHEKE, PSKKeyExchangeMode(0xfa)}},
+			out:   &PSKKeyExchangeModes{},
+		},
+		{name: "early data", value: EarlyData{}, out: &EarlyData{}},
+		{name: "max early data", value: MaxEarlyData{Size: 4096}, out: &MaxEarlyData{}},
+		{
+			name:  "certificate authorities",
+			value: CertificateAuthorities{Authorities: [][]byte{[]byte("ca1"), []byte("ca2")}},
+			out:   &CertificateAuthorities{},
+		},
+		{
+			name: "oid filters",
+			value: OIDFilters{Filters: []OIDFilter{
+				{OID: []byte{1, 2, 3}, Values: []byte{4, 5}},
+			}},
+			out: &OIDFilters{},
+		},
+		{name: "post handshake auth", value: PostHandshakeAuth{}, out: &PostHandshakeAuth{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := test.value.MarshalData()
+			require.NoError(t, err)
+			require.NoError(t, test.out.UnmarshalData(data))
+			roundTrip, err := test.out.MarshalData()
+			require.NoError(t, err)
+			assert.Equal(t, data, roundTrip)
+			assert.Equal(t, test.value.ExtensionType(), test.out.ExtensionType())
+		})
+	}
+}
+
+func TestContextSpecificFormsRejectOtherPayloads(t *testing.T) {
+	clientVersions, err := (OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}}).MarshalData()
+	require.NoError(t, err)
+	assert.ErrorIs(t, (&SelectedVersion{}).UnmarshalData(clientVersions), dtlserrors.ErrInvalidSupportedVersionsFormat)
+
+	serverShare, err := (ServerKeyShare{
+		Share: KeyShareEntry{Group: elliptic.X25519, KeyExchange: []byte{1}},
+	}).MarshalData()
+	require.NoError(t, err)
+	assert.ErrorIs(t, (&RetryKeyShare{}).UnmarshalData(serverShare), dtlserrors.ErrInvalidKeyShareFormat)
+
+	selectedPSK, err := (SelectedPSK{Identity: 0}).MarshalData()
+	require.NoError(t, err)
+	assert.ErrorIs(t, (&OfferedPSKs{}).UnmarshalData(selectedPSK), dtlserrors.ErrPreSharedKeyFormat)
+
+	maxEarlyData, err := (MaxEarlyData{Size: 1}).MarshalData()
+	require.NoError(t, err)
+	assert.ErrorIs(t, (&EarlyData{}).UnmarshalData(maxEarlyData), dtlserrors.ErrEarlyDataIndicationFormat)
+}
+
+func TestKeyShareDuplicateGroup(t *testing.T) {
+	_, err := (ClientKeyShare{Shares: []KeyShareEntry{
+		{Group: elliptic.X25519, KeyExchange: []byte{1}},
+		{Group: elliptic.X25519, KeyExchange: []byte{2}},
+	}}).MarshalData()
+	assert.ErrorIs(t, err, dtlserrors.ErrDuplicateKeyShare)
+}
+
+func FuzzClientKeyShareUnmarshalData(f *testing.F) {
+	f.Add([]byte{0, 0})
+	f.Add([]byte{0, 5, 0, 29, 0, 1, 1})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var value ClientKeyShare
+		if err := value.UnmarshalData(data); err != nil {
+			return
+		}
+		encoded, err := value.MarshalData()
+		require.NoError(t, err)
+		assert.Equal(t, data, encoded)
+	})
+}
+
+func FuzzPayloadUnmarshal(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0, 0})
+	f.Add([]byte{0, 2, 0xfe, 0xfc})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_ = (&OfferedVersions{}).UnmarshalData(data)
+		_ = (&SelectedVersion{}).UnmarshalData(data)
+		_ = (&Cookie{}).UnmarshalData(data)
+		_ = (&ClientKeyShare{}).UnmarshalData(data)
+		_ = (&ServerKeyShare{}).UnmarshalData(data)
+		_ = (&RetryKeyShare{}).UnmarshalData(data)
+		_ = (&OfferedPSKs{}).UnmarshalData(data)
+		_ = (&SelectedPSK{}).UnmarshalData(data)
+		_ = (&PSKKeyExchangeModes{}).UnmarshalData(data)
+		_ = (&EarlyData{}).UnmarshalData(data)
+		_ = (&MaxEarlyData{}).UnmarshalData(data)
+		_ = (&CertificateAuthorities{}).UnmarshalData(data)
+		_ = (&OIDFilters{}).UnmarshalData(data)
+		_ = (&PostHandshakeAuth{}).UnmarshalData(data)
+	})
+}

--- a/pkg/protocol/extension/dtls13/key_share.go
+++ b/pkg/protocol/extension/dtls13/key_share.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// KeyShareEntry contains the encoded key exchange for a named group.
+type KeyShareEntry struct {
+	Group       elliptic.Curve
+	KeyExchange []byte
+}
+
+// ClientKeyShare is the ClientHello key_share payload.
+type ClientKeyShare struct {
+	Shares []KeyShareEntry
+}
+
+// ExtensionType returns the IANA extension type.
+func (ClientKeyShare) ExtensionType() extension.Type { return extension.TypeKeyShare }
+
+// MarshalData encodes extension_data.
+func (c ClientKeyShare) MarshalData() ([]byte, error) {
+	entries, err := marshalKeyShareEntries(c.Shares, true)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]byte, 2, 2+len(entries))
+	binary.BigEndian.PutUint16(out, uint16(len(entries))) //nolint:gosec // marshalKeyShareEntries bounds the length.
+	out = append(out, entries...)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (c *ClientKeyShare) UnmarshalData(data []byte) error {
+	if len(data) < 2 || int(binary.BigEndian.Uint16(data)) != len(data)-2 {
+		return dtlserrors.ErrInvalidKeyShareFormat
+	}
+
+	shares, err := unmarshalKeyShareEntries(data[2:])
+	if err != nil {
+		return err
+	}
+	c.Shares = shares
+
+	return nil
+}
+
+// ServerKeyShare is the ServerHello key_share payload.
+type ServerKeyShare struct {
+	Share KeyShareEntry
+}
+
+// ExtensionType returns the IANA extension type.
+func (ServerKeyShare) ExtensionType() extension.Type { return extension.TypeKeyShare }
+
+// MarshalData encodes extension_data.
+func (s ServerKeyShare) MarshalData() ([]byte, error) {
+	return marshalKeyShareEntry(s.Share)
+}
+
+// UnmarshalData decodes extension_data.
+func (s *ServerKeyShare) UnmarshalData(data []byte) error {
+	shares, err := unmarshalKeyShareEntries(data)
+	if err != nil || len(shares) != 1 {
+		return dtlserrors.ErrInvalidKeyShareFormat
+	}
+	s.Share = shares[0]
+
+	return nil
+}
+
+// RetryKeyShare is the HelloRetryRequest key_share payload.
+type RetryKeyShare struct {
+	SelectedGroup elliptic.Curve
+}
+
+// ExtensionType returns the IANA extension type.
+func (RetryKeyShare) ExtensionType() extension.Type { return extension.TypeKeyShare }
+
+// MarshalData encodes extension_data.
+func (r RetryKeyShare) MarshalData() ([]byte, error) {
+	out := make([]byte, 2)
+	binary.BigEndian.PutUint16(out, uint16(r.SelectedGroup))
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data without filtering unknown groups.
+func (r *RetryKeyShare) UnmarshalData(data []byte) error {
+	if len(data) != 2 {
+		return dtlserrors.ErrInvalidKeyShareFormat
+	}
+	r.SelectedGroup = elliptic.Curve(binary.BigEndian.Uint16(data))
+
+	return nil
+}
+
+func marshalKeyShareEntries(entries []KeyShareEntry, allowEmpty bool) ([]byte, error) {
+	if !allowEmpty && len(entries) == 0 {
+		return nil, dtlserrors.ErrInvalidKeyShareFormat
+	}
+
+	out := make([]byte, 0)
+	seen := make(map[elliptic.Curve]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, ok := seen[entry.Group]; ok {
+			return nil, dtlserrors.ErrDuplicateKeyShare
+		}
+		seen[entry.Group] = struct{}{}
+
+		encoded, err := marshalKeyShareEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) > 0xffff-len(encoded) {
+			return nil, dtlserrors.ErrInvalidKeyShareFormat
+		}
+		out = append(out, encoded...)
+	}
+
+	return out, nil
+}
+
+func marshalKeyShareEntry(entry KeyShareEntry) ([]byte, error) {
+	if len(entry.KeyExchange) == 0 || len(entry.KeyExchange) > 0xffff {
+		return nil, dtlserrors.ErrInvalidKeyShareFormat
+	}
+
+	out := make([]byte, 4, 4+len(entry.KeyExchange))
+	binary.BigEndian.PutUint16(out, uint16(entry.Group))
+	binary.BigEndian.PutUint16(out[2:], uint16(len(entry.KeyExchange))) //nolint:gosec // length is bounded above.
+	out = append(out, entry.KeyExchange...)
+
+	return out, nil
+}
+
+func unmarshalKeyShareEntries(data []byte) ([]KeyShareEntry, error) {
+	shares := make([]KeyShareEntry, 0)
+	seen := map[elliptic.Curve]struct{}{}
+	for len(data) > 0 {
+		if len(data) < 4 {
+			return nil, dtlserrors.ErrInvalidKeyShareFormat
+		}
+		group := elliptic.Curve(binary.BigEndian.Uint16(data))
+		length := int(binary.BigEndian.Uint16(data[2:]))
+		data = data[4:]
+		if length == 0 || length > len(data) {
+			return nil, dtlserrors.ErrInvalidKeyShareFormat
+		}
+		if _, ok := seen[group]; ok {
+			return nil, dtlserrors.ErrDuplicateKeyShare
+		}
+		seen[group] = struct{}{}
+		shares = append(shares, KeyShareEntry{Group: group, KeyExchange: bytes.Clone(data[:length])})
+		data = data[length:]
+	}
+
+	return shares, nil
+}

--- a/pkg/protocol/extension/dtls13/oid_filters.go
+++ b/pkg/protocol/extension/dtls13/oid_filters.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// OIDFilter contains one certificate extension OID and its requested values.
+type OIDFilter struct {
+	OID    []byte
+	Values []byte
+}
+
+// OIDFilters is the oid_filters payload.
+type OIDFilters struct {
+	Filters []OIDFilter
+}
+
+// ExtensionType returns the IANA extension type.
+func (OIDFilters) ExtensionType() extension.Type { return extension.TypeOIDFilters }
+
+// MarshalData encodes extension_data.
+func (o OIDFilters) MarshalData() ([]byte, error) {
+	filters := make([]byte, 0)
+	seen := map[string]struct{}{}
+	for _, filter := range o.Filters {
+		if len(filter.OID) == 0 || len(filter.OID) > 255 {
+			return nil, dtlserrors.ErrEmptyOIDFilter
+		}
+		if _, ok := seen[string(filter.OID)]; ok {
+			return nil, dtlserrors.ErrDuplicateOID
+		}
+		seen[string(filter.OID)] = struct{}{}
+		if len(filter.Values) > 0xffff || len(filters) > 0xffff-3-len(filter.OID)-len(filter.Values) {
+			return nil, dtlserrors.ErrOIDFiltersFormat
+		}
+
+		filters = append(filters, byte(len(filter.OID))) //nolint:gosec // bounded above.
+		filters = append(filters, filter.OID...)
+		filters = binary.BigEndian.AppendUint16(filters, uint16(len(filter.Values))) //nolint:gosec // bounded above.
+		filters = append(filters, filter.Values...)
+	}
+
+	out := make([]byte, 2, 2+len(filters))
+	binary.BigEndian.PutUint16(out, uint16(len(filters))) //nolint:gosec // bounded above.
+	out = append(out, filters...)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (o *OIDFilters) UnmarshalData(data []byte) error { //nolint:cyclop
+	if len(data) < 2 {
+		return dtlserrors.ErrLengthMismatch
+	}
+	length := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if length != len(data) {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	filters := make([]OIDFilter, 0)
+	seen := map[string]struct{}{}
+	for len(data) > 0 {
+		oidLen := int(data[0])
+		data = data[1:]
+		if oidLen == 0 || oidLen > len(data) {
+			return dtlserrors.ErrOIDFiltersFormat
+		}
+		oid := bytes.Clone(data[:oidLen])
+		data = data[oidLen:]
+		if _, ok := seen[string(oid)]; ok {
+			return dtlserrors.ErrDuplicateOID
+		}
+		seen[string(oid)] = struct{}{}
+
+		if len(data) < 2 {
+			return dtlserrors.ErrOIDFiltersFormat
+		}
+		valuesLen := int(binary.BigEndian.Uint16(data))
+		data = data[2:]
+		if valuesLen > len(data) {
+			return dtlserrors.ErrOIDFiltersFormat
+		}
+		filters = append(filters, OIDFilter{OID: oid, Values: bytes.Clone(data[:valuesLen])})
+		data = data[valuesLen:]
+	}
+
+	o.Filters = filters
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/post_handshake_auth.go
+++ b/pkg/protocol/extension/dtls13/post_handshake_auth.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// PostHandshakeAuth is the empty post_handshake_auth payload.
+type PostHandshakeAuth struct{}
+
+// ExtensionType returns the IANA extension type.
+func (PostHandshakeAuth) ExtensionType() extension.Type {
+	return extension.TypePostHandshakeAuth
+}
+
+// MarshalData encodes extension_data.
+func (PostHandshakeAuth) MarshalData() ([]byte, error) { return []byte{}, nil }
+
+// UnmarshalData decodes extension_data.
+func (*PostHandshakeAuth) UnmarshalData(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/pre_shared_key.go
+++ b/pkg/protocol/extension/dtls13/pre_shared_key.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+const minPSKBinderSize = 32
+
+// PSKIdentity identifies a pre-shared key offered by the client.
+type PSKIdentity struct {
+	Identity            []byte
+	ObfuscatedTicketAge uint32
+}
+
+// PSKBinder is the binder associated with a PSK identity.
+type PSKBinder []byte
+
+// OfferedPSKs is the ClientHello pre_shared_key payload.
+type OfferedPSKs struct {
+	Identities []PSKIdentity
+	Binders    []PSKBinder
+}
+
+// ExtensionType returns the IANA extension type.
+func (OfferedPSKs) ExtensionType() extension.Type { return extension.TypePreSharedKey }
+
+// MarshalData encodes extension_data.
+func (o OfferedPSKs) MarshalData() ([]byte, error) { //nolint:cyclop
+	if len(o.Identities) == 0 || len(o.Identities) != len(o.Binders) {
+		return nil, dtlserrors.ErrPreSharedKeyFormat
+	}
+
+	identities := make([]byte, 0)
+	for _, identity := range o.Identities {
+		if len(identity.Identity) == 0 || len(identity.Identity) > 0xffff ||
+			len(identities) > 0xffff-6-len(identity.Identity) {
+			return nil, dtlserrors.ErrPreSharedKeyFormat
+		}
+		//nolint:gosec // Identity length is bounded above.
+		identities = binary.BigEndian.AppendUint16(identities, uint16(len(identity.Identity)))
+		identities = append(identities, identity.Identity...)
+		identities = binary.BigEndian.AppendUint32(identities, identity.ObfuscatedTicketAge)
+	}
+
+	binders := make([]byte, 0)
+	for _, binder := range o.Binders {
+		if len(binder) < minPSKBinderSize || len(binder) > 255 || len(binders) > 0xffff-1-len(binder) {
+			return nil, dtlserrors.ErrPreSharedKeyFormat
+		}
+		binders = append(binders, byte(len(binder))) //nolint:gosec // bounded above.
+		binders = append(binders, binder...)
+	}
+
+	out := make([]byte, 0, 4+len(identities)+len(binders))
+	out = binary.BigEndian.AppendUint16(out, uint16(len(identities))) //nolint:gosec // bounded above.
+	out = append(out, identities...)
+	out = binary.BigEndian.AppendUint16(out, uint16(len(binders))) //nolint:gosec // bounded above.
+	out = append(out, binders...)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (o *OfferedPSKs) UnmarshalData(data []byte) error { //nolint:cyclop
+	if len(data) < 2 {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+
+	identitiesLen := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if identitiesLen == 0 || identitiesLen > len(data) {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+	identitiesData := data[:identitiesLen]
+	data = data[identitiesLen:]
+
+	identities := make([]PSKIdentity, 0)
+	for len(identitiesData) > 0 {
+		if len(identitiesData) < 2 {
+			return dtlserrors.ErrPreSharedKeyFormat
+		}
+		identityLen := int(binary.BigEndian.Uint16(identitiesData))
+		identitiesData = identitiesData[2:]
+		if identityLen == 0 || len(identitiesData) < identityLen+4 {
+			return dtlserrors.ErrPreSharedKeyFormat
+		}
+		identities = append(identities, PSKIdentity{
+			Identity:            bytes.Clone(identitiesData[:identityLen]),
+			ObfuscatedTicketAge: binary.BigEndian.Uint32(identitiesData[identityLen:]),
+		})
+		identitiesData = identitiesData[identityLen+4:]
+	}
+
+	if len(data) < 2 {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+	bindersLen := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if bindersLen == 0 || bindersLen != len(data) {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+
+	binders := make([]PSKBinder, 0)
+	for len(data) > 0 {
+		binderLen := int(data[0])
+		data = data[1:]
+		if binderLen < minPSKBinderSize || binderLen > len(data) {
+			return dtlserrors.ErrPreSharedKeyFormat
+		}
+		binders = append(binders, PSKBinder(bytes.Clone(data[:binderLen])))
+		data = data[binderLen:]
+	}
+	if len(identities) != len(binders) {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+
+	o.Identities = identities
+	o.Binders = binders
+
+	return nil
+}
+
+// SelectedPSK is the ServerHello pre_shared_key payload.
+type SelectedPSK struct {
+	Identity uint16
+}
+
+// ExtensionType returns the IANA extension type.
+func (SelectedPSK) ExtensionType() extension.Type { return extension.TypePreSharedKey }
+
+// MarshalData encodes extension_data.
+func (s SelectedPSK) MarshalData() ([]byte, error) {
+	out := make([]byte, 2)
+	binary.BigEndian.PutUint16(out, s.Identity)
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (s *SelectedPSK) UnmarshalData(data []byte) error {
+	if len(data) != 2 {
+		return dtlserrors.ErrPreSharedKeyFormat
+	}
+	s.Identity = binary.BigEndian.Uint16(data)
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/psk_key_exchange_modes.go
+++ b/pkg/protocol/extension/dtls13/psk_key_exchange_modes.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls13
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// PSKKeyExchangeMode is a value in the PskKeyExchangeMode registry.
+type PSKKeyExchangeMode uint8
+
+const (
+	PSKKE    PSKKeyExchangeMode = 0
+	PSKDHEKE PSKKeyExchangeMode = 1
+)
+
+// PSKKeyExchangeModes is the ClientHello psk_key_exchange_modes payload.
+type PSKKeyExchangeModes struct {
+	Modes []PSKKeyExchangeMode
+}
+
+// ExtensionType returns the IANA extension type.
+func (PSKKeyExchangeModes) ExtensionType() extension.Type {
+	return extension.TypePSKKeyExchangeModes
+}
+
+// MarshalData encodes extension_data.
+func (p PSKKeyExchangeModes) MarshalData() ([]byte, error) {
+	if len(p.Modes) == 0 {
+		return nil, dtlserrors.ErrNoPskKeyExchangeMode
+	}
+	if len(p.Modes) > 255 {
+		return nil, dtlserrors.ErrPskKeyExchangeModesFormat
+	}
+
+	out := make([]byte, 1, 1+len(p.Modes))
+	out[0] = byte(len(p.Modes)) //nolint:gosec // length is bounded above.
+	for _, mode := range p.Modes {
+		out = append(out, byte(mode))
+	}
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data without filtering unknown modes.
+func (p *PSKKeyExchangeModes) UnmarshalData(data []byte) error {
+	if len(data) < 2 || int(data[0]) != len(data)-1 {
+		return dtlserrors.ErrPskKeyExchangeModesFormat
+	}
+
+	p.Modes = make([]PSKKeyExchangeMode, len(data)-1)
+	for i, mode := range data[1:] {
+		p.Modes[i] = PSKKeyExchangeMode(mode)
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/dtls13/supported_versions.go
+++ b/pkg/protocol/extension/dtls13/supported_versions.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package dtls13 implements extension payloads specific to DTLS 1.3.
+package dtls13
+
+import (
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+// OfferedVersions is the ClientHello supported_versions payload.
+type OfferedVersions struct {
+	Versions []protocol.Version
+}
+
+// ExtensionType returns the IANA extension type.
+func (OfferedVersions) ExtensionType() extension.Type { return extension.TypeSupportedVersions }
+
+// MarshalData encodes extension_data.
+func (o OfferedVersions) MarshalData() ([]byte, error) {
+	length := len(o.Versions) * 2
+	if length < 2 || length > 254 {
+		return nil, dtlserrors.ErrInvalidSupportedVersionsFormat
+	}
+
+	out := make([]byte, 1, 1+length)
+	out[0] = byte(length) //nolint:gosec // length is bounded above.
+	for _, version := range o.Versions {
+		out = append(out, version.Major, version.Minor)
+	}
+
+	return out, nil
+}
+
+// UnmarshalData decodes extension_data without filtering unknown versions.
+func (o *OfferedVersions) UnmarshalData(data []byte) error {
+	if len(data) < 3 || int(data[0]) != len(data)-1 || data[0]%2 != 0 {
+		return dtlserrors.ErrInvalidSupportedVersionsFormat
+	}
+
+	o.Versions = o.Versions[:0]
+	for offset := 1; offset < len(data); offset += 2 {
+		o.Versions = append(o.Versions, protocol.Version{Major: data[offset], Minor: data[offset+1]})
+	}
+
+	return nil
+}
+
+// SelectedVersion is the ServerHello and HelloRetryRequest
+// supported_versions payload.
+type SelectedVersion struct {
+	Version protocol.Version
+}
+
+// ExtensionType returns the IANA extension type.
+func (SelectedVersion) ExtensionType() extension.Type { return extension.TypeSupportedVersions }
+
+// MarshalData encodes extension_data.
+func (s SelectedVersion) MarshalData() ([]byte, error) {
+	return []byte{s.Version.Major, s.Version.Minor}, nil
+}
+
+// UnmarshalData decodes extension_data.
+func (s *SelectedVersion) UnmarshalData(data []byte) error {
+	if len(data) != 2 {
+		return dtlserrors.ErrInvalidSupportedVersionsFormat
+	}
+
+	s.Version = protocol.Version{Major: data[0], Minor: data[1]}
+
+	return nil
+}

--- a/pkg/protocol/extension/raw.go
+++ b/pkg/protocol/extension/raw.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+)
+
+// Type is the two-byte value assigned to a TLS extension by IANA.
+//
+// TypeValue remains available for compatibility with the existing framed
+// extension API.
+type Type = TypeValue
+
+const (
+	TypeServerName              Type = ServerNameTypeValue
+	TypeSupportedGroups         Type = SupportedEllipticCurvesTypeValue
+	TypeSupportedPointFormats   Type = SupportedPointFormatsTypeValue
+	TypeSignatureAlgorithms     Type = SupportedSignatureAlgorithmsTypeValue
+	TypeUseSRTP                 Type = UseSRTPTypeValue
+	TypeALPN                    Type = ALPNTypeValue
+	TypeExtendedMasterSecret    Type = UseExtendedMasterSecretTypeValue
+	TypePreSharedKey            Type = PreSharedKeyValue
+	TypeEarlyData               Type = EarlyDataIndicationTypeValue
+	TypeSupportedVersions       Type = SupportedVersionsTypeValue
+	TypeCookie                  Type = CookieTypeValue
+	TypePSKKeyExchangeModes     Type = PskKeyExchangeModesTypeValue
+	TypeCertificateAuthorities  Type = CertificateAuthoritiesTypeValue
+	TypeOIDFilters              Type = OIDFiltersTypeValue
+	TypePostHandshakeAuth       Type = PostHandshakeAuthTypeValue
+	TypeSignatureAlgorithmsCert Type = SignatureAlgorithmsCertTypeValue
+	TypeKeyShare                Type = KeyShareTypeValue
+	TypeConnectionID            Type = ConnectionIDTypeValue
+	TypeRenegotiationInfo       Type = RenegotiationInfoTypeValue
+)
+
+// Value is an extension payload that can be framed in an extension list.
+type Value interface {
+	ExtensionType() Type
+	MarshalData() ([]byte, error)
+}
+
+// PayloadUnmarshaller decodes extension_data without the extension header.
+type PayloadUnmarshaller interface {
+	UnmarshalData(data []byte) error
+}
+
+// Raw is a lossless representation of an extension whose payload has not
+// been decoded. Data does not include the type or length fields.
+type Raw struct {
+	Type Type
+	Data []byte
+}
+
+// ExtensionType returns the extension type.
+func (r Raw) ExtensionType() Type { return r.Type }
+
+// MarshalData returns a copy of the undecoded payload.
+func (r Raw) MarshalData() ([]byte, error) { return bytes.Clone(r.Data), nil }
+
+// UnmarshalData replaces the undecoded payload with a copy of data.
+func (r *Raw) UnmarshalData(data []byte) error {
+	r.Data = bytes.Clone(data)
+
+	return nil
+}
+
+// ParseList parses a complete uint16-length-prefixed extension list. It
+// validates framing only and preserves unknown extensions, order, and
+// duplicates for contextual processing by the caller.
+func ParseList(buf []byte) ([]Raw, error) {
+	if len(buf) < 2 {
+		return nil, dtlserrors.ErrBufferTooSmall
+	}
+
+	declaredLen := int(binary.BigEndian.Uint16(buf))
+	if declaredLen != len(buf)-2 {
+		return nil, dtlserrors.ErrLengthMismatch
+	}
+
+	values := make([]Raw, 0)
+	for offset := 2; offset < len(buf); {
+		if len(buf)-offset < 4 {
+			return nil, dtlserrors.ErrBufferTooSmall
+		}
+
+		typ := Type(binary.BigEndian.Uint16(buf[offset:]))
+		payloadLen := int(binary.BigEndian.Uint16(buf[offset+2:]))
+		offset += 4
+		if payloadLen > len(buf)-offset {
+			return nil, dtlserrors.ErrLengthMismatch
+		}
+
+		values = append(values, Raw{
+			Type: typ,
+			Data: bytes.Clone(buf[offset : offset+payloadLen]),
+		})
+		offset += payloadLen
+	}
+
+	return values, nil
+}
+
+// MarshalList frames extension payloads as a uint16-length-prefixed list.
+func MarshalList(values []Value) ([]byte, error) {
+	payloads := make([][]byte, len(values))
+	totalLen := 0
+	for i, value := range values {
+		payload, err := value.MarshalData()
+		if err != nil {
+			return nil, err
+		}
+		if len(payload) > 0xffff || totalLen > 0xffff-4-len(payload) {
+			return nil, dtlserrors.ErrInvalidExtensionsLength
+		}
+
+		payloads[i] = payload
+		totalLen += 4 + len(payload)
+	}
+
+	out := make([]byte, 2, 2+totalLen)
+	binary.BigEndian.PutUint16(out, uint16(totalLen)) //nolint:gosec // totalLen is bounded above.
+	for i, value := range values {
+		out = binary.BigEndian.AppendUint16(out, uint16(value.ExtensionType()))
+		out = binary.BigEndian.AppendUint16(out, uint16(len(payloads[i]))) //nolint:gosec // bounded above.
+		out = append(out, payloads[i]...)
+	}
+
+	return out, nil
+}
+
+// MarshalRawList frames raw extensions without decoding their payloads.
+func MarshalRawList(values []Raw) ([]byte, error) {
+	typed := make([]Value, len(values))
+	for i := range values {
+		typed[i] = values[i]
+	}
+
+	return MarshalList(typed)
+}

--- a/pkg/protocol/extension/raw_test.go
+++ b/pkg/protocol/extension/raw_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawListRoundTrip(t *testing.T) {
+	wire := []byte{
+		0x00, 0x11,
+		0xfa, 0xce, 0x00, 0x03, 0x01, 0x02, 0x03,
+		0xfa, 0xce, 0x00, 0x00,
+		0x00, 0x10, 0x00, 0x02, 0xaa, 0xbb,
+	}
+
+	values, err := ParseList(wire)
+	require.NoError(t, err)
+	require.Len(t, values, 3)
+	assert.Equal(t, Type(0xface), values[0].Type)
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, values[0].Data)
+	assert.Equal(t, Type(0xface), values[1].Type, "duplicates must be preserved")
+
+	encoded, err := MarshalRawList(values)
+	require.NoError(t, err)
+	assert.Equal(t, wire, encoded)
+}
+
+func TestParseListCopiesPayload(t *testing.T) {
+	wire := []byte{0x00, 0x05, 0x12, 0x34, 0x00, 0x01, 0xaa}
+	values, err := ParseList(wire)
+	require.NoError(t, err)
+
+	wire[6] = 0xbb
+	assert.Equal(t, []byte{0xaa}, values[0].Data)
+}
+
+func TestParseListErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		wire []byte
+		err  error
+	}{
+		{name: "missing list length", wire: []byte{0x00}, err: dtlserrors.ErrBufferTooSmall},
+		{name: "outer length", wire: []byte{0x00, 0x01}, err: dtlserrors.ErrLengthMismatch},
+		{name: "short header", wire: []byte{0x00, 0x01, 0x00}, err: dtlserrors.ErrBufferTooSmall},
+		{name: "short payload", wire: []byte{0x00, 0x04, 0x00, 0x01, 0x00, 0x01}, err: dtlserrors.ErrLengthMismatch},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseList(test.wire)
+			assert.ErrorIs(t, err, test.err)
+		})
+	}
+}
+
+func TestMarshalListBounds(t *testing.T) {
+	_, err := MarshalList([]Value{Raw{Type: 1, Data: make([]byte, 0x10000)}})
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidExtensionsLength)
+
+	_, err = MarshalList([]Value{Raw{Type: 1, Data: make([]byte, 0xffff)}})
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidExtensionsLength)
+}
+
+func FuzzParseList(f *testing.F) {
+	f.Add([]byte{0x00, 0x00})
+	f.Add([]byte{0x00, 0x04, 0xfa, 0xce, 0x00, 0x00})
+
+	f.Fuzz(func(t *testing.T, wire []byte) {
+		values, err := ParseList(wire)
+		if err != nil {
+			return
+		}
+
+		encoded, err := MarshalRawList(values)
+		require.NoError(t, err)
+		assert.Equal(t, wire, encoded)
+	})
+}


### PR DESCRIPTION
#### Description
first part of ~3 parts of #1009  
This mainly does:
1. split extension by version and just copies code around (no cleanup yet).
2. Adds Type, Raw, ParseList and MarshalList.
3. Adds new payload interfaces.
4. Splits DTLS 1.3 union types.
5. Split shared SNI, APLN and SRTP offer/responses.

I'll remove the old APIs in the final PR after I switch our code to it.
 
Relates to #1005 