### PR TITLE
Serialize DTLS 1.3 application writes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -157,14 +157,6 @@ func (c handshakeConn) CommitLocalKeyUpdate(generation *dtlsstate.TrafficGenerat
 	return c.conn.commitLocalKeyUpdate(generation)
 }
 
-func (c handshakeConn) PauseApplicationData() {
-	c.conn.pauseApplicationData()
-}
-
-func (c handshakeConn) ResumeApplicationData() {
-	c.conn.resumeApplicationData()
-}
-
 func (c handshakeConn) TakePendingACKs() []protocol.RecordNumber {
 	return c.conn.takePendingACKs()
 }
@@ -207,11 +199,10 @@ type Conn struct {
 	maximumTransmissionUnit int
 	paddingLengthGenerator  func(uint) uint
 
-	handshakeEstablished  *dtlshandshake.Establishment
-	handshakeMutex        sync.Mutex
-	handshakeDone         chan struct{}
-	writeLock             sync.Mutex
-	applicationDataResume chan struct{} // guarded by writeLock; nil while writes may proceed
+	handshakeEstablished *dtlshandshake.Establishment
+	handshakeMutex       sync.Mutex
+	handshakeDone        chan struct{}
+	writeLock            sync.Mutex
 
 	encryptedPackets []addrPkt
 
@@ -595,24 +586,30 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	defer cancel()
 
 	err := c.writeApplicationData(ctx, []*dtlsflight.Packet{
-		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &protocol.ApplicationData{
-					Data: payload,
-				},
-			},
-			ShouldWrapCID: c.state.ShouldWrapConnectionID(),
-			ShouldEncrypt: true,
-		},
+		c.newApplicationDataPacket(payload),
 	})
 	if errors.Is(err, context.Canceled) && errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
 		return len(payload), dtlserrors.ErrDeadlineExceeded
 	}
 
 	return len(payload), err
+}
+
+func (c *Conn) newApplicationDataPacket(payload []byte) *dtlsflight.Packet {
+	return &dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header: recordlayer.Header{
+				Version: protocol.Version1_2,
+			},
+			Content: &protocol.ApplicationData{
+				// The DTLS 1.3 FSM may retain this packet after Write returns on
+				// cancellation, so take ownership before queueing it.
+				Data: bytes.Clone(payload),
+			},
+		},
+		ShouldWrapCID: c.state.ShouldWrapConnectionID(),
+		ShouldEncrypt: true,
+	}
 }
 
 // KeyUpdateOptions controls a DTLS 1.3 application traffic-key update.
@@ -680,53 +677,22 @@ func (c *Conn) normalizeKeyUpdateError(ctx, operationCtx context.Context, err er
 }
 
 func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Packet) error {
-	for {
-		c.writeLock.Lock()
-		resume := c.applicationDataResume
-		if resume == nil {
-			epoch := dtlsstate.CommonState(c.state).LocalEpoch()
-			for _, pkt := range pkts {
-				pkt.Record.Header.Epoch = epoch
-			}
-			_, err := c.writePacketsWithResultLocked(ctx, pkts)
-			c.writeLock.Unlock()
-
-			return err
+	if dtlsstate.CommonState(c.state).LocalVersion.Equal(protocol.Version1_3) {
+		writer, ok := c.fsm.(dtlshandshake.ApplicationDataWriter)
+		if !ok {
+			return dtlserrors.ErrNotImplemented
 		}
-		c.writeLock.Unlock()
 
-		select {
-		case <-resume:
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-c.closed.Done():
-			return dtlserrors.ErrConnClosed
-		}
+		return writer.WriteApplicationData(ctx, pkts)
 	}
-}
 
-func (c *Conn) pauseApplicationData() {
-	// Serialize pausing with application record preparation.
-	// TODO: Replace this pause gate with unified serialization of application
-	// and post-handshake writes.
-	// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.6.3
-	// https://www.rfc-editor.org/rfc/rfc9147.html#section-4.2.1
-	// https://www.rfc-editor.org/rfc/rfc9147.html#section-8
-	//nolint:godox
-	c.writeLock.Lock()
-	defer c.writeLock.Unlock()
-	if c.applicationDataResume == nil {
-		c.applicationDataResume = make(chan struct{})
+	epoch := dtlsstate.CommonState(c.state).LocalEpoch()
+	for _, pkt := range pkts {
+		pkt.Record.Header.Epoch = epoch
 	}
-}
+	_, err := c.writePacketsWithResult(ctx, pkts)
 
-func (c *Conn) resumeApplicationData() {
-	c.writeLock.Lock()
-	defer c.writeLock.Unlock()
-	if c.applicationDataResume != nil {
-		close(c.applicationDataResume)
-		c.applicationDataResume = nil
-	}
+	return err
 }
 
 // Close closes the connection.

--- a/conn_test.go
+++ b/conn_test.go
@@ -179,6 +179,17 @@ func TestReadWriteDeadline(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+func TestApplicationDataPacketOwnsPayload(t *testing.T) {
+	conn := &Conn{state: dtlsstate.NewActive(true)}
+	payload := []byte("application data")
+	packet := conn.newApplicationDataPacket(payload)
+	payload[0] = 'X'
+
+	applicationData, ok := packet.Record.Content.(*protocol.ApplicationData)
+	require.True(t, ok)
+	assert.Equal(t, []byte("application data"), applicationData.Data)
+}
+
 func TestSequenceNumberOverflow(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(5 * time.Second)
@@ -3868,6 +3879,23 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	n, err = client.Read(buf)
 	require.NoError(t, err)
 	assert.Equal(t, serverPayload, buf[:n])
+
+	require.NoError(t, client.UpdateKeys(ctx, KeyUpdateOptions{RequestPeerUpdate: true}))
+	updatedClientPayload := []byte("client to server after KeyUpdate")
+	n, err = client.Write(updatedClientPayload)
+	require.NoError(t, err)
+	require.Equal(t, len(updatedClientPayload), n)
+	n, err = server.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, updatedClientPayload, buf[:n])
+
+	updatedServerPayload := []byte("server to client after KeyUpdate")
+	n, err = server.Write(updatedServerPayload)
+	require.NoError(t, err)
+	require.Equal(t, len(updatedServerPayload), n)
+	n, err = client.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, updatedServerPayload, buf[:n])
 }
 
 func TestDTLS13RetransmittedClientFinalFlight(t *testing.T) {

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -140,7 +140,7 @@ func (s *fsm13) Run(ctx context.Context, conn Conn, initialState State) (err err
 	defer s.received.release()
 	defer func() {
 		if err != nil {
-			s.postHandshake.fail(conn, err)
+			s.postHandshake.fail(err)
 		}
 	}()
 
@@ -175,6 +175,35 @@ type KeyUpdater interface {
 	UpdateKeys(context.Context, handshake.KeyUpdateRequest) error
 }
 
+// ApplicationDataWriter serializes DTLS 1.3 application data with
+// post-handshake messages.
+type ApplicationDataWriter interface {
+	WriteApplicationData(context.Context, []*dtlsflight.Packet) error
+}
+
+// WriteApplicationData queues application records on the post-handshake state
+// machine. In particular, a required KeyUpdate response already in the queue is
+// emitted before these records.
+func (s *fsm13) WriteApplicationData(ctx context.Context, packets []*dtlsflight.Packet) error {
+	completion, completionCtx := newPostHandshakeCompletion()
+	command := postHandshakeCommand{
+		Kind:       commandSendApplicationData,
+		Canceled:   ctx.Done(),
+		Packets:    packets,
+		Completion: completion,
+		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+			_, err := conn.WritePackets(ctx, packets)
+
+			return err
+		},
+	}
+	if err := s.submitPostHandshakeCommand(ctx, command); err != nil {
+		return err
+	}
+
+	return s.waitPostHandshakeCompletion(ctx, completionCtx, completion)
+}
+
 // UpdateKeys queues a reliable DTLS 1.3 KeyUpdate and waits until its ACK has
 // committed the next local write generation.
 func (s *fsm13) UpdateKeys(ctx context.Context, request handshake.KeyUpdateRequest) error {
@@ -189,14 +218,14 @@ func (s *fsm13) UpdateKeys(ctx context.Context, request handshake.KeyUpdateReque
 		KeyUpdate:  keyUpdateCommand{Request: request},
 		Completion: completion,
 	}
-	if err := s.submitKeyUpdateCommand(ctx, command); err != nil {
+	if err := s.submitPostHandshakeCommand(ctx, command); err != nil {
 		return err
 	}
 
-	return s.waitKeyUpdateCompletion(ctx, completionCtx, completion)
+	return s.waitPostHandshakeCompletion(ctx, completionCtx, completion)
 }
 
-func (s *fsm13) submitKeyUpdateCommand(ctx context.Context, command postHandshakeCommand) error {
+func (s *fsm13) submitPostHandshakeCommand(ctx context.Context, command postHandshakeCommand) error {
 	select {
 	case s.postHandshake.commands <- command:
 		return nil
@@ -207,7 +236,7 @@ func (s *fsm13) submitKeyUpdateCommand(ctx context.Context, command postHandshak
 	}
 }
 
-func (s *fsm13) waitKeyUpdateCompletion(
+func (s *fsm13) waitPostHandshakeCompletion(
 	ctx context.Context,
 	completionCtx context.Context,
 	completion *postHandshakeCompletion,

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -128,19 +128,18 @@ const (
 	commandSendKeyUpdate
 	commandSendNewConnectionID
 	commandSendRequestConnectionID
+	commandSendApplicationData
 )
 
 type keyUpdateCommand struct {
 	Request handshake.KeyUpdateRequest
-
-	// True when this is a protocol-required response to an incoming
-	// update_requested KeyUpdate.
-	RequiredResponse bool
 }
 
 type postHandshakeCommand struct {
 	Kind postHandshakeCommandKind
 
+	Packets   []*dtlsflight.Packet
+	Write     func(Conn, []*dtlsflight.Packet) error
 	KeyUpdate keyUpdateCommand
 	Canceled  <-chan struct{}
 
@@ -160,26 +159,12 @@ type postHandshake struct {
 	// Reverse lookup for received ACK record numbers.
 	recordIndex map[protocol.RecordNumber]postHandshakeRecord
 
-	pendingRequiredKeyUpdateResponses int
-
 	initialRetransmitInterval time.Duration
 	handshakeContext
 }
 
 type keyUpdateCommitConn interface {
 	CommitLocalKeyUpdate(*dtlsstate.TrafficGeneration) error
-}
-
-// TODO: Replace this pause gate with unified serialization of application
-// and post-handshake writes.
-// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.6.3
-// https://www.rfc-editor.org/rfc/rfc9147.html#section-4.2.1
-// https://www.rfc-editor.org/rfc/rfc9147.html#section-8
-//
-//nolint:godox
-type applicationDataPauser interface {
-	PauseApplicationData()
-	ResumeApplicationData()
 }
 
 type pendingACKConn interface {
@@ -241,7 +226,14 @@ func (p *postHandshake) initialize() {
 }
 
 func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn) error {
-	for len(p.flights) == 0 && len(p.queue) != 0 {
+	for len(p.queue) != 0 {
+		// Reliable post-handshake messages use one active outbound flight.
+		// Application records may follow a flight that has already been emitted.
+		// For KeyUpdate they continue using the current generation until the ACK
+		// commits the pending generation.
+		if len(p.flights) != 0 && p.queue[0].Kind != commandSendApplicationData {
+			return nil
+		}
 		command := p.queue[0]
 		p.queue = p.queue[1:]
 		if err, canceled := canceledPostHandshakeCommand(command); canceled {
@@ -253,7 +245,6 @@ func (p *postHandshake) startQueuedPostHandshake(ctx context.Context, conn Conn)
 		err := p.startPostHandshakeCommand(ctx, conn, command)
 		if err != nil {
 			command.Completion.complete(err)
-			p.failRequiredKeyUpdateResponse(conn, command)
 
 			return err
 		}
@@ -287,19 +278,23 @@ func (p *postHandshake) startPostHandshakeCommand(
 	case commandSendNewConnectionID,
 		commandSendRequestConnectionID:
 		return dtlserrors.ErrNotImplemented
+	case commandSendApplicationData:
+		return p.writeApplicationData(conn, command)
 	default:
 		return dtlserrors.ErrUnexpectedPostHandshakeMessage
 	}
 }
 
-func (p *postHandshake) failRequiredKeyUpdateResponse(conn Conn, command postHandshakeCommand) {
-	if !command.KeyUpdate.RequiredResponse {
-		return
+func (p *postHandshake) writeApplicationData(conn Conn, command postHandshakeCommand) error {
+	for _, packet := range command.Packets {
+		packet.Record.Header.Epoch = p.state.LocalEpoch()
 	}
-	p.pendingRequiredKeyUpdateResponses = 0
-	if pauser, ok := conn.(applicationDataPauser); ok {
-		pauser.ResumeApplicationData()
-	}
+	err := command.Write(conn, command.Packets)
+	command.Completion.complete(err)
+
+	// Report application write failures to the caller without terminating the
+	// post-handshake state machine. This preserves Conn.Write's behavior.
+	return nil
 }
 
 func (p *postHandshake) applyACK(ack protocol.ACK) []postHandshakeFlightID {
@@ -466,9 +461,7 @@ func (p *postHandshake) handleKeyUpdate(
 		return err
 	}
 
-	if err = p.queueRequiredKeyUpdateResponse(conn, message.RequestUpdate); err != nil {
-		return err
-	}
+	p.queueRequiredKeyUpdateResponse(message.RequestUpdate)
 
 	p.state.TrafficKeys.Install(nil, next)
 	p.state.SetRemoteEpoch(next.Epoch)
@@ -477,31 +470,27 @@ func (p *postHandshake) handleKeyUpdate(
 	return conn.HandleQueuedPackets(ctx)
 }
 
-func (p *postHandshake) queueRequiredKeyUpdateResponse(
-	conn Conn,
-	request handshake.KeyUpdateRequest,
-) error {
+func (p *postHandshake) queueRequiredKeyUpdateResponse(request handshake.KeyUpdateRequest) {
 	if request != handshake.KeyUpdateRequested {
-		return nil
+		return
 	}
-	pauser, ok := conn.(applicationDataPauser)
-	if !ok {
-		return dtlserrors.ErrNotImplemented
-	}
-	if p.pendingRequiredKeyUpdateResponses == 0 {
-		pauser.PauseApplicationData()
-	}
-	p.pendingRequiredKeyUpdateResponses++
 	command := postHandshakeCommand{
 		Kind: commandSendKeyUpdate,
 		KeyUpdate: keyUpdateCommand{
-			Request:          handshake.KeyUpdateNotRequested,
-			RequiredResponse: true,
+			Request: handshake.KeyUpdateNotRequested,
 		},
 	}
-	p.queue = append(p.queue, command)
+	insertAt := len(p.queue)
+	for i, queued := range p.queue {
+		if queued.Kind == commandSendApplicationData {
+			insertAt = i
 
-	return nil
+			break
+		}
+	}
+	p.queue = append(p.queue, postHandshakeCommand{})
+	copy(p.queue[insertAt+1:], p.queue[insertAt:])
+	p.queue[insertAt] = command
 }
 
 func (p *postHandshake) handleNewSessionTicket(
@@ -558,22 +547,6 @@ func (p *postHandshake) startKeyUpdate(
 	p.flights[flight.ID] = flight
 	p.registerTransmission(flight, result.TrackedRecords, true)
 	flight.NextRetransmit = time.Now().Add(flight.RetransmitInterval)
-
-	if command.KeyUpdate.RequiredResponse {
-		pauser, ok := conn.(applicationDataPauser)
-		if !ok {
-			return dtlserrors.ErrNotImplemented
-		}
-		p.pendingRequiredKeyUpdateResponses--
-		// RFC 8446 4.6.3 requires this response before the next Application Data
-		// record,
-		// and RFC 9147 8 defers using the next write keys until it is ACKed.
-		// https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3
-		// https://datatracker.ietf.org/doc/html/rfc9147#section-8
-		if p.pendingRequiredKeyUpdateResponses == 0 {
-			pauser.ResumeApplicationData()
-		}
-	}
 
 	return nil
 }
@@ -769,7 +742,7 @@ func (p *postHandshake) completePostHandshakeFlight(conn Conn, id postHandshakeF
 	return completionErr
 }
 
-func (p *postHandshake) fail(conn Conn, err error) {
+func (p *postHandshake) fail(err error) {
 	for _, command := range p.queue {
 		command.Completion.complete(err)
 	}
@@ -779,12 +752,6 @@ func (p *postHandshake) fail(conn Conn, err error) {
 		delete(p.flights, id)
 	}
 	p.recordIndex = make(map[protocol.RecordNumber]postHandshakeRecord)
-	if p.pendingRequiredKeyUpdateResponses != 0 {
-		p.pendingRequiredKeyUpdateResponses = 0
-		if pauser, ok := conn.(applicationDataPauser); ok {
-			pauser.ResumeApplicationData()
-		}
-	}
 }
 
 func (p *postHandshake) retransmitPostHandshake(

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,12 +55,9 @@ type postHandshakeWriteConn struct {
 
 type postHandshakeKeyUpdateConn struct {
 	flightTestConn
-	state        *dtlsstate.State13
-	result       *WriteResult
-	committed    *dtlsstate.TrafficGeneration
-	blocked      bool
-	blockCount   int
-	unblockCount int
+	state     *dtlsstate.State13
+	result    *WriteResult
+	committed *dtlsstate.TrafficGeneration
 }
 
 func (c *postHandshakeKeyUpdateConn) WritePackets(
@@ -80,16 +78,6 @@ func (c *postHandshakeKeyUpdateConn) CommitLocalKeyUpdate(generation *dtlsstate.
 	c.state.SetLocalEpoch(generation.Epoch)
 
 	return nil
-}
-
-func (c *postHandshakeKeyUpdateConn) PauseApplicationData() {
-	c.blocked = true
-	c.blockCount++
-}
-
-func (c *postHandshakeKeyUpdateConn) ResumeApplicationData() {
-	c.blocked = false
-	c.unblockCount++
 }
 
 func newPostHandshakeKeyUpdateTestState(t *testing.T, isClient bool) *dtlsstate.State13 {
@@ -225,12 +213,12 @@ func TestPostHandshakeCompletionKeepsFirstOutcome(t *testing.T) {
 	assert.NoError(t, completion.result())
 }
 
-func TestWaitKeyUpdateCompletionKeepsCallerCancellationSeparate(t *testing.T) {
+func TestWaitPostHandshakeCompletionKeepsCallerCancellationSeparate(t *testing.T) {
 	completion, completionCtx := newPostHandshakeCompletion()
 	callerCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	assert.ErrorIs(t, (&fsm13{}).waitKeyUpdateCompletion(
+	assert.ErrorIs(t, (&fsm13{}).waitPostHandshakeCompletion(
 		callerCtx,
 		completionCtx,
 		completion,
@@ -572,14 +560,10 @@ func TestRequestedKeyUpdateInstallsReadKeysAndQueuesResponse(t *testing.T) {
 	assert.Equal(t, uint64(1), currentRead.Generation)
 	_, oldReadRetained := state.TrafficKeys.Read(dtlsflight13.EpochApplication)
 	assert.True(t, oldReadRetained)
-	assert.True(t, conn.blocked)
-	assert.Equal(t, 1, conn.blockCount)
 	require.Len(t, post.queue, 1)
-	assert.True(t, post.queue[0].KeyUpdate.RequiredResponse)
+	assert.Equal(t, handshake.KeyUpdateNotRequested, post.queue[0].KeyUpdate.Request)
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
-	assert.False(t, conn.blocked)
-	assert.Equal(t, 1, conn.unblockCount)
 	require.Len(t, conn.writtenPackets, 1)
 	responseHandshake, ok := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
 	require.True(t, ok)
@@ -590,7 +574,7 @@ func TestRequestedKeyUpdateInstallsReadKeysAndQueuesResponse(t *testing.T) {
 	assert.Equal(t, dtlsflight13.EpochApplication, state.LocalEpoch())
 }
 
-func TestRequiredKeyUpdateResponsesKeepApplicationDataBlockedUntilEmitted(t *testing.T) {
+func TestRequiredKeyUpdateResponsesAreSerialized(t *testing.T) {
 	state := newPostHandshakeKeyUpdateTestState(t, false)
 	post := newPostHandshake(handshakeContext{
 		state: state,
@@ -605,14 +589,10 @@ func TestRequiredKeyUpdateResponsesKeepApplicationDataBlockedUntilEmitted(t *tes
 	require.NoError(t, post.handleKeyUpdate(
 		context.Background(), conn, request, dtlsflight13.EpochApplication+1,
 	))
-	assert.True(t, conn.blocked)
-	assert.Equal(t, 1, conn.blockCount)
-	assert.Equal(t, 2, post.pendingRequiredKeyUpdateResponses)
 	require.Len(t, post.queue, 2)
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
-	assert.True(t, conn.blocked)
-	assert.Equal(t, 1, post.pendingRequiredKeyUpdateResponses)
+	require.Len(t, post.queue, 1)
 	require.Len(t, conn.writtenPackets, 1)
 	require.Len(t, post.flights, 1)
 	for id := range post.flights {
@@ -620,10 +600,115 @@ func TestRequiredKeyUpdateResponsesKeepApplicationDataBlockedUntilEmitted(t *tes
 	}
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
-	assert.False(t, conn.blocked)
-	assert.Equal(t, 1, conn.unblockCount)
-	assert.Zero(t, post.pendingRequiredKeyUpdateResponses)
+	assert.Empty(t, post.queue)
 	assert.Len(t, conn.writtenPackets, 2)
+}
+
+func TestApplicationDataChangesEpochOnlyAfterKeyUpdateACK(t *testing.T) {
+	state := newPostHandshakeKeyUpdateTestState(t, false)
+	post := newPostHandshake(handshakeContext{
+		state: state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	record := protocol.RecordNumber{Epoch: uint64(dtlsflight13.EpochApplication), SequenceNumber: 4}
+	conn := &postHandshakeKeyUpdateConn{
+		state: state,
+		result: &WriteResult{TrackedRecords: []SentHandshakeRecord{{
+			Number: record,
+			Fragments: []SentHandshakeFragment{{
+				MessageSequence: 0,
+				Length:          1,
+			}},
+		}}},
+	}
+	applicationPacket := &dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header:  recordlayer.Header{Version: protocol.Version1_2},
+			Content: &protocol.ApplicationData{Data: []byte("after update")},
+		},
+		ShouldEncrypt: true,
+	}
+	post.queue = append(post.queue, postHandshakeCommand{
+		Kind:    commandSendApplicationData,
+		Packets: []*dtlsflight.Packet{applicationPacket},
+		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+			_, err := conn.WritePackets(context.Background(), packets)
+
+			return err
+		},
+	})
+	post.queueRequiredKeyUpdateResponse(handshake.KeyUpdateRequested)
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	require.Len(t, conn.writtenPackets, 2)
+	_, isKeyUpdate := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	assert.True(t, isKeyUpdate)
+	_, isApplicationData := conn.writtenPackets[1].Record.Content.(*protocol.ApplicationData)
+	assert.True(t, isApplicationData)
+	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Record.Header.Epoch)
+	assert.Empty(t, post.queue)
+
+	completed := post.applyACK(protocol.ACK{Records: []protocol.RecordNumber{record}})
+	require.Len(t, completed, 1)
+	require.NoError(t, post.completePostHandshakeFlight(conn, completed[0]))
+	afterACKPacket := &dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header:  recordlayer.Header{Version: protocol.Version1_2},
+			Content: &protocol.ApplicationData{Data: []byte("after ACK")},
+		},
+		ShouldEncrypt: true,
+	}
+	post.queue = append(post.queue, postHandshakeCommand{
+		Kind:    commandSendApplicationData,
+		Packets: []*dtlsflight.Packet{afterACKPacket},
+		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+			_, err := conn.WritePackets(context.Background(), packets)
+
+			return err
+		},
+	})
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	require.Len(t, conn.writtenPackets, 3)
+	assert.Equal(t, dtlsflight13.EpochApplication+1, afterACKPacket.Record.Header.Epoch)
+}
+
+func TestApplicationDataDoesNotWaitForNewSessionTicketACK(t *testing.T) {
+	state := dtlsstate.NewState13(false)
+	state.SetLocalEpoch(dtlsflight13.EpochApplication)
+	post := newPostHandshake(handshakeContext{
+		state: &state,
+		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
+	})
+	applicationPacket := &dtlsflight.Packet{
+		Record: &recordlayer.RecordLayer{
+			Header:  recordlayer.Header{Version: protocol.Version1_2},
+			Content: &protocol.ApplicationData{Data: []byte("after ticket")},
+		},
+		ShouldEncrypt: true,
+	}
+	post.queue = append(post.queue,
+		postHandshakeCommand{Kind: commandSendNewSessionTicket},
+		postHandshakeCommand{
+			Kind:    commandSendApplicationData,
+			Packets: []*dtlsflight.Packet{applicationPacket},
+			Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+				_, err := conn.WritePackets(context.Background(), packets)
+
+				return err
+			},
+		},
+	)
+	conn := &postHandshakeWriteConn{result: &WriteResult{}}
+
+	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
+	assert.Empty(t, post.queue)
+	require.Len(t, post.flights, 1)
+	require.Len(t, conn.writtenPackets, 2)
+	_, isTicket := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	assert.True(t, isTicket)
+	_, isApplicationData := conn.writtenPackets[1].Record.Content.(*protocol.ApplicationData)
+	assert.True(t, isApplicationData)
+	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Record.Header.Epoch)
 }
 
 func TestRetransmittedKeyUpdateDoesNotRatchetReadKeysTwice(t *testing.T) {

--- a/pkg/protocol/application_data.go
+++ b/pkg/protocol/application_data.go
@@ -21,7 +21,7 @@ func (a ApplicationData) ContentType() ContentType {
 
 // Marshal encodes the ApplicationData to binary.
 func (a *ApplicationData) Marshal() ([]byte, error) {
-	return bytes.Clone(a.Data), nil
+	return a.Data, nil
 }
 
 // Unmarshal populates the ApplicationData from binary.


### PR DESCRIPTION
Route application data through the post-handshake command queue so KeyUpdate and application records have a single ordering point. Remove the pause/resume gate while keeping writes on the current epoch until a KeyUpdate ACK commits the next generation.

Add queue-ordering and end-to-end KeyUpdate coverage.

Closes #996
