### PR TITLE
Fuzz CID in record headers

### DIFF
--- a/pkg/protocol/recordlayer/header_13_test.go
+++ b/pkg/protocol/recordlayer/header_13_test.go
@@ -151,6 +151,8 @@ func FuzzUnifiedHeaderUnmarshal(f *testing.F) {
 }
 
 func FuzzUnifiedHeaderCIDUnmarshal(f *testing.F) {
+	const cidLength = 32
+
 	testcases := [][]byte{
 		{
 			0x2f,       // 0b00101111
@@ -172,8 +174,25 @@ func FuzzUnifiedHeaderCIDUnmarshal(f *testing.F) {
 	for _, tc := range testcases {
 		f.Add(tc)
 	}
+
+	cid := make([]byte, cidLength)
+	for i := range cid {
+		cid[i] = byte(i)
+	}
+	raw, err := (&UnifiedHeader{
+		ConnectionID:   cid,
+		SequenceNumber: 0xaabb,
+		SeqBit:         true,
+		Length:         42,
+		LengthBit:      true,
+		EpochLow:       3,
+	}).Marshal()
+	if err != nil {
+		f.Fatalf("marshal fuzz seed: %v", err)
+	}
+	f.Add(raw)
+
 	f.Fuzz(func(t *testing.T, data []byte) {
-		cidLength := 32
 		uh := UnifiedHeader{ConnectionID: make([]byte, cidLength)}
 		err := uh.Unmarshal(data)
 		if err != nil {
@@ -187,5 +206,9 @@ func FuzzUnifiedHeaderCIDUnmarshal(f *testing.F) {
 			assert.Equal(t, cidLength, parsedLength)
 		}
 		assert.LessOrEqual(t, uh.EpochLow, uint8(0b000000011))
+
+		raw, err := uh.Marshal()
+		assert.NoError(t, err)
+		assert.Equal(t, data[:uh.Size()], raw)
 	})
 }

--- a/pkg/protocol/recordlayer/header_test.go
+++ b/pkg/protocol/recordlayer/header_test.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package recordlayer
+
+import (
+	"testing"
+
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzHeaderCIDUnmarshal(f *testing.F) {
+	const cidLength = 4
+
+	for _, header := range []Header{
+		{
+			ContentType:    protocol.ContentTypeApplicationData,
+			ContentLen:     3,
+			Version:        protocol.Version1_2,
+			Epoch:          1,
+			SequenceNumber: 2,
+		},
+		{
+			ContentType:    protocol.ContentTypeConnectionID,
+			ContentLen:     3,
+			Version:        protocol.Version1_2,
+			Epoch:          1,
+			SequenceNumber: 2,
+			ConnectionID:   []byte{0x01, 0x02, 0x03, 0x04},
+		},
+	} {
+		raw, err := header.Marshal()
+		if err != nil {
+			f.Fatalf("marshal fuzz seed: %v", err)
+		}
+		f.Add(raw)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		header := Header{ConnectionID: make([]byte, cidLength)}
+		if err := header.Unmarshal(data); err != nil {
+			return
+		}
+
+		raw, err := header.Marshal()
+		require.NoError(t, err)
+		require.Equal(t, data[:header.Size()], raw)
+	})
+}


### PR DESCRIPTION
#### Description
Adds fuzz for CID in forms in 1.2 and 1.3 headers, with round-trip validation, closes #846  