### PR TITLE
Make receive buffer size configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ var defaultCurves = []elliptic.Curve{ //nolint:gochecknoglobals
 type connConfigValues struct {
 	logger                      logging.LeveledLogger
 	maximumTransmissionUnit     int
+	receiveBufferSize           int
 	paddingLengthGenerator      func(uint) uint
 	replayProtectionWindow      int
 	initialRetransmitInterval   time.Duration
@@ -74,10 +75,11 @@ func newConnConfigValues(config *dtlsConfig) (connConfigValues, error) {
 
 	return connConfigValues{
 		logger:                      newConnLogger(config),
-		maximumTransmissionUnit:     effectiveMTU(config.MTU),
-		paddingLengthGenerator:      effectivePaddingLengthGenerator(config.PaddingLengthGenerator),
+		maximumTransmissionUnit:     config.MTU,
+		receiveBufferSize:           config.ReceiveBufferSize,
+		paddingLengthGenerator:      config.PaddingLengthGenerator,
 		replayProtectionWindow:      effectiveReplayProtectionWindow(config.ReplayProtectionWindow),
-		initialRetransmitInterval:   effectiveFlightInterval(config.FlightInterval),
+		initialRetransmitInterval:   config.FlightInterval,
 		minVersion:                  minVersion,
 		maxVersion:                  maxVersion,
 		cipherSuites:                cipherSuites,
@@ -120,36 +122,12 @@ func newConnLogger(config *dtlsConfig) logging.LeveledLogger {
 	return loggerFactory.NewLogger("dtls")
 }
 
-func effectiveMTU(mtu int) int {
-	if mtu <= 0 {
-		return defaultMTU
-	}
-
-	return mtu
-}
-
 func effectiveReplayProtectionWindow(replayProtectionWindow int) int {
 	if replayProtectionWindow <= 0 {
 		return defaultReplayProtectionWindow
 	}
 
 	return replayProtectionWindow
-}
-
-func effectivePaddingLengthGenerator(generator func(uint) uint) func(uint) uint {
-	if generator == nil {
-		return func(uint) uint { return 0 }
-	}
-
-	return generator
-}
-
-func effectiveFlightInterval(flightInterval time.Duration) time.Duration {
-	if flightInterval <= 0 {
-		return initialTickerInterval
-	}
-
-	return flightInterval
 }
 
 func effectiveServerName(serverName string) string {

--- a/conn.go
+++ b/conn.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	initialTickerInterval = time.Second
-	inboundBufferSize     = 8192
+	// defaultReceiveBufferSize is the default size of the buffers used to
+	// receive datagrams. Overridable via WithReceiveBufferSize.
+	defaultReceiveBufferSize = 8192
 	// Default replay protection window is specified by RFC 6347 Section 4.1.2.6.
 	defaultReplayProtectionWindow = 64
 	// maxAppDataPacketQueueSize is the maximum number of app data packets we will.
@@ -75,6 +76,7 @@ type addrPkt struct {
 // call. Anything retained beyond that call must take an exact owned copy.
 type readBufferLease struct {
 	conn                 *Conn
+	pool                 *sync.Pool
 	recyclableReadBuffer *[]byte
 	datagramContainsCID  bool
 }
@@ -88,8 +90,8 @@ func (w *readBufferLease) enqueue(packet addrPkt) bool {
 func (w *readBufferLease) releaseReadBuffer() {
 	readBuffer := w.recyclableReadBuffer
 	w.recyclableReadBuffer = nil
-	if readBuffer != nil {
-		poolReadBuffer.Put(readBuffer)
+	if readBuffer != nil && w.pool != nil {
+		w.pool.Put(readBuffer)
 	}
 }
 
@@ -200,6 +202,7 @@ type Conn struct {
 
 	maximumTransmissionUnit int
 	paddingLengthGenerator  func(uint) uint
+	readBufferPool          *sync.Pool
 
 	handshakeEstablished *dtlshandshake.Establishment
 	handshakeMutex       sync.Mutex
@@ -275,6 +278,7 @@ func newConn(
 		maximumTransmissionUnit: configValues.maximumTransmissionUnit,
 		paddingLengthGenerator:  configValues.paddingLengthGenerator,
 		cidPathMigrationPolicy:  configValues.cidPathMigrationPolicy,
+		readBufferPool:          readBufferPoolForSize(configValues.receiveBufferSize),
 
 		decrypted: make(chan any, 1),
 		log:       configValues.logger,
@@ -1336,12 +1340,22 @@ func (c *Conn) fragmentHandshake(dtlsHandshake *handshake.Handshake) ([][]byte, 
 	return fragmentedHandshakes, nil
 }
 
-var poolReadBuffer = sync.Pool{ //nolint:gochecknoglobals
-	New: func() any {
-		b := make([]byte, inboundBufferSize)
+// readBufferPools caches read buffer pools by size so buffers are reused across
+// connections. Only a small bounded set of distinct sizes is expected in a
+// program.
+var readBufferPools sync.Map //nolint:gochecknoglobals // map[int]*sync.Pool
 
-		return &b
-	},
+// readBufferPoolForSize returns the shared read buffer pool for size.
+func readBufferPoolForSize(size int) *sync.Pool {
+	pool, _ := readBufferPools.LoadOrStore(size, &sync.Pool{
+		New: func() any {
+			b := make([]byte, size)
+
+			return &b
+		},
+	})
+
+	return pool.(*sync.Pool) //nolint:forcetypeassert // only *sync.Pool values are stored
 }
 
 func (c *Conn) readAndBuffer(ctx context.Context) error {
@@ -1372,11 +1386,11 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 }
 
 func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSummary, error) { //nolint:cyclop
-	bufptr, ok := poolReadBuffer.Get().(*[]byte)
+	bufptr, ok := c.readBufferPool.Get().(*[]byte)
 	if !ok {
 		return datagramProcessingSummary{}, dtlserrors.ErrFailedToAccessPoolReadBuffer
 	}
-	bufferLease := readBufferLease{conn: c, recyclableReadBuffer: bufptr}
+	bufferLease := readBufferLease{conn: c, pool: c.readBufferPool, recyclableReadBuffer: bufptr}
 	defer bufferLease.releaseReadBuffer()
 
 	b := *bufptr

--- a/conn_test.go
+++ b/conn_test.go
@@ -3814,6 +3814,7 @@ func TestReadAndBufferNoFSMQueuesExactRecordCopy(t *testing.T) {
 		nextConn:       netctx.NewPacketConn(dtlsnet.PacketConnFromConn(cb)),
 		fragmentBuffer: dtlsfragmentbuffer.New(),
 		handshakeCache: dtlsflight.NewCache(),
+		readBufferPool: readBufferPoolForSize(defaultReceiveBufferSize),
 		log:            logging.NewDefaultLoggerFactory().NewLogger("dtls"),
 		state: &dtlsstate.State13{Common: &dtlsstate.Common{
 			LocalVersion: protocol.Version1_3,

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -134,6 +134,7 @@ var (
 		"verify connection option requires a non-nil callback",
 	)
 	ErrInvalidMTU                    = stderrors.New("MTU must be positive")
+	ErrInvalidReceiveBufferSize      = stderrors.New("receive buffer size must be positive")
 	ErrInvalidReplayProtectionWindow = stderrors.New(
 		"replay protection window must be non-negative",
 	)

--- a/internal/net/udp/packet_conn.go
+++ b/internal/net/udp/packet_conn.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	receiveMTU           = 8192
-	defaultListenBacklog = 128 // same as Linux default
+	defaultReceiveBufferSize = 8192
+	defaultListenBacklog     = 128 // same as Linux default
 )
 
 // Typed errors.
@@ -44,13 +44,14 @@ var (
 type listener struct {
 	pConn *net.UDPConn
 
-	accepting      atomic.Value // bool
-	acceptCh       chan *PacketConn
-	doneCh         chan struct{}
-	doneOnce       sync.Once
-	acceptFilter   func([]byte) bool
-	datagramRouter func([]byte) (string, bool)
-	connIdentifier func([]byte) (string, bool)
+	accepting         atomic.Value // bool
+	acceptCh          chan *PacketConn
+	doneCh            chan struct{}
+	doneOnce          sync.Once
+	acceptFilter      func([]byte) bool
+	datagramRouter    func([]byte) (string, bool)
+	connIdentifier    func([]byte) (string, bool)
+	receiveBufferSize int
 
 	connLock sync.Mutex
 	conns    map[string]*PacketConn
@@ -158,6 +159,11 @@ type ListenConfig struct {
 	// added.
 	ConnectionIdentifier func([]byte) (string, bool)
 
+	// ReceiveBufferSize sets the size of the buffer used to read incoming
+	// datagrams. Datagrams larger than this size are truncated.
+	// If zero or negative, the default value 8192 is used.
+	ReceiveBufferSize int
+
 	// Internal listen config used to open the UDP socket.
 	ListenConfig net.ListenConfig
 }
@@ -168,6 +174,9 @@ type ListenConfig struct {
 func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (dtlsnet.PacketListener, error) {
 	if lc.Backlog == 0 {
 		lc.Backlog = defaultListenBacklog
+	}
+	if lc.ReceiveBufferSize <= 0 {
+		lc.ReceiveBufferSize = defaultReceiveBufferSize
 	}
 
 	laddrStr := ":0"
@@ -184,14 +193,15 @@ func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (dtlsnet.Pack
 	}
 
 	packetListener := &listener{
-		pConn:          conn,
-		acceptCh:       make(chan *PacketConn, lc.Backlog),
-		conns:          make(map[string]*PacketConn),
-		doneCh:         make(chan struct{}),
-		acceptFilter:   lc.AcceptFilter,
-		datagramRouter: lc.DatagramRouter,
-		connIdentifier: lc.ConnectionIdentifier,
-		readDoneCh:     make(chan struct{}),
+		pConn:             conn,
+		acceptCh:          make(chan *PacketConn, lc.Backlog),
+		conns:             make(map[string]*PacketConn),
+		doneCh:            make(chan struct{}),
+		acceptFilter:      lc.AcceptFilter,
+		datagramRouter:    lc.DatagramRouter,
+		connIdentifier:    lc.ConnectionIdentifier,
+		receiveBufferSize: lc.ReceiveBufferSize,
+		readDoneCh:        make(chan struct{}),
 	}
 
 	packetListener.accepting.Store(true)
@@ -221,7 +231,7 @@ func (l *listener) readLoop() {
 	defer l.readWG.Done()
 	defer close(l.readDoneCh)
 
-	buf := make([]byte, receiveMTU)
+	buf := make([]byte, l.receiveBufferSize)
 
 	for {
 		n, raddr, err := l.pConn.ReadFrom(buf)

--- a/listener.go
+++ b/listener.go
@@ -26,7 +26,8 @@ func listenWithConfig(network string, laddr *net.UDPAddr, config *dtlsConfig) (n
 
 			return h.ContentType == protocol.ContentTypeHandshake
 		},
-		ListenConfig: config.ListenConfig,
+		ReceiveBufferSize: config.ReceiveBufferSize,
+		ListenConfig:      config.ListenConfig,
 	}
 	// If connection ID support is enabled, then they must be supported in
 	// routing.

--- a/options.go
+++ b/options.go
@@ -56,6 +56,7 @@ type dtlsConfig struct {
 	ServerName                    string
 	LoggerFactory                 logging.LoggerFactory
 	MTU                           int
+	ReceiveBufferSize             int
 	ReplayProtectionWindow        int
 	KeyLogWriter                  io.Writer
 	SupportedProtocols            []string
@@ -86,7 +87,9 @@ func (c *dtlsConfig) applyDefaults() {
 	c.ExtendedMasterSecret = RequestExtendedMasterSecret
 	c.FlightInterval = time.Second
 	c.MTU = defaultMTU
+	c.ReceiveBufferSize = defaultReceiveBufferSize
 	c.ReplayProtectionWindow = defaultReplayProtectionWindow
+	c.PaddingLengthGenerator = func(uint) uint { return 0 }
 }
 
 // buildConfig builds a config from the provided options, for mixed client/server cases.
@@ -365,6 +368,26 @@ func WithMTU(mtu int) Option {
 			return dtlserrors.ErrInvalidMTU
 		}
 		c.MTU = mtu
+
+		return nil
+	})
+}
+
+// WithReceiveBufferSize sets the size of the in-memory buffers used to read
+// incoming datagrams. A datagram larger than this size cannot be received —
+// depending on the transport it is truncated or rejected — so it must be at
+// least as large as the largest datagram the peer may send. The default is
+// 8192 bytes.
+//
+// This does not change the kernel socket receive buffer (SO_RCVBUF); use
+// net.UDPConn.SetReadBuffer for that.
+// Returns an error if the size is not positive.
+func WithReceiveBufferSize(size int) Option {
+	return sharedOption(func(c *dtlsConfig) error {
+		if size <= 0 {
+			return dtlserrors.ErrInvalidReceiveBufferSize
+		}
+		c.ReceiveBufferSize = size
 
 		return nil
 	})

--- a/receive_buffer_size_test.go
+++ b/receive_buffer_size_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	"github.com/pion/transport/v4/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Datagrams larger than the default receive buffer size were silently
+// truncated by both the listener demux loop and the connection read loop,
+// surfacing as read timeouts or EOF instead of data.
+// https://github.com/pion/dtls/issues/642
+func TestReceiveBufferSizeLargeDatagram(t *testing.T) {
+	lim := test.TimeOut(30 * time.Second)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	// Larger than the 8192-byte default receive buffer, small enough that the
+	// resulting datagram fits well under platform datagram limits (macOS caps
+	// UDP datagrams at net.inet.udp.maxdgram, 9216 bytes by default).
+	const payloadSize = 8500
+	const bufferSize = 16384
+
+	serverCert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	listener, err := ListenWithOptions("udp",
+		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		WithCertificates(serverCert),
+		WithReceiveBufferSize(bufferSize),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, listener.Close())
+	}()
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	serverRead := make(chan readResult, 1)
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverRead <- readResult{err: acceptErr}
+
+			return
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		buf := make([]byte, bufferSize)
+		n, readErr := conn.Read(buf)
+		serverRead <- readResult{data: buf[:n], err: readErr}
+
+		assert.NoError(t, conn.Close())
+	}()
+
+	serverAddr, ok := listener.Addr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	client, err := DialWithOptions("udp", serverAddr,
+		WithInsecureSkipVerify(true),
+		WithReceiveBufferSize(bufferSize),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, client.Close())
+	}()
+
+	n, err := client.Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, payloadSize, n)
+
+	res := <-serverRead
+	require.NoError(t, res.err)
+	assert.Equal(t, payload, res.data)
+}
+
+func TestWithReceiveBufferSizeValidation(t *testing.T) {
+	for _, size := range []int{0, -1} {
+		_, err := buildConfig(WithReceiveBufferSize(size))
+		assert.Error(t, err)
+	}
+
+	config, err := buildConfig(WithReceiveBufferSize(16384))
+	assert.NoError(t, err)
+	assert.Equal(t, 16384, config.ReceiveBufferSize)
+}


### PR DESCRIPTION
The buffers used to read incoming datagrams are hard-coded to 8192 bytes in two places: the conn read loop and the udp listener's demux loop. A datagram bigger than that gets silently truncated by the OS and the receiver just sees a timeout or EOF...even though the send side produces datagrams up to 64K.

This adds a `WithReceiveBufferSize` option that sizes both read paths:

```go
dtls.DialWithOptions("udp", addr, dtls.WithReceiveBufferSize(65536))
```

The default stays 8192, so no change unless you opt in.

Added a test that round-trips an 8500-byte payload over loopback UDP. It fails against main with the same timeout from the issue.

Fixes #642