### PR TITLE
Switch to the new extensions API

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
-	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
@@ -2377,7 +2377,7 @@ func (c *Conn) pickVersionFromClientHello() (bool, error) {
 	var remote []protocol.Version
 	seenSupportedVersions := false
 	for _, e := range ch.Extensions {
-		if sv, ok := e.(*extension.SupportedVersions); ok { //nolint:govet
+		if sv, ok := e.(*extension13.OfferedVersions); ok { //nolint:govet
 			seenSupportedVersions = true
 			remote = sv.Versions
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -41,6 +41,8 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
@@ -331,7 +333,7 @@ func sendClientHello(
 	cookie []byte,
 	ca net.Conn,
 	sequenceNumber uint64,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 	cipherSuiteIDsOverride ...uint16,
 ) error {
 	cipherSuites := cipherSuiteIDsOverride
@@ -1990,21 +1992,21 @@ func TestServerTimeout(t *testing.T) {
 		&ciphersuite.TLSEcdheRsaWithAes128GcmSha256{},
 	}
 
-	extensions := []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: []signaturehash.Algorithm{
+	extensions := []extension.Value{
+		&extension.SignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs([]signaturehash.Algorithm{
 				{Hash: hash.SHA256, Signature: signature.ECDSA},
 				{Hash: hash.SHA384, Signature: signature.ECDSA},
 				{Hash: hash.SHA512, Signature: signature.ECDSA},
 				{Hash: hash.SHA256, Signature: signature.RSA},
 				{Hash: hash.SHA384, Signature: signature.RSA},
 				{Hash: hash.SHA512, Signature: signature.RSA},
-			},
+			}),
 		},
-		&extension.SupportedEllipticCurves{
-			EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
+		&extension.SupportedGroups{
+			Groups: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
 		},
-		&extension.SupportedPointFormats{
+		&extension12.SupportedPointFormats{
 			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 		},
 	}
@@ -2313,22 +2315,18 @@ type rawExtension13 struct {
 	raw       []byte
 }
 
-func (e rawExtension13) Marshal() ([]byte, error) {
-	return append([]byte(nil), e.raw...), nil
-}
-
-func (e rawExtension13) Unmarshal([]byte) error {
-	return nil
-}
-
-func (e rawExtension13) TypeValue() extension.TypeValue {
+func (e rawExtension13) ExtensionType() extension.Type {
 	return e.typeValue
+}
+
+func (e rawExtension13) MarshalData() ([]byte, error) {
+	return append([]byte(nil), e.raw[4:]...), nil
 }
 
 func marshalVersionNegotiationHelloRetryRequestServerHello13(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -2344,7 +2342,7 @@ func marshalVersionNegotiationServerHello13(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
 	random handshake.Random,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -2400,8 +2398,8 @@ func TestPickVersionFromServerResponseRejectsHelloRetryRequestWithoutSupportedVe
 	rawServerHello := marshalVersionNegotiationHelloRetryRequestServerHello13(
 		t,
 		cfg,
-		[]extension.Extension{
-			&extension.KeyShare{SelectedGroup: &selectedGroup},
+		[]extension.Value{
+			&extension13.RetryKeyShare{SelectedGroup: selectedGroup},
 		},
 	)
 
@@ -2428,7 +2426,7 @@ func TestPickVersionFromServerResponseRejectsServerHelloWithClientHelloSupported
 		t,
 		cfg,
 		random,
-		[]extension.Extension{
+		[]extension.Value{
 			rawExtension13{
 				typeValue: extension.SupportedVersionsTypeValue,
 				raw: []byte{
@@ -2441,17 +2439,9 @@ func TestPickVersionFromServerResponseRejectsServerHelloWithClientHelloSupported
 		},
 	)
 
-	conn := &Conn{
-		handshakeCache:  dtlsflight.NewCache(),
-		handshakeConfig: cfg,
-	}
-	conn.handshakeCache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
-
-	ok, err := conn.pickVersionFromServerResponse()
-
-	assert.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
-	assert.False(t, ok)
-	assert.Equal(t, protocol.Version{}, dtlsstate.CommonState(conn.state).LocalVersion)
+	parsed := &handshake.Handshake{}
+	err := parsed.Unmarshal(rawServerHello)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidSupportedVersionsFormat)
 }
 
 func TestSelectRemoteVersionActivatesChosenState(t *testing.T) {
@@ -2619,9 +2609,9 @@ func TestRenegotiationInfo(t *testing.T) {
 
 			time.Sleep(50 * time.Millisecond)
 
-			extensions := []extension.Extension{}
+			extensions := []extension.Value{}
 			if test.SendRenegotiationInfoExt {
-				extensions = append(extensions, &extension.RenegotiationInfo{
+				extensions = append(extensions, &extension12.RenegotiationInfo{
 					RenegotiatedConnection: 0,
 				})
 			}
@@ -2656,7 +2646,7 @@ func TestRenegotiationInfo(t *testing.T) {
 
 			actualNegotationInfo := false
 			for _, v := range serverHello.Extensions {
-				if _, ok := v.(*extension.RenegotiationInfo); ok {
+				if _, ok := v.(*extension12.RenegotiationInfo); ok {
 					actualNegotationInfo = true
 				}
 			}
@@ -2727,9 +2717,9 @@ func TestServerNameIndicationExtension(t *testing.T) {
 			gotSNI := false
 			var actualServerName string
 			for _, v := range clientHello.Extensions {
-				if _, ok := v.(*extension.ServerName); ok {
+				if _, ok := v.(*extension.ServerNameOffer); ok {
 					gotSNI = true
-					extensionServerName, ok := v.(*extension.ServerName)
+					extensionServerName, ok := v.(*extension.ServerNameOffer)
 					assert.True(t, ok)
 
 					actualServerName = extensionServerName.ServerName
@@ -2795,15 +2785,6 @@ func TestALPNExtension(t *testing.T) {
 			ExpectAlertFromClient:  false,
 			ExpectAlertFromServer:  true,
 			Alert:                  alert.NoApplicationProtocol,
-		},
-		{
-			Name:                   "Multiple protocols in ServerHello",
-			ClientProtocolNameList: []string{"http/1.1"},
-			ServerProtocolNameList: []string{"http/1.1"},
-			ExpectedProtocol:       "http/1.1",
-			ExpectAlertFromClient:  true,
-			ExpectAlertFromServer:  false,
-			Alert:                  alert.InternalError,
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
@@ -2883,16 +2864,19 @@ func TestALPNExtension(t *testing.T) {
 				assert.True(t, ok)
 
 				var negotiatedProtocol string
-				for _, v := range serverHello.Extensions {
-					if _, ok := v.(*extension.ALPN); ok {
-						e, ok := v.(*extension.ALPN)
+				for i, v := range serverHello.Extensions {
+					if _, ok := v.(*extension.ALPNSelection); ok {
+						e, ok := v.(*extension.ALPNSelection)
 						assert.True(t, ok)
 
-						negotiatedProtocol = e.ProtocolNameList[0]
+						negotiatedProtocol = e.Protocol
 
 						// Manipulate ServerHello
 						if test.ExpectAlertFromClient {
-							e.ProtocolNameList = append(e.ProtocolNameList, "oops")
+							serverHello.Extensions[i] = extension.Raw{
+								Type: extension.TypeALPN,
+								Data: []byte{0x00, 0x08, 0x02, 'h', '2', 0x04, 'o', 'o', 'p', 's'},
+							}
 						}
 					}
 				}
@@ -2944,11 +2928,11 @@ func TestSupportedGroupsExtension(t *testing.T) {
 			_, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), nil, true)
 			assert.ErrorIs(t, err, context.Canceled)
 		}()
-		extensions := []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
+		extensions := []extension.Value{
+			&extension.SupportedGroups{
+				Groups: []elliptic.Curve{elliptic.X25519, elliptic.P256, elliptic.P384},
 			},
-			&extension.SupportedPointFormats{
+			&extension12.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}
@@ -2984,7 +2968,7 @@ func TestSupportedGroupsExtension(t *testing.T) {
 
 		gotGroups := false
 		for _, v := range serverHello.Extensions {
-			if _, ok := v.(*extension.SupportedEllipticCurves); ok {
+			if _, ok := v.(*extension.SupportedGroups); ok {
 				gotGroups = true
 			}
 		}
@@ -3471,7 +3455,7 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 		assert.Error(t, dconn.HandshakeContext(ctx))
 		close(done)
 	}()
-	extensions := []extension.Extension{}
+	extensions := []extension.Value{}
 
 	time.Sleep(50 * time.Millisecond)
 

--- a/connection_id_test.go
+++ b/connection_id_test.go
@@ -194,7 +194,7 @@ func TestCIDConnIdentifier(t *testing.T) {
 				SessionID:         []byte("hello"),
 				CipherSuiteID:     &cs,
 				CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-				Extensions: []extension.Extension{
+				Extensions: []extension.Value{
 					&extension.ConnectionID{
 						CID: cid,
 					},

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -873,9 +873,7 @@ func testPionE2ESimpleServerHelloHook(t *testing.T, server, client func(*comm), 
 			dtls.WithCertificates(cert),
 			dtls.WithCipherSuites(supportedList...),
 			dtls.WithServerHelloMessageHook(func(sh handshake.MessageServerHello) handshake.Message {
-				sh.Extensions = append(sh.Extensions, &extension.ALPN{
-					ProtocolNameList: []string{apln},
-				})
+				sh.Extensions = append(sh.Extensions, &extension.ALPNSelection{Protocol: apln})
 
 				return &sh
 			}),

--- a/flight_test.go
+++ b/flight_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
@@ -316,9 +317,9 @@ func newFlight13ProtectedServerFlightFixture(t *testing.T) flight13ProtectedServ
 	require.NoError(t, err)
 	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
 		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
-	}, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	}, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
 	require.NoError(t, err)
@@ -556,9 +557,9 @@ func TestFlight13_5GenerateSelectsClientCertificateBySignatureScheme(t *testing.
 	rawRequest, err := (&handshake.Handshake{
 		Message: &handshake.MessageCertificateRequest13{
 			CertificateRequestContext: []byte("request"),
-			Extensions: []extension.Extension{
-				&extension.SupportedSignatureAlgorithms{
-					SignatureHashAlgorithms: []signaturehash.Algorithm{ecdsaSHA256},
+			Extensions: []extension.Value{
+				&extension.SignatureAlgorithms{
+					Schemes: dtlsflight.SignatureSchemeIDs([]signaturehash.Algorithm{ecdsaSHA256}),
 				},
 			},
 		},
@@ -606,22 +607,18 @@ type rawExtension struct {
 	raw       []byte
 }
 
-func (e rawExtension) Marshal() ([]byte, error) {
-	return append([]byte(nil), e.raw...), nil
-}
-
-func (e rawExtension) Unmarshal([]byte) error {
-	return nil
-}
-
-func (e rawExtension) TypeValue() extension.TypeValue {
+func (e rawExtension) ExtensionType() extension.Type {
 	return e.typeValue
+}
+
+func (e rawExtension) MarshalData() ([]byte, error) {
+	return append([]byte(nil), e.raw[4:]...), nil
 }
 
 func marshalHelloRetryRequestServerHello(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -637,7 +634,7 @@ func marshalServerHello(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
 	random handshake.Random,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -648,7 +645,7 @@ func marshalServerHelloWithSequence(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
 	random handshake.Random,
-	extensions []extension.Extension,
+	extensions []extension.Value,
 	seq uint16,
 ) []byte {
 	t.Helper()
@@ -720,9 +717,9 @@ func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) 
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var supportedVersions *extension.SupportedVersions
+	var supportedVersions *extension13.OfferedVersions
 	for _, ext := range clientHello.Extensions {
-		if sv, ok := ext.(*extension.SupportedVersions); ok {
+		if sv, ok := ext.(*extension13.OfferedVersions); ok {
 			supportedVersions = sv
 
 			break
@@ -730,7 +727,6 @@ func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) 
 	}
 	require.NotNil(t, supportedVersions)
 	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
-	assert.False(t, supportedVersions.IsSelectedVersion())
 }
 
 func TestFlight13_1GenerateClientHelloIncludesSignatureAlgorithms(t *testing.T) {
@@ -739,21 +735,21 @@ func TestFlight13_1GenerateClientHelloIncludesSignatureAlgorithms(t *testing.T) 
 
 	clientHello := generateFlight13_1ClientHello(t, cfg)
 
-	var signatureAlgorithms *extension.SupportedSignatureAlgorithms
-	var signatureAlgorithmsCert *extension.SignatureAlgorithmsCert
+	var signatureAlgorithms *extension.SignatureAlgorithms
+	var signatureAlgorithmsCert *extension.CertificateSignatureAlgorithms
 	for _, ext := range clientHello.Extensions {
 		switch typed := ext.(type) {
-		case *extension.SupportedSignatureAlgorithms:
+		case *extension.SignatureAlgorithms:
 			signatureAlgorithms = typed
-		case *extension.SignatureAlgorithmsCert:
+		case *extension.CertificateSignatureAlgorithms:
 			signatureAlgorithmsCert = typed
 		}
 	}
 
 	require.NotNil(t, signatureAlgorithms)
-	assert.Equal(t, cfg.LocalSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
+	assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes), signatureAlgorithms.Schemes)
 	require.NotNil(t, signatureAlgorithmsCert)
-	assert.Equal(t, cfg.LocalCertSignatureSchemes, signatureAlgorithmsCert.SignatureHashAlgorithms)
+	assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalCertSignatureSchemes), signatureAlgorithmsCert.Schemes)
 }
 
 func TestFlight13_1GenerateClientHelloIncludesSupportedGroups(t *testing.T) {
@@ -761,9 +757,9 @@ func TestFlight13_1GenerateClientHelloIncludesSupportedGroups(t *testing.T) {
 
 	clientHello := generateFlight13_1ClientHello(t, cfg)
 
-	var supportedGroups *extension.SupportedEllipticCurves
+	var supportedGroups *extension.SupportedGroups
 	for _, ext := range clientHello.Extensions {
-		if typed, ok := ext.(*extension.SupportedEllipticCurves); ok {
+		if typed, ok := ext.(*extension.SupportedGroups); ok {
 			supportedGroups = typed
 
 			break
@@ -771,7 +767,7 @@ func TestFlight13_1GenerateClientHelloIncludesSupportedGroups(t *testing.T) {
 	}
 
 	require.NotNil(t, supportedGroups)
-	assert.Equal(t, cfg.EllipticCurves, supportedGroups.EllipticCurves)
+	assert.Equal(t, cfg.EllipticCurves, supportedGroups.Groups)
 }
 
 func TestFlight13_1GenerateRetainsPrivateKeysForAdvertisedShares(t *testing.T) {
@@ -797,20 +793,20 @@ func TestFlight13_1GenerateRetainsPrivateKeysForAdvertisedShares(t *testing.T) {
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var keyShare *extension.KeyShare
+	var keyShare *extension13.ClientKeyShare
 	for _, ext := range clientHello.Extensions {
-		if ks, ok := ext.(*extension.KeyShare); ok {
+		if ks, ok := ext.(*extension13.ClientKeyShare); ok {
 			keyShare = ks
 
 			break
 		}
 	}
 	require.NotNil(t, keyShare)
-	require.Len(t, keyShare.ClientShares, len(cfg.EllipticCurves))
-	require.Len(t, state.LocalKeyEntries, len(keyShare.ClientShares))
-	require.Len(t, state.LocalKeypairs, len(keyShare.ClientShares))
+	require.Len(t, keyShare.Shares, len(cfg.EllipticCurves))
+	require.Len(t, state.LocalKeyEntries, len(keyShare.Shares))
+	require.Len(t, state.LocalKeypairs, len(keyShare.Shares))
 
-	for _, entry := range keyShare.ClientShares {
+	for _, entry := range keyShare.Shares {
 		t.Run(entry.Group.String(), func(t *testing.T) {
 			localKeypair, ok := state.LocalKeypairs[entry.Group]
 			require.True(t, ok)
@@ -854,18 +850,18 @@ func TestFlight13_1GenerateClientHelloIncludesX25519MLKEM768KeyShare(t *testing.
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var keyShare *extension.KeyShare
+	var keyShare *extension13.ClientKeyShare
 	for _, ext := range clientHello.Extensions {
-		if ks, ok := ext.(*extension.KeyShare); ok {
+		if ks, ok := ext.(*extension13.ClientKeyShare); ok {
 			keyShare = ks
 
 			break
 		}
 	}
 	require.NotNil(t, keyShare)
-	require.Len(t, keyShare.ClientShares, 1)
-	assert.Equal(t, elliptic.X25519MLKEM768, keyShare.ClientShares[0].Group)
-	assert.Len(t, keyShare.ClientShares[0].KeyExchange, elliptic.X25519MLKEM768ClientPublicKeySize)
+	require.Len(t, keyShare.Shares, 1)
+	assert.Equal(t, elliptic.X25519MLKEM768, keyShare.Shares[0].Group)
+	assert.Len(t, keyShare.Shares[0].KeyExchange, elliptic.X25519MLKEM768ClientPublicKeySize)
 
 	localKeypair := state.LocalKeypairs[elliptic.X25519MLKEM768]
 	require.NotNil(t, localKeypair)
@@ -897,12 +893,9 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
 		cfg,
-		[]extension.Extension{
-			&extension.SupportedVersions{
-				Versions:        []protocol.Version{protocol.Version1_3},
-				SelectedVersion: true,
-			},
-			&extension.KeyShare{SelectedGroup: &selectedGroup},
+		[]extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
+			&extension13.RetryKeyShare{SelectedGroup: selectedGroup},
 		},
 	)
 
@@ -933,8 +926,8 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *test
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
 		cfg,
-		[]extension.Extension{
-			&extension.KeyShare{SelectedGroup: &selectedGroup},
+		[]extension.Value{
+			&extension13.RetryKeyShare{SelectedGroup: selectedGroup},
 		},
 	)
 
@@ -964,12 +957,9 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithWrongSelectedVersion(t *test
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
 		cfg,
-		[]extension.Extension{
-			&extension.SupportedVersions{
-				Versions:        []protocol.Version{protocol.Version1_2},
-				SelectedVersion: true,
-			},
-			&extension.KeyShare{SelectedGroup: &selectedGroup},
+		[]extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_2},
+			&extension13.RetryKeyShare{SelectedGroup: selectedGroup},
 		},
 	)
 
@@ -999,7 +989,7 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithClientHelloSupportedVersions
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
 		cfg,
-		[]extension.Extension{
+		[]extension.Value{
 			rawExtension{
 				typeValue: extension.SupportedVersionsTypeValue,
 				raw: []byte{
@@ -1009,27 +999,13 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithClientHelloSupportedVersions
 					0xfe, 0xfc, // DTLS v1.3
 				},
 			},
-			&extension.KeyShare{SelectedGroup: &selectedGroup},
+			&extension13.RetryKeyShare{SelectedGroup: selectedGroup},
 		},
 	)
 
-	state := newTestState13(false)
-	cache := dtlsflight.NewCache()
-	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
-
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
-		t, dtlsflight13.Flight1, context.Background(), &handshakeTestContext13{
-			state: state,
-			cache: cache,
-			cfg:   cfg,
-		})
-
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
-	require.NotNil(t, dtlsAlert)
-	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
-	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
-	assert.Zero(t, nextFlight)
-	assert.False(t, state.HasRemoteKeyEntries)
+	parsed := &handshake.Handshake{}
+	err := parsed.Unmarshal(rawServerHello)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidSupportedVersionsFormat)
 }
 
 func TestFlight13_3GenerateRejectsWithoutCommonVersion(t *testing.T) {
@@ -1073,9 +1049,9 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var supportedVersions *extension.SupportedVersions
+	var supportedVersions *extension13.OfferedVersions
 	for _, ext := range clientHello.Extensions {
-		if sv, ok := ext.(*extension.SupportedVersions); ok {
+		if sv, ok := ext.(*extension13.OfferedVersions); ok {
 			supportedVersions = sv
 
 			break
@@ -1083,22 +1059,21 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 	}
 	require.NotNil(t, supportedVersions)
 	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
-	assert.False(t, supportedVersions.IsSelectedVersion())
 
-	var signatureAlgorithms *extension.SupportedSignatureAlgorithms
+	var signatureAlgorithms *extension.SignatureAlgorithms
 	for _, ext := range clientHello.Extensions {
-		if sigAlgs, ok := ext.(*extension.SupportedSignatureAlgorithms); ok {
+		if sigAlgs, ok := ext.(*extension.SignatureAlgorithms); ok {
 			signatureAlgorithms = sigAlgs
 
 			break
 		}
 	}
 	require.NotNil(t, signatureAlgorithms)
-	assert.Equal(t, cfg.LocalSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
+	assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes), signatureAlgorithms.Schemes)
 
-	var cookieExt *extension.CookieExt
+	var cookieExt *extension13.Cookie
 	for _, ext := range clientHello.Extensions {
-		if c, ok := ext.(*extension.CookieExt); ok {
+		if c, ok := ext.(*extension13.Cookie); ok {
 			cookieExt = c
 
 			break
@@ -1116,10 +1091,10 @@ func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.
 	require.NoError(t, err)
 	state := newTestState13(false)
 	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	state.LocalKeyEntries = []extension.KeyShareEntry{
+	state.LocalKeyEntries = []extension13.KeyShareEntry{
 		{Group: originalKeypair.Curve, KeyExchange: originalKeypair.PublicKey},
 	}
-	state.RemoteKeyEntries = []extension.KeyShareEntry{{Group: selectedGroup}}
+	state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: selectedGroup}}
 	state.HasRemoteKeyEntries = true
 	require.NoError(t, state.LocalRandom.Populate())
 
@@ -1142,23 +1117,23 @@ func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var keyShare *extension.KeyShare
+	var keyShare *extension13.ClientKeyShare
 	for _, ext := range clientHello.Extensions {
-		if ks, ok := ext.(*extension.KeyShare); ok {
+		if ks, ok := ext.(*extension13.ClientKeyShare); ok {
 			keyShare = ks
 
 			break
 		}
 	}
 	require.NotNil(t, keyShare)
-	require.Len(t, keyShare.ClientShares, 2)
-	assert.Equal(t, selectedGroup, keyShare.ClientShares[0].Group)
-	assert.NotEmpty(t, keyShare.ClientShares[0].KeyExchange)
-	assert.Equal(t, elliptic.X25519, keyShare.ClientShares[1].Group)
+	require.Len(t, keyShare.Shares, 2)
+	assert.Equal(t, selectedGroup, keyShare.Shares[0].Group)
+	assert.NotEmpty(t, keyShare.Shares[0].KeyExchange)
+	assert.Equal(t, elliptic.X25519, keyShare.Shares[1].Group)
 
 	selectedKeypair := state.LocalKeypairs[selectedGroup]
 	require.NotNil(t, selectedKeypair)
-	assert.Equal(t, keyShare.ClientShares[0].KeyExchange, selectedKeypair.PublicKey)
+	assert.Equal(t, keyShare.Shares[0].KeyExchange, selectedKeypair.PublicKey)
 }
 
 func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T) {
@@ -1169,10 +1144,10 @@ func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T)
 	require.NoError(t, err)
 	state := newTestState13(false)
 	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	state.LocalKeyEntries = []extension.KeyShareEntry{
+	state.LocalKeyEntries = []extension13.KeyShareEntry{
 		{Group: keypair.Curve, KeyExchange: keypair.PublicKey},
 	}
-	state.RemoteKeyEntries = []extension.KeyShareEntry{{Group: selectedGroup}}
+	state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: selectedGroup}}
 	state.HasRemoteKeyEntries = true
 	require.NoError(t, state.LocalRandom.Populate())
 
@@ -1195,17 +1170,17 @@ func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T)
 	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var keyShare *extension.KeyShare
+	var keyShare *extension13.ClientKeyShare
 	for _, ext := range clientHello.Extensions {
-		if ks, ok := ext.(*extension.KeyShare); ok {
+		if ks, ok := ext.(*extension13.ClientKeyShare); ok {
 			keyShare = ks
 
 			break
 		}
 	}
 	require.NotNil(t, keyShare)
-	require.Len(t, keyShare.ClientShares, 1)
-	assert.Equal(t, selectedGroup, keyShare.ClientShares[0].Group)
+	require.Len(t, keyShare.Shares, 1)
+	assert.Equal(t, selectedGroup, keyShare.Shares[0].Group)
 }
 
 func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
@@ -1227,9 +1202,9 @@ func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
 	require.NoError(t, err)
 
 	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01, 0x02, 0x03}}
-	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
 	require.NoError(t, err)
@@ -1328,9 +1303,9 @@ func TestFlight13_3ParseDrainsQueuedProtectedHandshakeBeforeEncryptedExtensions(
 	require.NoError(t, err)
 	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
 		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
-	}, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	}, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello[0])
 	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
@@ -1426,9 +1401,9 @@ func TestFlight13ClientParsesEncryptedExtensionsFromProtectedRecord(t *testing.T
 	require.NoError(t, err)
 	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
 		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
-	}, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	}, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
 	require.NoError(t, err)
@@ -1523,9 +1498,9 @@ func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 	require.NoError(t, err)
 	rawServerHello := marshalServerHello(t, cfg, handshake.Random{
 		RandomBytes: [handshake.RandomBytesLength]byte{0x01},
-	}, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	}, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 	serverHelloCanonical, err := canonicalHandshake13(rawServerHello)
 	require.NoError(t, err)
@@ -1599,9 +1574,9 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 	clientHello1Canonical := canonicalPacketHandshake13(t, pkts[0])
 
 	group := cfg.EllipticCurves[0]
-	rawHelloRetryRequest := marshalHelloRetryRequestServerHello(t, cfg, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{SelectedGroup: &group},
+	rawHelloRetryRequest := marshalHelloRetryRequestServerHello(t, cfg, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.RetryKeyShare{SelectedGroup: group},
 	})
 	helloRetryRequestCanonical, err := canonicalHandshake13(rawHelloRetryRequest)
 	require.NoError(t, err)
@@ -1640,9 +1615,9 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 		t,
 		cfg,
 		handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x02}},
-		[]extension.Extension{
-			&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-			&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+		[]extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
+			&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 		},
 		1,
 	)
@@ -2047,8 +2022,8 @@ func TestFlight13_3ParseRejectsSecondHelloRetryRequest(t *testing.T) {
 	_, _, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg})
 	require.NoError(t, err)
 
-	rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+	rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
 	})
 
 	cache := dtlsflight.NewCache()
@@ -2089,9 +2064,9 @@ func TestFlight13_3ParseRejectsWrongLegacyVersion(t *testing.T) {
 		Random:            handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}},
 		CipherSuiteID:     &cipherSuiteID,
 		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-		Extensions: []extension.Extension{
-			&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-			&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+		Extensions: []extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
+			&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 		},
 	}
 	rawServerHello, err := (&handshake.Handshake{Message: serverHello}).Marshal()
@@ -2129,8 +2104,8 @@ func TestFlight13_3ParseRejectsMissingSupportedVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
-	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Value{
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 
 	cache := dtlsflight.NewCache()
@@ -2161,8 +2136,8 @@ func TestFlight13_3ParseRejectsMissingKeyShare(t *testing.T) {
 	require.NoError(t, err)
 
 	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
-	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
 	})
 
 	cache := dtlsflight.NewCache()
@@ -2195,9 +2170,9 @@ func TestFlight13_3ParseRejectsUnofferedKeyShareGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
-	rawServerHello := marshalServerHello(t, cfg, random, []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
+	rawServerHello := marshalServerHello(t, cfg, random, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
 	})
 
 	cache := dtlsflight.NewCache()
@@ -2237,21 +2212,15 @@ func TestFlight13_0ParseSelectsNegotiatedGroupWithoutGeneratingKeypair(t *testin
 			uint16(cfg.LocalCipherSuites[0].ID()),
 		},
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-			},
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.P384},
-			},
-			&extension.KeyShare{
-				ClientShares: []extension.KeyShareEntry{
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.P384}},
+			&extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{
 					{Group: elliptic.P384, KeyExchange: clientKeypair.PublicKey},
 				},
 			},
-			&extension.SupportedVersions{
-				Versions: []protocol.Version{protocol.Version1_3},
-			},
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 		},
 	}
 	rawClientHello, err := (&handshake.Handshake{Message: clientHello}).Marshal()
@@ -2292,21 +2261,15 @@ func TestFlight13_0ParseSelectsX25519MLKEM768WithoutGeneratingKeypair(t *testing
 			uint16(cfg.LocalCipherSuites[0].ID()),
 		},
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-			},
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.X25519MLKEM768},
-			},
-			&extension.KeyShare{
-				ClientShares: []extension.KeyShareEntry{
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519MLKEM768}},
+			&extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{
 					{Group: elliptic.X25519MLKEM768, KeyExchange: clientKeypair.PublicKey},
 				},
 			},
-			&extension.SupportedVersions{
-				Versions: []protocol.Version{protocol.Version1_3},
-			},
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 		},
 	}
 	rawClientHello, err := (&handshake.Handshake{Message: clientHello}).Marshal()
@@ -2342,22 +2305,18 @@ func TestFlight13_0ParseSelectsServerPreferredGroupFromClientShares(t *testing.T
 
 	state := newTestState13(false)
 	cache := dtlsflight.NewCache()
-	pushFlight13_0ClientHello(t, cache, cfg, []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+	pushFlight13_0ClientHello(t, cache, cfg, []extension.Value{
+		&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+		&extension.SupportedGroups{
+			Groups: []elliptic.Curve{elliptic.X25519, elliptic.X25519MLKEM768},
 		},
-		&extension.SupportedEllipticCurves{
-			EllipticCurves: []elliptic.Curve{elliptic.X25519, elliptic.X25519MLKEM768},
-		},
-		&extension.KeyShare{
-			ClientShares: []extension.KeyShareEntry{
+		&extension13.ClientKeyShare{
+			Shares: []extension13.KeyShareEntry{
 				{Group: elliptic.X25519, KeyExchange: x25519Keypair.PublicKey},
 				{Group: elliptic.X25519MLKEM768, KeyExchange: mlkemKeypair.PublicKey},
 			},
 		},
-		&extension.SupportedVersions{
-			Versions: []protocol.Version{protocol.Version1_3},
-		},
+		&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 	})
 
 	nextFlight, dtlsAlert, err := flight13ParseForTest(
@@ -2384,21 +2343,15 @@ func TestFlight13_0ParseRequestsPreferredGroupWhenShareMissing(t *testing.T) {
 
 	state := newTestState13(false)
 	cache := dtlsflight.NewCache()
-	pushFlight13_0ClientHello(t, cache, cfg, []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-		},
-		&extension.SupportedEllipticCurves{
-			EllipticCurves: cfg.EllipticCurves,
-		},
-		&extension.KeyShare{
-			ClientShares: []extension.KeyShareEntry{
+	pushFlight13_0ClientHello(t, cache, cfg, []extension.Value{
+		&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+		&extension.SupportedGroups{Groups: cfg.EllipticCurves},
+		&extension13.ClientKeyShare{
+			Shares: []extension13.KeyShareEntry{
 				{Group: elliptic.X25519, KeyExchange: x25519Keypair.PublicKey},
 			},
 		},
-		&extension.SupportedVersions{
-			Versions: []protocol.Version{protocol.Version1_3},
-		},
+		&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 	})
 
 	nextFlight, dtlsAlert, err := flight13ParseForTest(
@@ -2414,10 +2367,9 @@ func TestFlight13_0ParseRequestsPreferredGroupWhenShareMissing(t *testing.T) {
 	assert.Equal(t, elliptic.X25519MLKEM768, state.SelectedGroup)
 
 	serverHello := serverHelloFromFlight13_2(t, state, cfg)
-	keyShare, ok := findKeyShare(serverHello.Extensions)
+	keyShare, ok := findRetryKeyShare(serverHello.Extensions)
 	require.True(t, ok)
-	require.NotNil(t, keyShare.SelectedGroup)
-	assert.Equal(t, elliptic.X25519MLKEM768, *keyShare.SelectedGroup)
+	assert.Equal(t, elliptic.X25519MLKEM768, keyShare.SelectedGroup)
 }
 
 func TestFlight13_0ParseRejectsClientHelloWithSelectedSupportedVersion(t *testing.T) {
@@ -2430,40 +2382,23 @@ func TestFlight13_0ParseRejectsClientHelloWithSelectedSupportedVersion(t *testin
 			uint16(cfg.LocalCipherSuites[0].ID()),
 		},
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-		Extensions: []extension.Extension{
-			&extension.SupportedVersions{
-				Versions:        []protocol.Version{protocol.Version1_3},
-				SelectedVersion: true,
-			},
+		Extensions: []extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
 		},
 	}
 	rawClientHello, err := (&handshake.Handshake{Message: clientHello}).Marshal()
 	require.NoError(t, err)
 
-	state := newTestState13(false)
-	cache := dtlsflight.NewCache()
-	cache.Push(rawClientHello, cfg.InitialEpoch, 0, handshake.TypeClientHello, true)
-
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
-		t, dtlsflight13.Flight0, context.Background(), &handshakeTestContext13{
-			state: state,
-			cache: cache,
-			cfg:   cfg,
-		})
-
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
-	require.NotNil(t, dtlsAlert)
-	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
-	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
-	assert.Zero(t, nextFlight)
-	assert.Empty(t, state.RemoteVersions)
+	parsed := &handshake.Handshake{}
+	err = parsed.Unmarshal(rawClientHello)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidSupportedVersionsFormat)
 }
 
 func pushFlight13_0ClientHello(
 	t *testing.T,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-	exts []extension.Extension,
+	exts []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -2484,27 +2419,21 @@ func pushFlight13_0ClientHello(
 	return rawClientHello
 }
 
-func requiredClientHello13Extensions(t *testing.T, cfg *dtlsconfig.HandshakeConfig) []extension.Extension {
+func requiredClientHello13Extensions(t *testing.T, cfg *dtlsconfig.HandshakeConfig) []extension.Value {
 	t.Helper()
 
 	clientKeypair, err := elliptic.GenerateKeypair(cfg.EllipticCurves[0])
 	require.NoError(t, err)
 
-	return []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-		},
-		&extension.SupportedEllipticCurves{
-			EllipticCurves: cfg.EllipticCurves,
-		},
-		&extension.KeyShare{
-			ClientShares: []extension.KeyShareEntry{
+	return []extension.Value{
+		&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+		&extension.SupportedGroups{Groups: cfg.EllipticCurves},
+		&extension13.ClientKeyShare{
+			Shares: []extension13.KeyShareEntry{
 				{Group: clientKeypair.Curve, KeyExchange: clientKeypair.PublicKey},
 			},
 		},
-		&extension.SupportedVersions{
-			Versions: []protocol.Version{protocol.Version1_3},
-		},
+		&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 	}
 }
 
@@ -2534,15 +2463,13 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 		state := newTestState13(false)
 		cache := dtlsflight.NewCache()
 		binder := make([]byte, 32)
-		pushFlight13_0ClientHello(t, cache, cfg, []extension.Extension{
-			&extension.SupportedVersions{
-				Versions: []protocol.Version{protocol.Version1_3},
-			},
-			&extension.PreSharedKey{
-				Identities: []extension.PskIdentity{
+		pushFlight13_0ClientHello(t, cache, cfg, []extension.Value{
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension13.OfferedPSKs{
+				Identities: []extension13.PSKIdentity{
 					{Identity: []byte("psk"), ObfuscatedTicketAge: 0},
 				},
-				Binders: []extension.PskBinderEntry{binder},
+				Binders: []extension13.PSKBinder{binder},
 			},
 		})
 
@@ -2583,10 +2510,8 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 		state := newTestState13(false)
 		cache := dtlsflight.NewCache()
 		exts := requiredClientHello13Extensions(t, cfg)[1:]
-		exts = append([]extension.Extension{
-			&extension.SignatureAlgorithmsCert{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-			},
+		exts = append([]extension.Value{
+			&extension.CertificateSignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
 		}, exts...)
 		pushFlight13_0ClientHello(t, cache, cfg, exts)
 
@@ -2608,7 +2533,7 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 		state := newTestState13(false)
 		cache := dtlsflight.NewCache()
 		required := requiredClientHello13Extensions(t, cfg)
-		exts := []extension.Extension{required[0], required[2], required[3]}
+		exts := []extension.Value{required[0], required[2], required[3]}
 		pushFlight13_0ClientHello(t, cache, cfg, exts)
 
 		nextFlight, dtlsAlert, err := flight13ParseForTest(
@@ -2680,7 +2605,7 @@ func TestFlight13ServerParseAppendsHRRTranscriptOrder(t *testing.T) {
 	)
 	helloRetryRequestCanonical := canonicalPacketHandshake13(t, helloRetryRequest[0])
 
-	exts := append(requiredClientHello13Extensions(t, cfg), &extension.CookieExt{Cookie: cookie})
+	exts := append(requiredClientHello13Extensions(t, cfg), &extension13.Cookie{Cookie: cookie})
 	rawClientHello2 := pushClientHello13WithSequence(t, cache, protocol.Version1_2, 1, exts)
 	clientHello2Canonical, err := canonicalHandshake13(rawClientHello2)
 	require.NoError(t, err)
@@ -2724,9 +2649,9 @@ func serverHelloFromFlight13_2(
 	return serverHello
 }
 
-func findSupportedVersions(exts []extension.Extension) (*extension.SupportedVersions, bool) {
+func findSupportedVersions(exts []extension.Value) (*extension13.SelectedVersion, bool) {
 	for _, ext := range exts {
-		if typed, ok := ext.(*extension.SupportedVersions); ok {
+		if typed, ok := ext.(*extension13.SelectedVersion); ok {
 			return typed, true
 		}
 	}
@@ -2734,9 +2659,9 @@ func findSupportedVersions(exts []extension.Extension) (*extension.SupportedVers
 	return nil, false
 }
 
-func findKeyShare(exts []extension.Extension) (*extension.KeyShare, bool) {
+func findRetryKeyShare(exts []extension.Value) (*extension13.RetryKeyShare, bool) {
 	for _, ext := range exts {
-		if typed, ok := ext.(*extension.KeyShare); ok {
+		if typed, ok := ext.(*extension13.RetryKeyShare); ok {
 			return typed, true
 		}
 	}
@@ -2744,9 +2669,19 @@ func findKeyShare(exts []extension.Extension) (*extension.KeyShare, bool) {
 	return nil, false
 }
 
-func findCookie(exts []extension.Extension) (*extension.CookieExt, bool) {
+func findServerKeyShare(exts []extension.Value) (*extension13.ServerKeyShare, bool) {
 	for _, ext := range exts {
-		if typed, ok := ext.(*extension.CookieExt); ok {
+		if typed, ok := ext.(*extension13.ServerKeyShare); ok {
+			return typed, true
+		}
+	}
+
+	return nil, false
+}
+
+func findCookie(exts []extension.Value) (*extension13.Cookie, bool) {
+	for _, ext := range exts {
+		if typed, ok := ext.(*extension13.Cookie); ok {
 			return typed, true
 		}
 	}
@@ -2800,8 +2735,7 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		supportedVersions, ok := findSupportedVersions(serverHello.Extensions)
 		require.True(t, ok, "SupportedVersions extension must always be present")
-		assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
-		assert.True(t, supportedVersions.IsSelectedVersion())
+		assert.Equal(t, protocol.Version1_3, supportedVersions.Version)
 	})
 
 	t.Run("IncludesCipherSuiteAndCompressionMethod", func(t *testing.T) {
@@ -2832,7 +2766,7 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		serverHello := serverHelloFromFlight13_2(t, state, cfg)
 
-		_, hasKeyShare := findKeyShare(serverHello.Extensions)
+		_, hasKeyShare := findRetryKeyShare(serverHello.Extensions)
 		assert.False(t, hasKeyShare, "KeyShare must be omitted when no remote key entries were offered")
 
 		_, hasCookie := findCookie(serverHello.Extensions)
@@ -2848,16 +2782,15 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		serverHello := serverHelloFromFlight13_2(t, state, cfg)
 
-		keyShare, ok := findKeyShare(serverHello.Extensions)
+		keyShare, ok := findRetryKeyShare(serverHello.Extensions)
 		require.True(t, ok, "KeyShare must be present when remote key entries were offered")
-		require.NotNil(t, keyShare.SelectedGroup)
-		assert.Equal(t, elliptic.X25519, *keyShare.SelectedGroup)
+		assert.Equal(t, elliptic.X25519, keyShare.SelectedGroup)
 	})
 
 	t.Run("OmitsKeyShareWhenSelectedGroupWasAlreadyOffered", func(t *testing.T) {
 		state := newTestState13(false)
 		state.SelectedGroup = elliptic.X25519
-		state.RemoteKeyEntries = []extension.KeyShareEntry{{
+		state.RemoteKeyEntries = []extension13.KeyShareEntry{{
 			Group:       elliptic.X25519,
 			KeyExchange: []byte{0x01},
 		}}
@@ -2866,7 +2799,7 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		serverHello := serverHelloFromFlight13_2(t, state, cfg)
 
-		_, hasKeyShare := findKeyShare(serverHello.Extensions)
+		_, hasKeyShare := findRetryKeyShare(serverHello.Extensions)
 		assert.False(t, hasKeyShare, "KeyShare must be omitted when the selected group was already offered")
 	})
 
@@ -2896,12 +2829,11 @@ func TestFlight13_2Generate(t *testing.T) {
 
 		supportedVersions, ok := findSupportedVersions(serverHello.Extensions)
 		require.True(t, ok)
-		assert.Equal(t, dtlsconfig.SupportedVersionsRange(cfg.MinVersion, cfg.MaxVersion), supportedVersions.Versions)
+		assert.Equal(t, protocol.Version1_3, supportedVersions.Version)
 
-		keyShare, ok := findKeyShare(serverHello.Extensions)
+		keyShare, ok := findRetryKeyShare(serverHello.Extensions)
 		require.True(t, ok)
-		require.NotNil(t, keyShare.SelectedGroup)
-		assert.Equal(t, elliptic.P256, *keyShare.SelectedGroup)
+		assert.Equal(t, elliptic.P256, keyShare.SelectedGroup)
 
 		cookieExt, ok := findCookie(serverHello.Extensions)
 		require.True(t, ok)
@@ -2968,9 +2900,9 @@ func TestFlight13_4Generate(t *testing.T) {
 				require.NotNil(t, certificateRequest)
 				assert.Empty(t, certificateRequest.CertificateRequestContext)
 				require.Len(t, certificateRequest.Extensions, 1)
-				signatureAlgorithms, ok := certificateRequest.Extensions[0].(*extension.SupportedSignatureAlgorithms)
+				signatureAlgorithms, ok := certificateRequest.Extensions[0].(*extension.SignatureAlgorithms)
 				require.True(t, ok)
-				assert.Equal(t, cfg.LocalSignatureSchemes, signatureAlgorithms.SignatureHashAlgorithms)
+				assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes), signatureAlgorithms.Schemes)
 			})
 		}
 	})
@@ -3008,16 +2940,14 @@ func TestFlight13_4Generate(t *testing.T) {
 		require.NotNil(t, serverHello.CipherSuiteID)
 		assert.Equal(t, uint16(cfg.LocalCipherSuites[0].ID()), *serverHello.CipherSuiteID)
 
-		keyShare, ok := findKeyShare(serverHello.Extensions)
+		keyShare, ok := findServerKeyShare(serverHello.Extensions)
 		require.True(t, ok)
-		require.NotNil(t, keyShare.ServerShare)
-		assert.Equal(t, group, keyShare.ServerShare.Group)
-		assert.Equal(t, keypair.PublicKey, keyShare.ServerShare.KeyExchange)
+		assert.Equal(t, group, keyShare.Share.Group)
+		assert.Equal(t, keypair.PublicKey, keyShare.Share.KeyExchange)
 
 		supportedVersions, ok := findSupportedVersions(serverHello.Extensions)
 		require.True(t, ok)
-		assert.True(t, supportedVersions.IsSelectedVersion())
-		assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
+		assert.Equal(t, protocol.Version1_3, supportedVersions.Version)
 
 		encryptedExtensionsHandshake, ok := pkts[1].Record.Content.(*handshake.Handshake)
 		require.True(t, ok)
@@ -3118,7 +3048,7 @@ func pushClientHello13(
 	t *testing.T,
 	cache *dtlsflight.Cache,
 	version protocol.Version,
-	exts []extension.Extension,
+	exts []extension.Value,
 ) {
 	t.Helper()
 
@@ -3130,7 +3060,7 @@ func pushClientHello13WithSequence(
 	cache *dtlsflight.Cache,
 	version protocol.Version,
 	seq uint16,
-	exts []extension.Extension,
+	exts []extension.Value,
 ) []byte {
 	t.Helper()
 
@@ -3173,7 +3103,7 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := dtlsflight.NewCache()
 		cfg := testHandshakeConfig13(t)
 
-		exts := append(requiredClientHello13Extensions(t, cfg), &extension.CookieExt{Cookie: cookie})
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension13.Cookie{Cookie: cookie})
 		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3194,22 +3124,16 @@ func TestFlight13_2Parse(t *testing.T) {
 		state := newTestState13(false)
 		state.Cookie = cookie
 		cache := dtlsflight.NewCache()
-		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-			},
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: cfg.EllipticCurves,
-			},
-			&extension.KeyShare{
-				ClientShares: []extension.KeyShareEntry{
+		pushClientHello13(t, cache, protocol.Version1_2, []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+			&extension.SupportedGroups{Groups: cfg.EllipticCurves},
+			&extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{
 					{Group: elliptic.X25519MLKEM768, KeyExchange: clientKeypair.PublicKey},
 				},
 			},
-			&extension.SupportedVersions{
-				Versions: []protocol.Version{protocol.Version1_3},
-			},
-			&extension.CookieExt{Cookie: cookie},
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension13.Cookie{Cookie: cookie},
 		})
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3242,22 +3166,16 @@ func TestFlight13_2Parse(t *testing.T) {
 		state := newTestState13(false)
 		state.Cookie = cookie
 		cache := dtlsflight.NewCache()
-		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
-			},
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: []elliptic.Curve{elliptic.P384},
-			},
-			&extension.KeyShare{
-				ClientShares: []extension.KeyShareEntry{
+		pushClientHello13(t, cache, protocol.Version1_2, []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes)},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.P384}},
+			&extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{
 					{Group: elliptic.P384, KeyExchange: clientKeypair.PublicKey},
 				},
 			},
-			&extension.SupportedVersions{
-				Versions: []protocol.Version{protocol.Version1_3},
-			},
-			&extension.CookieExt{Cookie: cookie},
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension13.Cookie{Cookie: cookie},
 		})
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3294,7 +3212,7 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := dtlsflight.NewCache()
 		cfg := testHandshakeConfig13(t)
 
-		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerName{ServerName: "poison.example"})
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerNameOffer{ServerName: "poison.example"})
 		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3316,8 +3234,8 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := dtlsflight.NewCache()
 		cfg := testHandshakeConfig13(t)
 
-		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerName{ServerName: "poison.example"},
-			&extension.CookieExt{Cookie: []byte{0x00, 0x01, 0x02, 0x03}})
+		exts := append(requiredClientHello13Extensions(t, cfg), &extension.ServerNameOffer{ServerName: "poison.example"},
+			&extension13.Cookie{Cookie: []byte{0x00, 0x01, 0x02, 0x03}})
 		pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3339,8 +3257,8 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := dtlsflight.NewCache()
 		cfg := testHandshakeConfig13(t)
 
-		pushClientHello13(t, cache, protocol.Version{Major: 0xfe, Minor: 0xfd - 1}, []extension.Extension{
-			&extension.CookieExt{Cookie: cookie},
+		pushClientHello13(t, cache, protocol.Version{Major: 0xfe, Minor: 0xfd - 1}, []extension.Value{
+			&extension13.Cookie{Cookie: cookie},
 		})
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3358,8 +3276,8 @@ func TestFlight13_2Parse(t *testing.T) {
 		cache := dtlsflight.NewCache()
 		cfg := testHandshakeConfig13(t)
 
-		pushClientHello13(t, cache, protocol.Version1_2, []extension.Extension{
-			&extension.CookieExt{Cookie: cookie},
+		pushClientHello13(t, cache, protocol.Version1_2, []extension.Value{
+			&extension13.Cookie{Cookie: cookie},
 		})
 
 		next, dtlsAlert, err := flight13ParseForTest(
@@ -3372,7 +3290,7 @@ func TestFlight13_2Parse(t *testing.T) {
 	})
 }
 
-func findConnectionID(exts []extension.Extension) (*extension.ConnectionID, bool) {
+func findConnectionID(exts []extension.Value) (*extension.ConnectionID, bool) {
 	for _, ext := range exts {
 		if typed, ok := ext.(*extension.ConnectionID); ok {
 			return typed, true
@@ -3780,7 +3698,7 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 			for _, cid := range test.secondCIDs {
 				exts = append(exts, &extension.ConnectionID{CID: cid})
 			}
-			exts = append(exts, &extension.CookieExt{Cookie: cookie})
+			exts = append(exts, &extension13.Cookie{Cookie: cookie})
 			pushClientHello13(t, cache, protocol.Version1_2, exts)
 
 			nextFlight, dtlsAlert, err := flight13ParseForTest(
@@ -3811,7 +3729,7 @@ func TestFlight13_2ParseAcceptsRepeatedConnectionIDOffer(t *testing.T) {
 			cache := dtlsflight.NewCache()
 			exts := append(requiredClientHello13Extensions(t, cfg),
 				&extension.ConnectionID{CID: cid},
-				&extension.CookieExt{Cookie: cookie},
+				&extension13.Cookie{Cookie: cookie},
 			)
 			pushClientHello13(t, cache, protocol.Version1_2, exts)
 
@@ -4048,9 +3966,9 @@ func parseFlight13ServerHelloConnectionID(
 	group := cfg.EllipticCurves[0]
 	serverKeypair, err := elliptic.GenerateKeypair(group)
 	require.NoError(t, err)
-	extensions := []extension.Extension{
-		&extension.SupportedVersions{Versions: []protocol.Version{protocol.Version1_3}, SelectedVersion: true},
-		&extension.KeyShare{ServerShare: &extension.KeyShareEntry{
+	extensions := []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{
 			Group: group, KeyExchange: serverKeypair.PublicKey,
 		}},
 	}
@@ -4177,11 +4095,8 @@ func TestFlight13_1ParseRejectsConnectionIDInHelloRetryRequest(t *testing.T) {
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
 		cfg,
-		[]extension.Extension{
-			&extension.SupportedVersions{
-				Versions:        []protocol.Version{protocol.Version1_3},
-				SelectedVersion: true,
-			},
+		[]extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
 			&extension.ConnectionID{CID: []byte{}},
 		},
 	)

--- a/internal/flight/flight12/curves_test.go
+++ b/internal/flight/flight12/curves_test.go
@@ -37,14 +37,14 @@ func TestClientHelloFiltersX25519MLKEM768(t *testing.T) {
 	clientHello, ok := content.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
 
-	var supportedGroups *extension.SupportedEllipticCurves
+	var supportedGroups *extension.SupportedGroups
 	for _, ext := range clientHello.Extensions {
-		if groups, ok := ext.(*extension.SupportedEllipticCurves); ok {
+		if groups, ok := ext.(*extension.SupportedGroups); ok {
 			supportedGroups = groups
 		}
 	}
 	require.NotNil(t, supportedGroups)
-	require.Equal(t, []elliptic.Curve{elliptic.P256}, supportedGroups.EllipticCurves)
+	require.Equal(t, []elliptic.Curve{elliptic.P256}, supportedGroups.Groups)
 }
 
 func TestServerSelectsClassicalCurveFromClientGroups(t *testing.T) {

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -88,32 +89,32 @@ func flight0Parse(
 
 	for _, val := range clientHello.Extensions {
 		switch ext := val.(type) {
-		case *extension.SupportedEllipticCurves:
-			if len(ext.EllipticCurves) == 0 {
+		case *extension.SupportedGroups:
+			if len(ext.Groups) == 0 {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrNoSupportedEllipticCurves //nolint:lll
 			}
-			namedCurve, ok := selectEllipticCurve(cfg.EllipticCurves, ext.EllipticCurves)
+			namedCurve, ok := selectEllipticCurve(cfg.EllipticCurves, ext.Groups)
 			if !ok {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrNoSupportedEllipticCurves //nolint:lll
 			}
 			state.NamedCurve = namedCurve
-		case *extension.UseSRTP:
+		case *extension.SRTPOffer:
 			profile, ok := dtlsflight.FindMatchingSRTPProfile(cfg.LocalSRTPProtectionProfiles, ext.ProtectionProfiles)
 			if !ok {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrServerNoMatchingSRTPProfile //nolint:lll
 			}
 			state.SetSRTPProtectionProfile(profile)
 			state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
-		case *extension.UseExtendedMasterSecret:
+		case *extension12.ExtendedMasterSecret:
 			if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 				state.ExtendedMasterSecret = true
 			}
-		case *extension.ServerName:
+		case *extension.ServerNameOffer:
 			state.ServerName = ext.ServerName // remote server name
-		case *extension.RenegotiationInfo:
+		case *extension12.RenegotiationInfo:
 			state.RemoteSupportsRenegotiation = true
-		case *extension.ALPN:
-			state.PeerSupportedProtocols = ext.ProtocolNameList
+		case *extension.ALPNOffer:
+			state.PeerSupportedProtocols = ext.Protocols
 		case *extension.ConnectionID:
 			// Only set connection ID to be sent if server supports connection
 			// IDs.
@@ -121,9 +122,9 @@ func flight0Parse(
 				state.RemoteConnectionID = ext.CID
 				state.RemoteCIDOffered = true
 			}
-		case *extension.SignatureAlgorithmsCert:
+		case *extension.CertificateSignatureAlgorithms:
 			// Store the client's certificate signature schemes for later validation
-			state.RemoteCertSignatureSchemes = ext.SignatureHashAlgorithms
+			state.RemoteCertSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
 		}
 	}
 

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -84,18 +85,18 @@ func flight1Generate(
 		state.LocalRandom.RandomBytes = cfg.HelloRandomBytesGenerator()
 	}
 
-	extensions := []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+	extensions := []extension.Value{
+		&extension.SignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
 		},
-		&extension.RenegotiationInfo{
+		&extension12.RenegotiationInfo{
 			RenegotiatedConnection: 0,
 		},
 	}
 
 	if len(cfg.LocalCertSignatureSchemes) > 0 {
-		extensions = append(extensions, &extension.SignatureAlgorithmsCert{
-			SignatureHashAlgorithms: cfg.LocalCertSignatureSchemes,
+		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalCertSignatureSchemes),
 		})
 	}
 
@@ -109,18 +110,18 @@ func flight1Generate(
 	}
 
 	if setEllipticCurveCryptographyClientHelloExtensions {
-		extensions = append(extensions, []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: ellipticCurves,
+		extensions = append(extensions, []extension.Value{
+			&extension.SupportedGroups{
+				Groups: ellipticCurves,
 			},
-			&extension.SupportedPointFormats{
+			&extension12.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}...)
 	}
 
 	if len(cfg.LocalSRTPProtectionProfiles) > 0 {
-		extensions = append(extensions, &extension.UseSRTP{
+		extensions = append(extensions, &extension.SRTPOffer{
 			ProtectionProfiles:  cfg.LocalSRTPProtectionProfiles,
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
@@ -128,17 +129,15 @@ func flight1Generate(
 
 	if cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 
 	if len(cfg.ServerName) > 0 {
-		extensions = append(extensions, &extension.ServerName{ServerName: cfg.ServerName})
+		extensions = append(extensions, &extension.ServerNameOffer{ServerName: cfg.ServerName})
 	}
 
 	if len(cfg.SupportedProtocols) > 0 {
-		extensions = append(extensions, &extension.ALPN{ProtocolNameList: cfg.SupportedProtocols})
+		extensions = append(extensions, &extension.ALPNOffer{Protocols: cfg.SupportedProtocols})
 	}
 
 	if cfg.HasSessionStore {

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -64,25 +65,21 @@ func flight3Parse(
 		}
 		for _, v := range serverHelloMsg.Extensions {
 			switch ext := v.(type) {
-			case *extension.UseSRTP:
-				profile, found := dtlsflight.FindMatchingSRTPProfile(ext.ProtectionProfiles, cfg.LocalSRTPProtectionProfiles)
+			case *extension.SRTPSelection:
+				profile, found := dtlsflight.FindMatchingSRTPProfile(
+					[]extension.SRTPProtectionProfile{ext.ProtectionProfile}, cfg.LocalSRTPProtectionProfiles,
+				)
 				if !found {
 					return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlserrors.ErrClientNoMatchingSRTPProfile //nolint:lll
 				}
 				state.SetSRTPProtectionProfile(profile)
 				state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
-			case *extension.UseExtendedMasterSecret:
+			case *extension12.ExtendedMasterSecret:
 				if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 					state.ExtendedMasterSecret = true
 				}
-			case *extension.ALPN:
-				if len(ext.ProtocolNameList) > 1 { // This should be exactly 1, the zero case is handle when unmarshalling
-					return 0, &alert.Alert{
-						Level:       alert.Fatal,
-						Description: alert.InternalError,
-					}, extension.ErrALPNInvalidFormat // Meh, internal error?
-				}
-				state.NegotiatedProtocol = ext.ProtocolNameList[0]
+			case *extension.ALPNSelection:
+				state.NegotiatedProtocol = ext.Protocol
 			case *extension.ConnectionID:
 				// Only set connection ID to be sent if client supports connection
 				// IDs.
@@ -296,53 +293,51 @@ func flight3Generate(
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	extensions := []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+	extensions := []extension.Value{
+		&extension.SignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
 		},
-		&extension.RenegotiationInfo{
+		&extension12.RenegotiationInfo{
 			RenegotiatedConnection: 0,
 		},
 	}
 
 	if len(cfg.LocalCertSignatureSchemes) > 0 {
-		extensions = append(extensions, &extension.SignatureAlgorithmsCert{
-			SignatureHashAlgorithms: cfg.LocalCertSignatureSchemes,
+		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalCertSignatureSchemes),
 		})
 	}
 
 	if state.NamedCurve != 0 {
 		ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
 
-		extensions = append(extensions, []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: ellipticCurves,
+		extensions = append(extensions, []extension.Value{
+			&extension.SupportedGroups{
+				Groups: ellipticCurves,
 			},
-			&extension.SupportedPointFormats{
+			&extension12.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}...)
 	}
 
 	if len(cfg.LocalSRTPProtectionProfiles) > 0 {
-		extensions = append(extensions, &extension.UseSRTP{
+		extensions = append(extensions, &extension.SRTPOffer{
 			ProtectionProfiles:  cfg.LocalSRTPProtectionProfiles,
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
 	}
 
 	if isExtendedMasterSecretRequested(cfg.ExtendedMasterSecret) {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 
 	if len(cfg.ServerName) > 0 {
-		extensions = append(extensions, &extension.ServerName{ServerName: cfg.ServerName})
+		extensions = append(extensions, &extension.ServerNameOffer{ServerName: cfg.ServerName})
 	}
 
 	if len(cfg.SupportedProtocols) > 0 {
-		extensions = append(extensions, &extension.ALPN{ProtocolNameList: cfg.SupportedProtocols})
+		extensions = append(extensions, &extension.ALPNOffer{Protocols: cfg.SupportedProtocols})
 	}
 
 	// If we sent a connection ID on the first ClientHello, send it on the

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -66,18 +67,16 @@ func flight4bGenerate(
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	var pkts []*dtlsflight.Packet
 
-	extensions := []extension.Extension{&extension.RenegotiationInfo{
+	extensions := []extension.Value{&extension12.RenegotiationInfo{
 		RenegotiatedConnection: 0,
 	}}
 	if (cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret) && state.ExtendedMasterSecret {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 	if state.SRTPProtectionProfile() != 0 {
-		extensions = append(extensions, &extension.UseSRTP{
-			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.SRTPProtectionProfile()},
+		extensions = append(extensions, &extension.SRTPSelection{
+			ProtectionProfile:   state.SRTPProtectionProfile(),
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
 	}
@@ -87,9 +86,7 @@ func flight4bGenerate(
 		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.NoApplicationProtocol}, err
 	}
 	if selectedProto != "" {
-		extensions = append(extensions, &extension.ALPN{
-			ProtocolNameList: []string{selectedProto},
-		})
+		extensions = append(extensions, &extension.ALPNSelection{Protocol: selectedProto})
 		state.NegotiatedProtocol = selectedProto
 	}
 

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -253,27 +254,25 @@ func flight4Generate(
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	extensions := []extension.Extension{}
+	extensions := []extension.Value{}
 
 	if (cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret) && state.ExtendedMasterSecret {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 	if state.SRTPProtectionProfile() != 0 {
-		extensions = append(extensions, &extension.UseSRTP{
-			ProtectionProfiles:  []dtlsconfig.SRTPProtectionProfile{state.SRTPProtectionProfile()},
+		extensions = append(extensions, &extension.SRTPSelection{
+			ProtectionProfile:   state.SRTPProtectionProfile(),
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
 	}
 	if state.RemoteSupportsRenegotiation {
-		extensions = append(extensions, &extension.RenegotiationInfo{
+		extensions = append(extensions, &extension12.RenegotiationInfo{
 			RenegotiatedConnection: 0,
 		})
 	}
 	if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypeCertificate {
-		extensions = append(extensions, &extension.SupportedPointFormats{
+		extensions = append(extensions, &extension12.SupportedPointFormats{
 			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 		})
 	}
@@ -283,9 +282,7 @@ func flight4Generate(
 		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.NoApplicationProtocol}, err
 	}
 	if selectedProto != "" {
-		extensions = append(extensions, &extension.ALPN{
-			ProtocolNameList: []string{selectedProto},
-		})
+		extensions = append(extensions, &extension.ALPNSelection{Protocol: selectedProto})
 		state.NegotiatedProtocol = selectedProto
 	}
 

--- a/internal/flight/flight13/extensions.go
+++ b/internal/flight/flight13/extensions.go
@@ -13,6 +13,7 @@ import (
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -72,31 +73,28 @@ func processClientHelloSecurityExtension(
 	state *dtlsstate.State13,
 	cfg *dtlsconfig.HandshakeConfig,
 	seen *clientHelloExtensionSet,
-	val extension.Extension,
+	val extension.Value,
 ) *clientHelloExtensionFailure {
 	switch ext := val.(type) {
-	case *extension.SupportedEllipticCurves:
+	case *extension.SupportedGroups:
 		seen.hasSupportedGroups = true
-		if len(ext.EllipticCurves) == 0 {
+		if len(ext.Groups) == 0 {
 			return newClientHelloExtensionFailure(alert.InsufficientSecurity, dtlserrors.ErrNoSupportedEllipticCurves)
 		}
-		state.RemoteGroups = ext.EllipticCurves
-	case *extension.UseSRTP:
+		state.RemoteGroups = ext.Groups
+	case *extension.SRTPOffer:
 		profile, ok := dtlsflight.FindMatchingSRTPProfile(cfg.LocalSRTPProtectionProfiles, ext.ProtectionProfiles)
 		if !ok {
 			return newClientHelloExtensionFailure(alert.InsufficientSecurity, dtlserrors.ErrServerNoMatchingSRTPProfile)
 		}
 		state.SetSRTPProtectionProfile(profile)
 		state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
-	case *extension.SupportedSignatureAlgorithms:
+	case *extension.SignatureAlgorithms:
 		seen.hasSignatureAlgorithms = true
-		state.RemoteSignatureSchemes = ext.SignatureHashAlgorithms
-	case *extension.SupportedVersions:
-		if ext.IsSelectedVersion() {
-			return newClientHelloExtensionFailure(alert.IllegalParameter, dtlserrors.ErrInvalidClientHello)
-		}
+		state.RemoteSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
+	case *extension13.OfferedVersions:
 		state.RemoteVersions = ext.Versions
-	case *extension.PreSharedKey:
+	case *extension13.OfferedPSKs:
 		seen.hasPreSharedKey = true
 	}
 
@@ -105,25 +103,25 @@ func processClientHelloSecurityExtension(
 
 func processClientHelloStateExtension(
 	state *dtlsstate.State13,
-	val extension.Extension,
+	val extension.Value,
 ) {
 	switch ext := val.(type) {
-	case *extension.ServerName:
+	case *extension.ServerNameOffer:
 		state.ServerName = ext.ServerName // remote server name
-	case *extension.ALPN:
-		state.PeerSupportedProtocols = ext.ProtocolNameList
-	case *extension.SignatureAlgorithmsCert:
+	case *extension.ALPNOffer:
+		state.PeerSupportedProtocols = ext.Protocols
+	case *extension.CertificateSignatureAlgorithms:
 		// Store the client's certificate signature schemes for later validation.
-		state.RemoteCertSignatureSchemes = ext.SignatureHashAlgorithms
-	case *extension.KeyShare:
-		state.RemoteKeyEntries = ext.ClientShares
+		state.RemoteCertSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
+	case *extension13.ClientKeyShare:
+		state.RemoteKeyEntries = ext.Shares
 		state.HasRemoteKeyEntries = true
 	}
 }
 
 // connectionIDExtension extracts a connection_id extension while preserving
 // the distinction between an absent extension and a present, zero-length CID.
-func connectionIDExtension(extensions []extension.Extension) ([]byte, bool, bool) {
+func connectionIDExtension(extensions []extension.Value) ([]byte, bool, bool) {
 	var cid []byte
 	found := false
 	for _, val := range extensions {

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -47,20 +49,18 @@ func flight1Generate(
 		state.LocalRandom.RandomBytes = cfg.HelloRandomBytesGenerator()
 	}
 
-	extensions := []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+	extensions := []extension.Value{
+		&extension.SignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
 		},
 	}
 
 	if cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 
-	extensions = append(extensions, &extension.RenegotiationInfo{
+	extensions = append(extensions, &extension12.RenegotiationInfo{
 		RenegotiatedConnection: 0,
 	})
 
@@ -74,54 +74,54 @@ func flight1Generate(
 	}
 
 	if setEllipticCurveCryptographyClientHelloExtensions {
-		extensions = append(extensions, []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: cfg.EllipticCurves,
+		extensions = append(extensions, []extension.Value{
+			&extension.SupportedGroups{
+				Groups: cfg.EllipticCurves,
 			},
-			&extension.SupportedPointFormats{
+			&extension12.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}...)
 	}
 
 	if len(cfg.SupportedProtocols) > 0 {
-		extensions = append(extensions, &extension.ALPN{ProtocolNameList: cfg.SupportedProtocols})
+		extensions = append(extensions, &extension.ALPNOffer{Protocols: cfg.SupportedProtocols})
 	}
 
-	entries := make([]extension.KeyShareEntry, 0, len(cfg.EllipticCurves))
+	entries := make([]extension13.KeyShareEntry, 0, len(cfg.EllipticCurves))
 	keypairs := make(map[elliptic.Curve]*elliptic.Keypair, len(cfg.EllipticCurves))
 	for _, group := range cfg.EllipticCurves {
 		keypair, err := elliptic.GenerateKeypair(group)
 		if err != nil {
 			return nil, nil, err
 		}
-		entries = append(entries, extension.KeyShareEntry{
+		entries = append(entries, extension13.KeyShareEntry{
 			Group: keypair.Curve, KeyExchange: keypair.PublicKey,
 		})
 		keypairs[keypair.Curve] = keypair
 	}
 	state.LocalKeyEntries = entries
 	state.LocalKeypairs = keypairs
-	extensions = append(extensions, &extension.KeyShare{
-		ClientShares: entries,
+	extensions = append(extensions, &extension13.ClientKeyShare{
+		Shares: entries,
 	})
 
-	extensions = append(extensions, &extension.SupportedVersions{
+	extensions = append(extensions, &extension13.OfferedVersions{
 		Versions: dtlsconfig.SupportedVersionsRange(cfg.MinVersion, cfg.MaxVersion),
 	})
 
 	if len(cfg.LocalCertSignatureSchemes) > 0 {
-		extensions = append(extensions, &extension.SignatureAlgorithmsCert{
-			SignatureHashAlgorithms: cfg.LocalCertSignatureSchemes,
+		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalCertSignatureSchemes),
 		})
 	}
 
 	if len(cfg.ServerName) > 0 {
-		extensions = append(extensions, &extension.ServerName{ServerName: cfg.ServerName})
+		extensions = append(extensions, &extension.ServerNameOffer{ServerName: cfg.ServerName})
 	}
 
 	if len(cfg.LocalSRTPProtectionProfiles) > 0 {
-		extensions = append(extensions, &extension.UseSRTP{
+		extensions = append(extensions, &extension.SRTPOffer{
 			ProtectionProfiles:  cfg.LocalSRTPProtectionProfiles,
 			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
 		})
@@ -237,19 +237,15 @@ func flight1Parse(
 	// optionally the "cookie" extension
 	for _, val := range sh.Extensions {
 		switch ext := val.(type) {
-		case *extension.SupportedVersions:
+		case *extension13.SelectedVersion:
 			// nolint:godox
 			// TODO: negotiate version
-			state.RemoteVersions = ext.Versions
-		case *extension.CookieExt:
+			state.RemoteVersions = []protocol.Version{ext.Version}
+		case *extension13.Cookie:
 			state.Cookie = ext.Cookie
-		case *extension.KeyShare:
-			if ext.SelectedGroup != nil {
-				state.RemoteKeyEntries = []extension.KeyShareEntry{
-					{Group: *ext.SelectedGroup},
-				}
-				state.HasRemoteKeyEntries = true
-			}
+		case *extension13.RetryKeyShare:
+			state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: ext.SelectedGroup}}
+			state.HasRemoteKeyEntries = true
 		}
 	}
 

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -91,11 +92,10 @@ func flight2Generate(
 	random := handshake.Random{}
 	random.UnmarshalFixed([32]byte(handshake.HelloRetryRequestRandom()))
 
-	exts := []extension.Extension{}
+	exts := []extension.Value{}
 
-	exts = append(exts, &extension.SupportedVersions{
-		Versions:        []protocol.Version{protocol.Version1_3},
-		SelectedVersion: true,
+	exts = append(exts, &extension13.SelectedVersion{
+		Version: protocol.Version1_3,
 	})
 	cipherSuiteID := uint16(flightCtx.state.CipherSuite.ID())
 
@@ -106,14 +106,14 @@ func flight2Generate(
 		// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.8
 		_, clientAlreadyOfferedShare := clientKeyShareForGroup(flightCtx.state, flightCtx.state.SelectedGroup)
 		if !clientAlreadyOfferedShare {
-			exts = append(exts, &extension.KeyShare{
-				SelectedGroup: &flightCtx.state.SelectedGroup,
+			exts = append(exts, &extension13.RetryKeyShare{
+				SelectedGroup: flightCtx.state.SelectedGroup,
 			})
 		}
 	}
 
 	if len(flightCtx.state.Cookie) > 0 {
-		exts = append(exts, &extension.CookieExt{
+		exts = append(exts, &extension13.Cookie{
 			Cookie: flightCtx.state.Cookie,
 		})
 	}

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -17,6 +17,8 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -180,7 +182,7 @@ func validateFlight3ServerHello(serverHello *handshake.MessageServerHello) ([]pr
 
 func applyFlight3ServerKeyShare(
 	flightCtx *handshakeContext,
-	serverShare *extension.KeyShareEntry,
+	serverShare *extension13.KeyShareEntry,
 ) *flightParseFailure {
 	localKeypair, ok := flightCtx.state.LocalKeypairs[serverShare.Group]
 	if !ok || localKeypair == nil {
@@ -193,7 +195,7 @@ func applyFlight3ServerKeyShare(
 	}
 	flightCtx.state.KeyAgreementSecret = keyAgreementSecret
 	flightCtx.state.SelectedGroup = serverShare.Group
-	flightCtx.state.RemoteKeyEntries = []extension.KeyShareEntry{*serverShare}
+	flightCtx.state.RemoteKeyEntries = []extension13.KeyShareEntry{*serverShare}
 	flightCtx.state.HasRemoteKeyEntries = true
 
 	return nil
@@ -264,40 +266,38 @@ func flight3Generate(
 		return nil, nil, dtlserrors.ErrNoAvailableSignatureSchemes
 	}
 
-	extensions := []extension.Extension{
-		&extension.SupportedSignatureAlgorithms{
-			SignatureHashAlgorithms: flightCtx.cfg.LocalSignatureSchemes,
+	extensions := []extension.Value{
+		&extension.SignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(flightCtx.cfg.LocalSignatureSchemes),
 		},
 	}
 
 	if flightCtx.cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		flightCtx.cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret {
-		extensions = append(extensions, &extension.UseExtendedMasterSecret{
-			Supported: true,
-		})
+		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
 
-	extensions = append(extensions, &extension.RenegotiationInfo{
+	extensions = append(extensions, &extension12.RenegotiationInfo{
 		RenegotiatedConnection: 0,
 	})
 
 	if flightCtx.state.SelectedGroup != 0 {
-		extensions = append(extensions, []extension.Extension{
-			&extension.SupportedEllipticCurves{
-				EllipticCurves: flightCtx.cfg.EllipticCurves,
+		extensions = append(extensions, []extension.Value{
+			&extension.SupportedGroups{
+				Groups: flightCtx.cfg.EllipticCurves,
 			},
-			&extension.SupportedPointFormats{
+			&extension12.SupportedPointFormats{
 				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 			},
 		}...)
 	}
 
 	if len(flightCtx.cfg.SupportedProtocols) > 0 {
-		extensions = append(extensions, &extension.ALPN{ProtocolNameList: flightCtx.cfg.SupportedProtocols})
+		extensions = append(extensions, &extension.ALPNOffer{Protocols: flightCtx.cfg.SupportedProtocols})
 	}
 
 	var localGroups []elliptic.Curve
-	var newEntries []extension.KeyShareEntry
+	var newEntries []extension13.KeyShareEntry
 	newKeypairs := map[elliptic.Curve]*elliptic.Keypair{}
 	if flightCtx.state.HasRemoteKeyEntries {
 		for _, entry := range flightCtx.state.LocalKeyEntries {
@@ -310,7 +310,7 @@ func flight3Generate(
 				if err != nil {
 					return nil, nil, err
 				}
-				newEntries = append(newEntries, extension.KeyShareEntry{
+				newEntries = append(newEntries, extension13.KeyShareEntry{
 					Group: keypair.Curve, KeyExchange: keypair.PublicKey,
 				})
 				newKeypairs[keypair.Curve] = keypair
@@ -324,29 +324,29 @@ func flight3Generate(
 		}
 		maps.Copy(flightCtx.state.LocalKeypairs, newKeypairs)
 	}
-	extensions = append(extensions, &extension.KeyShare{
-		ClientShares: flightCtx.state.LocalKeyEntries,
+	extensions = append(extensions, &extension13.ClientKeyShare{
+		Shares: flightCtx.state.LocalKeyEntries,
 	})
 
 	if !slices.Contains(flightCtx.state.RemoteVersions, protocol.Version1_3) {
 		return nil, nil, dtlserrors.ErrNoCommonProtocolVersion
 	}
-	extensions = append(extensions, &extension.SupportedVersions{
+	extensions = append(extensions, &extension13.OfferedVersions{
 		Versions: dtlsconfig.SupportedVersionsRange(flightCtx.cfg.MinVersion, flightCtx.cfg.MaxVersion),
 	})
 
 	if len(flightCtx.cfg.LocalCertSignatureSchemes) > 0 {
-		extensions = append(extensions, &extension.SignatureAlgorithmsCert{
-			SignatureHashAlgorithms: flightCtx.cfg.LocalCertSignatureSchemes,
+		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
+			Schemes: dtlsflight.SignatureSchemeIDs(flightCtx.cfg.LocalCertSignatureSchemes),
 		})
 	}
 
 	if len(flightCtx.cfg.ServerName) > 0 {
-		extensions = append(extensions, &extension.ServerName{ServerName: flightCtx.cfg.ServerName})
+		extensions = append(extensions, &extension.ServerNameOffer{ServerName: flightCtx.cfg.ServerName})
 	}
 
 	if len(flightCtx.cfg.LocalSRTPProtectionProfiles) > 0 {
-		extensions = append(extensions, &extension.UseSRTP{
+		extensions = append(extensions, &extension.SRTPOffer{
 			ProtectionProfiles:  flightCtx.cfg.LocalSRTPProtectionProfiles,
 			MasterKeyIdentifier: flightCtx.cfg.LocalSRTPMasterKeyIdentifier,
 		})
@@ -360,7 +360,7 @@ func flight3Generate(
 	}
 
 	if len(flightCtx.state.Cookie) > 0 {
-		extensions = append(extensions, &extension.CookieExt{Cookie: flightCtx.state.Cookie})
+		extensions = append(extensions, &extension13.Cookie{Cookie: flightCtx.state.Cookie})
 	}
 
 	clientHello := &handshake.MessageClientHello{

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -63,9 +64,9 @@ func flight4Parse(
 	return Flight4, nil, nil
 }
 
-func clientHelloCookie(extensions []extension.Extension) []byte {
+func clientHelloCookie(extensions []extension.Value) []byte {
 	for _, ext := range extensions {
-		if cookieExt, ok := ext.(*extension.CookieExt); ok {
+		if cookieExt, ok := ext.(*extension13.Cookie); ok {
 			return cookieExt.Cookie
 		}
 	}
@@ -129,10 +130,10 @@ func generateClientKeyShareSecret(
 func matchingClientKeyShare(
 	state *dtlsstate.State13,
 	cfg *dtlsconfig.HandshakeConfig,
-) (extension.KeyShareEntry, bool) {
+) (extension13.KeyShareEntry, bool) {
 	selectedGroup, ok := preferredClientGroup(state, cfg)
 	if !ok {
-		return extension.KeyShareEntry{}, false
+		return extension13.KeyShareEntry{}, false
 	}
 
 	return clientKeyShareForGroup(state, selectedGroup)
@@ -158,9 +159,9 @@ func preferredClientGroup(
 func clientKeyShareForGroup(
 	state *dtlsstate.State13,
 	group elliptic.Curve,
-) (extension.KeyShareEntry, bool) {
+) (extension13.KeyShareEntry, bool) {
 	if !state.HasRemoteKeyEntries {
-		return extension.KeyShareEntry{}, false
+		return extension13.KeyShareEntry{}, false
 	}
 	for _, entry := range state.RemoteKeyEntries {
 		if entry.Group == group {
@@ -168,7 +169,7 @@ func clientKeyShareForGroup(
 		}
 	}
 
-	return extension.KeyShareEntry{}, false
+	return extension13.KeyShareEntry{}, false
 }
 
 func needsClientKeypair(state *dtlsstate.State13) bool {
@@ -223,14 +224,13 @@ func flight4Generate( //nolint:cyclop
 	}
 
 	cipherSuiteID := uint16(state.CipherSuite.ID())
-	serverHelloExtensions := []extension.Extension{
-		&extension.SupportedVersions{
-			Versions:        []protocol.Version{protocol.Version1_3},
-			SelectedVersion: true,
+	serverHelloExtensions := []extension.Value{
+		&extension13.SelectedVersion{
+			Version: protocol.Version1_3,
 		},
 	}
-	serverHelloExtensions = append(serverHelloExtensions, &extension.KeyShare{
-		ServerShare: &extension.KeyShareEntry{
+	serverHelloExtensions = append(serverHelloExtensions, &extension13.ServerKeyShare{
+		Share: extension13.KeyShareEntry{
 			Group:       state.LocalKeypair.Curve,
 			KeyExchange: state.LocalKeypair.PublicKey,
 		},
@@ -276,13 +276,13 @@ func flight4Generate( //nolint:cyclop
 		// RFC 8446 Section 4.3.2 requires signature_algorithms in the request.
 		// https://www.rfc-editor.org/rfc/rfc9147.html#section-5.1
 		// https://www.rfc-editor.org/rfc/rfc8446.html#section-4.3.2
-		certificateRequestExtensions := []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: cfg.LocalSignatureSchemes,
+		certificateRequestExtensions := []extension.Value{
+			&extension.SignatureAlgorithms{
+				Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
 			},
 		}
 		if cfg.ClientCAs != nil {
-			certificateRequestExtensions = append(certificateRequestExtensions, &extension.CertificateAuthorities{
+			certificateRequestExtensions = append(certificateRequestExtensions, &extension13.CertificateAuthorities{
 				// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR
 				// because cert does not come from SystemCertPool and it's ok if certificate
 				// authorities is empty.

--- a/internal/flight/flight13/flight5handler.go
+++ b/internal/flight/flight13/flight5handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -142,7 +143,7 @@ func flight5ClientCertificate(
 		SignatureSchemes: certificateRequestSignatureSchemes(request),
 	}
 	for _, ext := range request.Extensions {
-		if authorities, ok := ext.(*extension.CertificateAuthorities); ok {
+		if authorities, ok := ext.(*extension13.CertificateAuthorities); ok {
 			requestInfo.AcceptableCAs = authorities.Authorities
 
 			break
@@ -164,8 +165,8 @@ func certificateRequestSignatureSchemes(
 	request *handshake.MessageCertificateRequest13,
 ) []signaturehash.Algorithm {
 	for _, ext := range request.Extensions {
-		if algorithms, ok := ext.(*extension.SupportedSignatureAlgorithms); ok {
-			return algorithms.SignatureHashAlgorithms
+		if algorithms, ok := ext.(*extension.SignatureAlgorithms); ok {
+			return dtlsflight.SignatureSchemes(algorithms.Schemes)
 		}
 	}
 

--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
@@ -328,25 +329,25 @@ func IsHelloRetryRequest(sh *handshake.MessageServerHello) bool {
 	return bytes.Equal(randomBytes[:], handshake.HelloRetryRequestRandom())
 }
 
-func ServerHelloSelectedVersions(extensions []extension.Extension) ([]protocol.Version, bool, error) {
+func ServerHelloSelectedVersions(extensions []extension.Value) ([]protocol.Version, bool, error) {
 	seenSupportedVersions := false
 	var versions []protocol.Version
 	for _, val := range extensions {
-		supportedVersions, ok := val.(*extension.SupportedVersions)
+		supportedVersions, ok := val.(*extension13.SelectedVersion)
 		if !ok {
 			continue
 		}
-		if seenSupportedVersions || !supportedVersions.IsSelectedVersion() || len(supportedVersions.Versions) != 1 {
+		if seenSupportedVersions {
 			return nil, true, dtlserrors.ErrInvalidServerHello
 		}
 		seenSupportedVersions = true
-		versions = supportedVersions.Versions
+		versions = []protocol.Version{supportedVersions.Version}
 	}
 
 	return versions, seenSupportedVersions, nil
 }
 
-func validateHelloRetryRequestSelectedVersion(extensions []extension.Extension) error {
+func validateHelloRetryRequestSelectedVersion(extensions []extension.Value) error {
 	versions, seenSupportedVersions, err := ServerHelloSelectedVersions(extensions)
 	if err != nil || !seenSupportedVersions {
 		return dtlserrors.ErrInvalidHelloRetryRequest
@@ -386,14 +387,14 @@ func selectServerHelloCipherSuite(
 	return selectedCipherSuite, nil, nil
 }
 
-func serverHelloKeyShare(extensions []extension.Extension) *extension.KeyShareEntry {
+func serverHelloKeyShare(extensions []extension.Value) *extension13.KeyShareEntry {
 	for _, ext := range extensions {
-		keyShare, ok := ext.(*extension.KeyShare)
-		if !ok || keyShare.ServerShare == nil {
+		keyShare, ok := ext.(*extension13.ServerKeyShare)
+		if !ok {
 			continue
 		}
 
-		return keyShare.ServerShare
+		return &keyShare.Share
 	}
 
 	return nil

--- a/internal/flight/helpers.go
+++ b/internal/flight/helpers.go
@@ -4,9 +4,12 @@
 package flight
 
 import (
+	"crypto/tls"
+	"encoding/binary"
 	"slices"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 )
 
 func FindMatchingSRTPProfile(a, b []dtlsconfig.SRTPProtectionProfile) (dtlsconfig.SRTPProtectionProfile, bool) {
@@ -17,6 +20,32 @@ func FindMatchingSRTPProfile(a, b []dtlsconfig.SRTPProtectionProfile) (dtlsconfi
 	}
 
 	return 0, false
+}
+
+// SignatureSchemeIDs converts negotiated signature algorithms to their
+// identifiers for the payload-oriented extension codecs.
+func SignatureSchemeIDs(algorithms []signaturehash.Algorithm) []uint16 {
+	ids := make([]uint16, 0, len(algorithms))
+	for i := range algorithms {
+		ids = append(ids, binary.BigEndian.Uint16(algorithms[i].Marshal()))
+	}
+
+	return ids
+}
+
+// SignatureSchemes converts known identifiers into algorithms used by
+// negotiation. Unknown identifiers remain preserved by the extension value
+// and are ignored here.
+func SignatureSchemes(ids []uint16) []signaturehash.Algorithm {
+	algorithms := make([]signaturehash.Algorithm, 0, len(ids))
+	for _, id := range ids {
+		var algorithm signaturehash.Algorithm
+		if err := algorithm.Unmarshal(tls.SignatureScheme(id)); err == nil {
+			algorithms = append(algorithms, algorithm)
+		}
+	}
+
+	return algorithms
 }
 
 func FindMatchingCipherSuite(a, b []dtlsconfig.CipherSuite) (dtlsconfig.CipherSuite, bool) {

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
@@ -1378,9 +1379,9 @@ func addCertificateRequestToServerFlight13(
 				Header: handshake.Header{MessageSequence: 2},
 				Message: &handshake.MessageCertificateRequest13{
 					CertificateRequestContext: requestContext,
-					Extensions: []extension.Extension{
-						&extension.SupportedSignatureAlgorithms{
-							SignatureHashAlgorithms: fixture.cfg.LocalSignatureSchemes,
+					Extensions: []extension.Value{
+						&extension.SignatureAlgorithms{
+							Schemes: dtlsflight.SignatureSchemeIDs(fixture.cfg.LocalSignatureSchemes),
 						},
 					},
 				},
@@ -1746,10 +1747,9 @@ func transcriptTestHelloRetryRequestPacket13(
 					Random:            random,
 					CipherSuiteID:     &cipherSuiteID,
 					CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-					Extensions: []extension.Extension{
-						&extension.SupportedVersions{
-							Versions:        []protocol.Version{protocol.Version1_3},
-							SelectedVersion: true,
+					Extensions: []extension.Value{
+						&extension13.SelectedVersion{
+							Version: protocol.Version1_3,
 						},
 					},
 				},

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/signature"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
@@ -1165,10 +1166,9 @@ func rawHelloRetryRequest13(
 		Random:            random,
 		CipherSuiteID:     &cipherSuiteID,
 		CompressionMethod: &protocol.CompressionMethod{},
-		Extensions: []extension.Extension{
-			&extension.SupportedVersions{
-				Versions:        []protocol.Version{protocol.Version1_3},
-				SelectedVersion: true,
+		Extensions: []extension.Value{
+			&extension13.SelectedVersion{
+				Version: protocol.Version1_3,
 			},
 		},
 	})
@@ -1199,15 +1199,15 @@ func pskClientHelloTranscript13(tb testing.TB, binder []byte) ([]byte, []byte) {
 		Version:            protocol.Version1_2,
 		CipherSuiteIDs:     []uint16{0x1301},
 		CompressionMethods: []*protocol.CompressionMethod{{}},
-		Extensions: []extension.Extension{
-			&extension.PreSharedKey{
-				Identities: []extension.PskIdentity{
+		Extensions: []extension.Value{
+			&extension13.OfferedPSKs{
+				Identities: []extension13.PSKIdentity{
 					{
 						Identity:            []byte("psk-identity"),
 						ObfuscatedTicketAge: 0x01020304,
 					},
 				},
-				Binders: []extension.PskBinderEntry{binder},
+				Binders: []extension13.PSKBinder{extension13.PSKBinder(binder)},
 			},
 		},
 	}

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
-	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 )
 
 type TrafficSecrets struct {
@@ -108,9 +108,9 @@ type State13 struct {
 	LocalKeypair  *elliptic.Keypair
 	LocalKeypairs map[elliptic.Curve]*elliptic.Keypair
 
-	LocalKeyEntries []extension.KeyShareEntry
+	LocalKeyEntries []extension13.KeyShareEntry
 
-	RemoteKeyEntries    []extension.KeyShareEntry
+	RemoteKeyEntries    []extension13.KeyShareEntry
 	HasRemoteKeyEntries bool
 	RemoteGroups        []elliptic.Curve
 

--- a/pkg/protocol/handshake/extensions.go
+++ b/pkg/protocol/handshake/extensions.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"bytes"
+
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+)
+
+// extensionContext identifies the payload form of context-dependent extension
+// payloads.
+type extensionContext uint8
+
+const (
+	extensionContextClientHello extensionContext = iota
+	extensionContextServerHello12
+	extensionContextServerHello13
+	extensionContextHelloRetryRequest
+	extensionContextEncryptedExtensions
+	extensionContextCertificateRequest
+	extensionContextCertificateEntry
+	extensionContextNewSessionTicket
+)
+
+type extensionPayloadValue interface {
+	extension.Value
+	extension.PayloadUnmarshaller
+}
+
+func decodeExtensionList(data []byte, context extensionContext) ([]extension.Value, error) {
+	rawExtensions, err := extension.ParseList(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeRawExtensions(rawExtensions, context)
+}
+
+func decodeRawExtensions(rawExtensions []extension.Raw, context extensionContext) ([]extension.Value, error) {
+	values := make([]extension.Value, 0, len(rawExtensions))
+	for _, raw := range rawExtensions {
+		value := extensionValueForContext(context, raw.Type)
+		if value == nil {
+			values = append(values, raw)
+
+			continue
+		}
+		if err := value.UnmarshalData(raw.Data); err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+
+	return values, nil
+}
+
+//nolint:gocyclo,cyclop
+func extensionValueForContext(context extensionContext, typ extension.Type) extensionPayloadValue {
+	switch context {
+	case extensionContextClientHello:
+		switch typ {
+		case extension.TypeServerName:
+			return &extension.ServerNameOffer{}
+		case extension.TypeALPN:
+			return &extension.ALPNOffer{}
+		case extension.TypeUseSRTP:
+			return &extension.SRTPOffer{}
+		case extension.TypeConnectionID:
+			return &extension.ConnectionID{}
+		case extension.TypeSupportedGroups:
+			return &extension.SupportedGroups{}
+		case extension.TypeSignatureAlgorithms:
+			return &extension.SignatureAlgorithms{}
+		case extension.TypeSignatureAlgorithmsCert:
+			return &extension.CertificateSignatureAlgorithms{}
+		case extension.TypeSupportedPointFormats:
+			return &extension12.SupportedPointFormats{}
+		case extension.TypeExtendedMasterSecret:
+			return &extension12.ExtendedMasterSecret{}
+		case extension.TypeRenegotiationInfo:
+			return &extension12.RenegotiationInfo{}
+		case extension.TypeSupportedVersions:
+			return &extension13.OfferedVersions{}
+		case extension.TypeCookie:
+			return &extension13.Cookie{}
+		case extension.TypeKeyShare:
+			return &extension13.ClientKeyShare{}
+		case extension.TypePreSharedKey:
+			return &extension13.OfferedPSKs{}
+		case extension.TypePSKKeyExchangeModes:
+			return &extension13.PSKKeyExchangeModes{}
+		case extension.TypeEarlyData:
+			return &extension13.EarlyData{}
+		case extension.TypeCertificateAuthorities:
+			return &extension13.CertificateAuthorities{}
+		case extension.TypePostHandshakeAuth:
+			return &extension13.PostHandshakeAuth{}
+		}
+	case extensionContextServerHello12:
+		switch typ {
+		case extension.TypeServerName:
+			return &extension.ServerNameAck{}
+		case extension.TypeALPN:
+			return &extension.ALPNSelection{}
+		case extension.TypeUseSRTP:
+			return &extension.SRTPSelection{}
+		case extension.TypeConnectionID:
+			return &extension.ConnectionID{}
+		case extension.TypeSupportedPointFormats:
+			return &extension12.SupportedPointFormats{}
+		case extension.TypeExtendedMasterSecret:
+			return &extension12.ExtendedMasterSecret{}
+		case extension.TypeRenegotiationInfo:
+			return &extension12.RenegotiationInfo{}
+		}
+	case extensionContextServerHello13:
+		switch typ {
+		case extension.TypeSupportedVersions:
+			return &extension13.SelectedVersion{}
+		case extension.TypeKeyShare:
+			return &extension13.ServerKeyShare{}
+		case extension.TypePreSharedKey:
+			return &extension13.SelectedPSK{}
+		case extension.TypeConnectionID:
+			return &extension.ConnectionID{}
+		}
+	case extensionContextHelloRetryRequest:
+		switch typ {
+		case extension.TypeSupportedVersions:
+			return &extension13.SelectedVersion{}
+		case extension.TypeKeyShare:
+			return &extension13.RetryKeyShare{}
+		case extension.TypeCookie:
+			return &extension13.Cookie{}
+		case extension.TypeConnectionID:
+			return &extension.ConnectionID{}
+		}
+	case extensionContextEncryptedExtensions:
+		switch typ {
+		case extension.TypeServerName:
+			return &extension.ServerNameAck{}
+		case extension.TypeALPN:
+			return &extension.ALPNSelection{}
+		case extension.TypeUseSRTP:
+			return &extension.SRTPSelection{}
+		case extension.TypeSupportedGroups:
+			return &extension.SupportedGroups{}
+		case extension.TypeEarlyData:
+			return &extension13.EarlyData{}
+		}
+	case extensionContextCertificateRequest:
+		switch typ {
+		case extension.TypeSignatureAlgorithms:
+			return &extension.SignatureAlgorithms{}
+		case extension.TypeSignatureAlgorithmsCert:
+			return &extension.CertificateSignatureAlgorithms{}
+		case extension.TypeCertificateAuthorities:
+			return &extension13.CertificateAuthorities{}
+		case extension.TypeOIDFilters:
+			return &extension13.OIDFilters{}
+		}
+	case extensionContextNewSessionTicket:
+		if typ == extension.TypeEarlyData {
+			return &extension13.MaxEarlyData{}
+		}
+	case extensionContextCertificateEntry:
+		// Not supported yet, this case is just added for the exhaustive linter.
+	}
+
+	return nil
+}
+
+func serverHelloExtensionContext(random Random, rawExtensions []extension.Raw) extensionContext {
+	randomBytes := random.MarshalFixed()
+	if bytes.Equal(randomBytes[:], HelloRetryRequestRandom()) {
+		return extensionContextHelloRetryRequest
+	}
+
+	for _, raw := range rawExtensions {
+		if raw.Type == extension.TypeSupportedVersions {
+			return extensionContextServerHello13
+		}
+	}
+
+	return extensionContextServerHello12
+}

--- a/pkg/protocol/handshake/extensions_test.go
+++ b/pkg/protocol/handshake/extensions_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package handshake
+
+import (
+	"testing"
+
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeExtensionListPreservesRawExtensions(t *testing.T) {
+	rawExtensions := []extension.Raw{
+		{Type: 0xfefe, Data: []byte{0x01, 0x02}},
+		{Type: 0xfefe, Data: []byte{0x03}},
+	}
+	encoded, err := extension.MarshalRawList(rawExtensions)
+	require.NoError(t, err)
+
+	decoded, err := decodeExtensionList(encoded, extensionContextClientHello)
+	require.NoError(t, err)
+	require.Len(t, decoded, 2)
+	assert.Equal(t, rawExtensions[0], decoded[0])
+	assert.Equal(t, rawExtensions[1], decoded[1])
+
+	roundTrip, err := extension.MarshalList(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, roundTrip)
+}
+
+func TestDecodeExtensionListUsesMessageContext(t *testing.T) {
+	selected := extension13.SelectedVersion{Version: protocol.Version1_3}
+	encoded, err := extension.MarshalList([]extension.Value{selected})
+	require.NoError(t, err)
+
+	serverHello, err := decodeExtensionList(encoded, extensionContextServerHello13)
+	require.NoError(t, err)
+	require.IsType(t, &extension13.SelectedVersion{}, serverHello[0])
+
+	_, err = decodeExtensionList(encoded, extensionContextClientHello)
+	assert.Error(t, err)
+}

--- a/pkg/protocol/handshake/handshake_test.go
+++ b/pkg/protocol/handshake/handshake_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,7 +40,7 @@ func TestHandshakeMessage(t *testing.T) {
 			Cookie:             []byte{},
 			CipherSuiteIDs:     []uint16{},
 			CompressionMethods: []*protocol.CompressionMethod{},
-			Extensions:         []extension.Extension{},
+			Extensions:         []extension.Value{},
 		},
 	}
 
@@ -60,8 +61,8 @@ func TestPostHandshakeMessageDispatch(t *testing.T) {
 			TicketAgeAdd:   2,
 			TicketNonce:    []byte{0x03},
 			Ticket:         []byte{0x04},
-			Extensions: []extension.Extension{
-				&extension.EarlyDataIndication{MaxEarlyData: &maxEarlyData},
+			Extensions: []extension.Value{
+				&extension13.MaxEarlyData{Size: maxEarlyData},
 			},
 		},
 		"KeyUpdate": &handshake.MessageKeyUpdate{

--- a/pkg/protocol/handshake/message_certificate_13.go
+++ b/pkg/protocol/handshake/message_certificate_13.go
@@ -24,7 +24,7 @@ type CertificateEntry13 struct {
 
 	// Extensions contains per-certificate extensions.
 	// Examples: OCSP status, SignedCertificateTimestamp, etc.
-	Extensions []extension.Extension
+	Extensions []extension.Value
 }
 
 // MessageCertificate13 represents the Certificate handshake message for DTLS 1.3.
@@ -92,7 +92,7 @@ func (m *MessageCertificate13) Marshal() ([]byte, error) {
 		certificateList = append(certificateList, entry.CertificateData...)
 
 		// Marshal extensions (includes a 2-byte length prefix)
-		extensionsData, err := extension.Marshal(entry.Extensions)
+		extensionsData, err := extension.MarshalList(entry.Extensions)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +142,7 @@ func parseCertificate13Entry(str *cryptobyte.String) (*CertificateEntry13, error
 
 	// Unmarshal extensions data
 	extensionsData := []byte(*str)[:cert13ExtLengthFieldSize+int(extensionsLen)]
-	extensions, err := extension.Unmarshal(extensionsData)
+	extensions, err := decodeExtensionList(extensionsData, extensionContextCertificateEntry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/protocol/handshake/message_certificate_13_test.go
+++ b/pkg/protocol/handshake/message_certificate_13_test.go
@@ -67,7 +67,7 @@ func TestHandshakeMessageCertificate13(t *testing.T) {
 				CertificateList: []CertificateEntry13{
 					{
 						CertificateData: certDER,
-						Extensions:      []extension.Extension{},
+						Extensions:      []extension.Value{},
 					},
 				},
 			},
@@ -84,7 +84,7 @@ func TestHandshakeMessageCertificate13(t *testing.T) {
 				CertificateList: []CertificateEntry13{
 					{
 						CertificateData: certDER,
-						Extensions:      []extension.Extension{},
+						Extensions:      []extension.Value{},
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func TestMessageCertificate13_SingleCertNoExtensions(t *testing.T) {
 					0x73, 0x30, 0xda, 0x2b, 0xc0, 0x0c, 0x9e, 0xb2, 0x25, 0x0d, 0x46, 0xb0, 0xbc, 0x66, 0x7f, 0x71,
 					0x66, 0xbf, 0x16, 0xb3, 0x80, 0x78, 0xd0, 0x0c, 0xef, 0xcc, 0xf5, 0xc1, 0x15, 0x0f, 0x58,
 				},
-				Extensions: []extension.Extension{},
+				Extensions: []extension.Value{},
 			},
 		},
 	}
@@ -191,7 +191,7 @@ func TestMessageCertificate13_WithContext(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: []byte{0xDE, 0xAD, 0xBE, 0xEF},
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -203,9 +203,9 @@ func TestMessageCertificate13_MultipleCertificates(t *testing.T) {
 	msg := &MessageCertificate13{
 		CertificateRequestContext: []byte{},
 		CertificateList: []CertificateEntry13{
-			{CertificateData: []byte{0x01, 0x02, 0x03}, Extensions: []extension.Extension{}},
-			{CertificateData: []byte{0x04, 0x05, 0x06, 0x07}, Extensions: []extension.Extension{}},
-			{CertificateData: []byte{0x08, 0x09}, Extensions: []extension.Extension{}},
+			{CertificateData: []byte{0x01, 0x02, 0x03}, Extensions: []extension.Value{}},
+			{CertificateData: []byte{0x04, 0x05, 0x06, 0x07}, Extensions: []extension.Value{}},
+			{CertificateData: []byte{0x08, 0x09}, Extensions: []extension.Value{}},
 		},
 	}
 	marshalUnmarshalMessageCertificate13AndVerifyMatch(t, msg, nil)
@@ -220,7 +220,7 @@ func TestMessageCertificate13_MaxContextLength(t *testing.T) {
 	msg := &MessageCertificate13{
 		CertificateRequestContext: context,
 		CertificateList: []CertificateEntry13{
-			{CertificateData: []byte{0x00}, Extensions: []extension.Extension{}},
+			{CertificateData: []byte{0x00}, Extensions: []extension.Value{}},
 		},
 	}
 	marshalUnmarshalMessageCertificate13AndVerifyMatch(t, msg, nil)
@@ -256,7 +256,7 @@ func TestMessageCertificate13_EmptyCertData(t *testing.T) {
 	msg := &MessageCertificate13{
 		CertificateRequestContext: []byte{},
 		CertificateList: []CertificateEntry13{
-			{CertificateData: []byte{}, Extensions: []extension.Extension{}},
+			{CertificateData: []byte{}, Extensions: []extension.Value{}},
 		},
 	}
 
@@ -277,7 +277,7 @@ func TestMessageCertificate13_CertDataAtMaxBoundary(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: certData,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestMessageCertificate13_CertDataJustBelowMaxBoundary(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: certData,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -329,7 +329,7 @@ func TestMessageCertificate13_CertDataOneByteOverBoundary(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: certData,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -353,11 +353,11 @@ func TestMessageCertificate13_MultipleCertsExceedingBoundary(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: certData1,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 			{
 				CertificateData: certData2,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -381,7 +381,7 @@ func TestMessageCertificate13_CertListAtExactBoundary(t *testing.T) {
 		CertificateList: []CertificateEntry13{
 			{
 				CertificateData: certData,
-				Extensions:      []extension.Extension{},
+				Extensions:      []extension.Value{},
 			},
 		},
 	}
@@ -545,9 +545,9 @@ func TestParseCertificateEntry_GeneratedCertificateWithExtensions(t *testing.T) 
 	require.NoError(t, err)
 
 	// Create extensions for the certificate entry
-	serverName := &extension.ServerName{ServerName: "test2.example.com"}
-	extensions := []extension.Extension{serverName}
-	extensionsData, err := extension.Marshal(extensions)
+	serverName := &extension.ServerNameOffer{ServerName: "test2.example.com"}
+	extensions := []extension.Value{serverName}
+	extensionsData, err := extension.MarshalList(extensions)
 	require.NoError(t, err)
 
 	// Construct wire format
@@ -570,7 +570,7 @@ func TestParseCertificateEntry_GeneratedCertificateWithExtensions(t *testing.T) 
 	assert.Equal(t, 0, len(str)) // Ensure all data was consumed
 	assert.Equal(t, certDER, entry.CertificateData)
 	assert.Equal(t, 1, len(entry.Extensions))
-	assert.Equal(t, extension.ServerNameTypeValue, entry.Extensions[0].TypeValue())
+	assert.Equal(t, extension.TypeServerName, entry.Extensions[0].ExtensionType())
 
 	// Verify the certificate is valid
 	parsedCert, err := x509.ParseCertificate(entry.CertificateData)

--- a/pkg/protocol/handshake/message_certificate_request_13.go
+++ b/pkg/protocol/handshake/message_certificate_request_13.go
@@ -23,7 +23,7 @@ type MessageCertificateRequest13 struct {
 
 	// Extensions contains the list of extensions.
 	// The signature_algorithms extension is REQUIRED per RFC 8446.
-	Extensions []extension.Extension
+	Extensions []extension.Value
 }
 
 // Type returns the handshake message type.
@@ -54,7 +54,7 @@ func (m *MessageCertificateRequest13) Marshal() ([]byte, error) {
 	// Validate that signature_algorithms extension is present (required by RFC 8446)
 	hasSignatureAlgorithms := false
 	for _, ext := range m.Extensions {
-		if ext.TypeValue() == extension.SupportedSignatureAlgorithmsTypeValue {
+		if ext.ExtensionType() == extension.TypeSignatureAlgorithms {
 			hasSignatureAlgorithms = true
 
 			break
@@ -72,7 +72,7 @@ func (m *MessageCertificateRequest13) Marshal() ([]byte, error) {
 	})
 
 	// Marshal extensions (includes 2-byte length prefix, like in TLS 1.2)
-	extensionsData, err := extension.Marshal(m.Extensions)
+	extensionsData, err := extension.MarshalList(m.Extensions)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (m *MessageCertificateRequest13) Unmarshal(data []byte) error {
 	}
 
 	var err error
-	m.Extensions, err = extension.Unmarshal([]byte(str))
+	m.Extensions, err = decodeExtensionList([]byte(str), extensionContextCertificateRequest)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (m *MessageCertificateRequest13) Unmarshal(data []byte) error {
 	// Validate that signature_algorithms extension is present (required by RFC 8446)
 	hasSignatureAlgorithms := false
 	for _, ext := range m.Extensions {
-		if ext.TypeValue() == extension.SupportedSignatureAlgorithmsTypeValue {
+		if ext.ExtensionType() == extension.TypeSignatureAlgorithms {
 			hasSignatureAlgorithms = true
 
 			break

--- a/pkg/protocol/handshake/message_certificate_request_13_test.go
+++ b/pkg/protocol/handshake/message_certificate_request_13_test.go
@@ -7,9 +7,6 @@ import (
 	"testing"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/pkg/crypto/hash"
-	"github.com/pion/dtls/v3/pkg/crypto/signature"
-	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,12 +29,8 @@ func TestHandshakeMessageCertificateRequest13(t *testing.T) {
 			},
 			parsedCertificateRequest: &MessageCertificateRequest13{
 				CertificateRequestContext: []byte{},
-				Extensions: []extension.Extension{
-					&extension.SupportedSignatureAlgorithms{
-						SignatureHashAlgorithms: []signaturehash.Algorithm{
-							{Hash: hash.SHA256, Signature: signature.ECDSA},
-						},
-					},
+				Extensions: []extension.Value{
+					&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
 				},
 			},
 		},
@@ -55,14 +48,8 @@ func TestHandshakeMessageCertificateRequest13(t *testing.T) {
 			},
 			parsedCertificateRequest: &MessageCertificateRequest13{
 				CertificateRequestContext: []byte{0x01, 0x02, 0x03, 0x04},
-				Extensions: []extension.Extension{
-					&extension.SupportedSignatureAlgorithms{
-						SignatureHashAlgorithms: []signaturehash.Algorithm{
-							{Hash: hash.SHA256, Signature: signature.ECDSA},
-							{Hash: hash.SHA256, Signature: signature.RSA},
-							{Hash: hash.SHA384, Signature: signature.ECDSA},
-						},
-					},
+				Extensions: []extension.Value{
+					&extension.SignatureAlgorithms{Schemes: []uint16{0x0403, 0x0401, 0x0503}},
 				},
 			},
 		},
@@ -108,13 +95,8 @@ func TestMessageCertificateRequest13_MinimalValid(t *testing.T) {
 	// Build (valid) message with empty context
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: []byte{},
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: []signaturehash.Algorithm{
-					{Hash: hash.SHA256, Signature: signature.ECDSA},
-					{Hash: hash.SHA256, Signature: signature.RSA},
-				},
-			},
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403, 0x0401}},
 		},
 	}
 	marshalUnmarshalMessageCertificateRequest13AndVerifyMatch(t, msg)
@@ -124,12 +106,8 @@ func TestMessageCertificateRequest13_WithContext(t *testing.T) {
 	// Build (valid) message with non-empty context
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: []byte{0x01, 0x02, 0x03, 0x04},
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: []signaturehash.Algorithm{
-					{Hash: hash.SHA256, Signature: signature.ECDSA},
-				},
-			},
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
 		},
 	}
 	marshalUnmarshalMessageCertificateRequest13AndVerifyMatch(t, msg)
@@ -143,12 +121,8 @@ func TestMessageCertificateRequest13_MaxContextLength(t *testing.T) {
 	}
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: context,
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: []signaturehash.Algorithm{
-					{Hash: hash.SHA256, Signature: signature.ECDSA},
-				},
-			},
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
 		},
 	}
 	marshalUnmarshalMessageCertificateRequest13AndVerifyMatch(t, msg)
@@ -159,15 +133,14 @@ func TestMessageCertificateRequest13_MultipleExtensions(t *testing.T) {
 	// (signature_algorithms, which must be present, and server_name)
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: []byte{0x01, 0x02, 0x03, 0x04},
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: []signaturehash.Algorithm{
-					{Hash: hash.SHA256, Signature: signature.ECDSA},
-					{Hash: hash.SHA384, Signature: signature.ECDSA},
-					{Hash: hash.SHA512, Signature: signature.RSA},
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403, 0x0503, 0x0601}},
+			extension.Raw{
+				Type: extension.TypeServerName,
+				Data: []byte{
+					0x00, 0x0e, 0x00, 0x00, 0x0b, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
 				},
 			},
-			&extension.ServerName{ServerName: "example.com"},
 		},
 	}
 	marshalUnmarshalMessageCertificateRequest13AndVerifyMatch(t, msg)
@@ -178,12 +151,8 @@ func TestMessageCertificateRequest13_ContextTooLong(t *testing.T) {
 	tooLongContext := make([]byte, certReq13ContextMaxLength+1)
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: tooLongContext,
-		Extensions: []extension.Extension{
-			&extension.SupportedSignatureAlgorithms{
-				SignatureHashAlgorithms: []signaturehash.Algorithm{
-					{Hash: hash.SHA256, Signature: signature.ECDSA},
-				},
-			},
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
 		},
 	}
 
@@ -336,7 +305,7 @@ func marshalUnmarshalMessageCertificateRequest13AndVerifyMatch(
 	// Verify has signature algorithms extension present
 	hasSignatureAlgorithms := false
 	for _, ext := range out.Extensions {
-		if ext.TypeValue() == extension.SupportedSignatureAlgorithmsTypeValue {
+		if ext.ExtensionType() == extension.TypeSignatureAlgorithms {
 			hasSignatureAlgorithms = true
 
 			break

--- a/pkg/protocol/handshake/message_client_hello.go
+++ b/pkg/protocol/handshake/message_client_hello.go
@@ -28,7 +28,7 @@ type MessageClientHello struct {
 
 	CipherSuiteIDs     []uint16
 	CompressionMethods []*protocol.CompressionMethod
-	Extensions         []extension.Extension
+	Extensions         []extension.Value
 }
 
 const handshakeMessageClientHelloVariableWidthStart = 34
@@ -50,7 +50,7 @@ func (m *MessageClientHello) Marshal() ([]byte, error) {
 		return nil, dtlserrors.ErrCompressionMethodsTooLong
 	}
 
-	extensions, err := extension.Marshal(m.Extensions)
+	extensions, err := extension.MarshalList(m.Extensions)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (m *MessageClientHello) Unmarshal(data []byte) error { //nolint:cyclop
 	currOffset += int(data[currOffset]) + 1
 
 	// Extensions
-	extensions, err := extension.Unmarshal(data[currOffset:])
+	extensions, err := decodeExtensionList(data[currOffset:], extensionContextClientHello)
 	if err != nil {
 		return err
 	}

--- a/pkg/protocol/handshake/message_client_hello_test.go
+++ b/pkg/protocol/handshake/message_client_hello_test.go
@@ -43,8 +43,8 @@ func TestHandshakeMessageClientHello(t *testing.T) {
 		CompressionMethods: []*protocol.CompressionMethod{
 			{},
 		},
-		Extensions: []extension.Extension{
-			&extension.SupportedEllipticCurves{EllipticCurves: []elliptic.Curve{elliptic.X25519}},
+		Extensions: []extension.Value{
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}},
 		},
 	}
 

--- a/pkg/protocol/handshake/message_encrypted_extensions.go
+++ b/pkg/protocol/handshake/message_encrypted_extensions.go
@@ -14,7 +14,7 @@ import (
 //
 // https://datatracker.ietf.org/doc/html/rfc8446#section-4.3.1
 type MessageEncryptedExtensions struct {
-	Extensions []extension.Extension
+	Extensions []extension.Value
 }
 
 // Type returns the Handshake Type.
@@ -24,7 +24,7 @@ func (m MessageEncryptedExtensions) Type() Type {
 
 // Marshal encodes the Handshake.
 func (m *MessageEncryptedExtensions) Marshal() ([]byte, error) {
-	return extension.Marshal(m.Extensions)
+	return extension.MarshalList(m.Extensions)
 }
 
 // Unmarshal populates the message from encoded data.
@@ -33,7 +33,7 @@ func (m *MessageEncryptedExtensions) Unmarshal(data []byte) error {
 		return dtlserrors.ErrBufferTooSmall
 	}
 
-	extensions, err := extension.Unmarshal(data)
+	extensions, err := decodeExtensionList(data, extensionContextEncryptedExtensions)
 	if err != nil {
 		return err
 	}

--- a/pkg/protocol/handshake/message_encrypted_extensions_test.go
+++ b/pkg/protocol/handshake/message_encrypted_extensions_test.go
@@ -17,16 +17,12 @@ var errMarshalEncryptedExtensionsTest = errors.New("marshal encrypted extensions
 
 type failingEncryptedExtensionsExtension struct{}
 
-func (f *failingEncryptedExtensionsExtension) Marshal() ([]byte, error) {
+func (f *failingEncryptedExtensionsExtension) MarshalData() ([]byte, error) {
 	return nil, errMarshalEncryptedExtensionsTest
 }
 
-func (f *failingEncryptedExtensionsExtension) Unmarshal([]byte) error {
-	return nil
-}
-
-func (f *failingEncryptedExtensionsExtension) TypeValue() extension.TypeValue {
-	return extension.ALPNTypeValue
+func (f *failingEncryptedExtensionsExtension) ExtensionType() extension.Type {
+	return extension.TypeALPN
 }
 
 func TestMessageEncryptedExtensionsType(t *testing.T) {
@@ -43,19 +39,18 @@ func TestMessageEncryptedExtensionsMarshal(t *testing.T) {
 
 	t.Run("WithExtensions", func(t *testing.T) {
 		raw, err := (&MessageEncryptedExtensions{
-			Extensions: []extension.Extension{
-				&extension.ALPN{ProtocolNameList: []string{"h2", "http/1.1"}},
-				&extension.UseExtendedMasterSecret{Supported: true},
+			Extensions: []extension.Value{
+				&extension.ALPNSelection{Protocol: "h2"},
+				extension.Raw{Type: extension.TypeExtendedMasterSecret},
 			},
 		}).Marshal()
 		require.NoError(t, err)
 		assert.Equal(t, []byte{
-			0x00, 0x16, // extensions length
+			0x00, 0x0d, // extensions length
 			0x00, 0x10, // ALPN
-			0x00, 0x0e, // ALPN extension length
-			0x00, 0x0c, // ALPN protocol name list length
+			0x00, 0x05, // ALPN extension length
+			0x00, 0x03, // ALPN protocol name list length
 			0x02, 0x68, 0x32, // h2
-			0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, // http/1.1
 			0x00, 0x17, // extended_master_secret
 			0x00, 0x00, // extended_master_secret extension length
 		}, raw)
@@ -63,7 +58,7 @@ func TestMessageEncryptedExtensionsMarshal(t *testing.T) {
 
 	t.Run("ExtensionMarshalError", func(t *testing.T) {
 		raw, err := (&MessageEncryptedExtensions{
-			Extensions: []extension.Extension{&failingEncryptedExtensionsExtension{}},
+			Extensions: []extension.Value{&failingEncryptedExtensionsExtension{}},
 		}).Marshal()
 		assert.ErrorIs(t, err, errMarshalEncryptedExtensionsTest)
 		assert.Nil(t, raw)
@@ -91,30 +86,29 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 		msg := &MessageEncryptedExtensions{}
 
 		err := msg.Unmarshal([]byte{
-			0x00, 0x16, // extensions length
+			0x00, 0x0d, // extensions length
 			0x00, 0x10, // ALPN
-			0x00, 0x0e, // ALPN extension length
-			0x00, 0x0c, // ALPN protocol name list length
+			0x00, 0x05, // ALPN extension length
+			0x00, 0x03, // ALPN protocol name list length
 			0x02, 0x68, 0x32, // h2
-			0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, // http/1.1
 			0x00, 0x17, // extended_master_secret
 			0x00, 0x00, // extended_master_secret extension length
 		})
 		require.NoError(t, err)
 		require.Len(t, msg.Extensions, 2)
 
-		alpn, ok := msg.Extensions[0].(*extension.ALPN)
+		alpn, ok := msg.Extensions[0].(*extension.ALPNSelection)
 		require.True(t, ok)
-		assert.Equal(t, []string{"h2", "http/1.1"}, alpn.ProtocolNameList)
+		assert.Equal(t, "h2", alpn.Protocol)
 
-		extendedMasterSecret, ok := msg.Extensions[1].(*extension.UseExtendedMasterSecret)
+		extendedMasterSecret, ok := msg.Extensions[1].(extension.Raw)
 		require.True(t, ok)
-		assert.True(t, extendedMasterSecret.Supported)
+		assert.Equal(t, extension.TypeExtendedMasterSecret, extendedMasterSecret.Type)
 	})
 
 	t.Run("ShortExtensionListHeader", func(t *testing.T) {
-		previouslyParsedExts := []extension.Extension{
-			&extension.UseExtendedMasterSecret{Supported: true},
+		previouslyParsedExts := []extension.Value{
+			extension.Raw{Type: extension.TypeExtendedMasterSecret},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 
@@ -124,8 +118,8 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 	})
 
 	t.Run("MismatchedExtensionListLength", func(t *testing.T) {
-		previouslyParsedExts := []extension.Extension{
-			&extension.UseExtendedMasterSecret{Supported: true},
+		previouslyParsedExts := []extension.Value{
+			extension.Raw{Type: extension.TypeExtendedMasterSecret},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 
@@ -135,8 +129,8 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 	})
 
 	t.Run("ExtensionUnmarshalError", func(t *testing.T) {
-		previouslyParsedExts := []extension.Extension{
-			&extension.UseExtendedMasterSecret{Supported: true},
+		previouslyParsedExts := []extension.Value{
+			extension.Raw{Type: extension.TypeExtendedMasterSecret},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 

--- a/pkg/protocol/handshake/message_new_session_ticket.go
+++ b/pkg/protocol/handshake/message_new_session_ticket.go
@@ -27,7 +27,7 @@ type MessageNewSessionTicket struct {
 	TicketAgeAdd   uint32
 	TicketNonce    []byte
 	Ticket         []byte
-	Extensions     []extension.Extension
+	Extensions     []extension.Value
 }
 
 // Type returns the Handshake Type.
@@ -44,7 +44,7 @@ func (m *MessageNewSessionTicket) Marshal() ([]byte, error) {
 		return nil, dtlserrors.ErrInvalidTicketLength
 	}
 
-	extensions, err := extension.Marshal(m.Extensions)
+	extensions, err := extension.MarshalList(m.Extensions)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (m *MessageNewSessionTicket) Unmarshal(data []byte) error {
 	ticket := bytes.Clone(data[offset : offset+ticketLength])
 	offset += ticketLength
 
-	extensions, err := extension.Unmarshal(data[offset:])
+	extensions, err := decodeExtensionList(data[offset:], extensionContextNewSessionTicket)
 	if err != nil {
 		return err
 	}

--- a/pkg/protocol/handshake/message_new_session_ticket_test.go
+++ b/pkg/protocol/handshake/message_new_session_ticket_test.go
@@ -8,6 +8,7 @@ import (
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +20,8 @@ func TestMessageNewSessionTicket(t *testing.T) {
 		TicketAgeAdd:   0x05060708,
 		TicketNonce:    []byte{0xaa, 0xbb},
 		Ticket:         []byte{0xcc, 0xdd, 0xee},
-		Extensions: []extension.Extension{
-			&extension.EarlyDataIndication{MaxEarlyData: &maxEarlyData},
+		Extensions: []extension.Value{
+			&extension13.MaxEarlyData{Size: maxEarlyData},
 		},
 	}
 	want := []byte{
@@ -55,9 +56,9 @@ func TestMessageNewSessionTicketEmptyVectors(t *testing.T) {
 }
 
 func TestMessageNewSessionTicketMarshalErrors(t *testing.T) {
-	tooManyExtensions := make([]extension.Extension, 16384)
+	tooManyExtensions := make([]extension.Value, 16384)
 	for i := range tooManyExtensions {
-		tooManyExtensions[i] = &extension.PostHandshakeAuth{Enabled: true}
+		tooManyExtensions[i] = extension.Raw{Type: extension.TypePostHandshakeAuth}
 	}
 
 	tests := map[string]*MessageNewSessionTicket{

--- a/pkg/protocol/handshake/message_server_hello.go
+++ b/pkg/protocol/handshake/message_server_hello.go
@@ -26,7 +26,7 @@ type MessageServerHello struct {
 
 	CipherSuiteID     *uint16
 	CompressionMethod *protocol.CompressionMethod
-	Extensions        []extension.Extension
+	Extensions        []extension.Value
 }
 
 const messageServerHelloVariableWidthStart = 2 + RandomLength
@@ -47,7 +47,7 @@ func (m *MessageServerHello) Marshal() ([]byte, error) {
 		return nil, dtlserrors.ErrSessionIDTooLong
 	}
 
-	extensions, err := extension.Marshal(m.Extensions)
+	extensions, err := extension.MarshalList(m.Extensions)
 	if err != nil {
 		return nil, err
 	}
@@ -113,12 +113,17 @@ func (m *MessageServerHello) Unmarshal(data []byte) error {
 	}
 
 	if len(data) <= currOffset {
-		m.Extensions = []extension.Extension{}
+		m.Extensions = []extension.Value{}
 
 		return nil
 	}
 
-	extensions, err := extension.Unmarshal(data[currOffset:])
+	rawExtensions, err := extension.ParseList(data[currOffset:])
+	if err != nil {
+		return err
+	}
+	context := serverHelloExtensionContext(m.Random, rawExtensions)
+	extensions, err := decodeRawExtensions(rawExtensions, context)
 	if err != nil {
 		return err
 	}

--- a/pkg/protocol/handshake/message_server_hello_test.go
+++ b/pkg/protocol/handshake/message_server_hello_test.go
@@ -35,7 +35,7 @@ func TestHandshakeMessageServerHello(t *testing.T) {
 		SessionID:         []byte{},
 		CipherSuiteID:     &cipherSuiteID,
 		CompressionMethod: &protocol.CompressionMethod{},
-		Extensions:        []extension.Extension{},
+		Extensions:        []extension.Value{},
 	}
 
 	c := &MessageServerHello{}
@@ -82,7 +82,7 @@ func TestHandshakeMessageServerHello_SessionIDTooLong(t *testing.T) {
 		SessionID:         make([]byte, 256),
 		CipherSuiteID:     &cipherSuiteID,
 		CompressionMethod: &protocol.CompressionMethod{ID: 0},
-		Extensions:        []extension.Extension{},
+		Extensions:        []extension.Value{},
 	}
 
 	_, err := c.Marshal()

--- a/supported_elliptic_curves_test.go
+++ b/supported_elliptic_curves_test.go
@@ -72,9 +72,9 @@ func TestSupportedEllipticCurves(t *testing.T) {
 				assert.NoError(t, clientHello.Unmarshal(msg))
 
 				for _, e := range clientHello.Extensions {
-					if e.TypeValue() == extension.SupportedEllipticCurvesTypeValue {
-						if c, ok := e.(*extension.SupportedEllipticCurves); ok {
-							actualCurves = c.EllipticCurves
+					if e.ExtensionType() == extension.TypeSupportedGroups {
+						if c, ok := e.(*extension.SupportedGroups); ok {
+							actualCurves = c.Groups
 						}
 					}
 				}


### PR DESCRIPTION
#### Description
Switches to the new extensions API added in https://github.com/pion/dtls/pull/1010 this API moves the extensions list ownership to handshake, so it can enforce spec rules about forms, orders and duplication in the handshake layer.

After this I'll remove the old API.

Part of #1009