### PR TITLE
Fix SRTP not being negotiated over DTLS 1.3

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1110,6 +1110,75 @@ func TestSRTPConfiguration(t *testing.T) {
 	}
 }
 
+func TestSRTPConfigurationDTLS13(t *testing.T) {
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientMKI := []byte("ClientSRTPMKI")
+	serverMKI := []byte("ServerSRTPMKI")
+
+	ca, cb := dpipe.Pipe()
+	type result struct {
+		c   *Conn
+		err error
+	}
+	resultCh := make(chan result)
+
+	go func() {
+		opts := []ClientOption{
+			WithMinVersion(protocol.Version1_3),
+			WithMaxVersion(protocol.Version1_3),
+			WithSRTPMasterKeyIdentifier(serverMKI),
+			WithSRTPProtectionProfiles(SRTP_AES128_CM_HMAC_SHA1_80),
+		}
+		client, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, true)
+		resultCh <- result{client, err}
+	}()
+
+	opts := []ServerOption{
+		WithMinVersion(protocol.Version1_3),
+		WithMaxVersion(protocol.Version1_3),
+		WithSRTPMasterKeyIdentifier(clientMKI),
+		WithSRTPProtectionProfiles(SRTP_AES128_CM_HMAC_SHA1_80),
+	}
+	server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), opts, true)
+	assert.NoError(t, err, "TestSRTPConfigurationDTLS13: Server handshake failed")
+	defer func() {
+		_ = server.Close()
+	}()
+
+	res := <-resultCh
+	assert.NoError(t, res.err, "TestSRTPConfigurationDTLS13: Client handshake failed")
+	defer func() {
+		_ = res.c.Close()
+	}()
+
+	assert.Equal(t, protocol.Version1_3, dtlsstate.CommonState(server.state).LocalVersion,
+		"TestSRTPConfigurationDTLS13: server did not negotiate DTLS 1.3")
+
+	actualClientSRTP, clientHasSRTP := res.c.SelectedSRTPProtectionProfile()
+	assert.True(t, clientHasSRTP, "TestSRTPConfigurationDTLS13: client selected no SRTP profile")
+	assert.Equal(t, SRTP_AES128_CM_HMAC_SHA1_80, actualClientSRTP,
+		"TestSRTPConfigurationDTLS13: Client SRTPProtectionProfile Mismatch")
+
+	actualServerSRTP, serverHasSRTP := server.SelectedSRTPProtectionProfile()
+	assert.True(t, serverHasSRTP, "TestSRTPConfigurationDTLS13: server selected no SRTP profile")
+	assert.Equal(t, SRTP_AES128_CM_HMAC_SHA1_80, actualServerSRTP,
+		"TestSRTPConfigurationDTLS13: Server SRTPProtectionProfile Mismatch")
+
+	actualServerMKI, _ := server.RemoteSRTPMasterKeyIdentifier()
+	assert.Truef(t, bytes.Equal(serverMKI, actualServerMKI),
+		"TestSRTPConfigurationDTLS13: Server SRTPMKI Mismatch")
+
+	actualClientMKI, _ := res.c.RemoteSRTPMasterKeyIdentifier()
+	assert.Truef(t, bytes.Equal(clientMKI, actualClientMKI),
+		"TestSRTPConfigurationDTLS13: Client SRTPMKI Mismatch")
+}
+
 func TestClientCertificate(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 	// Check for leaking routines
 	report := test.CheckRoutines(t)

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -82,9 +82,44 @@ func flight3Parse(
 	if failure != nil {
 		return 0, failure.alert, failure.err
 	}
+	if failure := processFlight3EncryptedExtensions(flightCtx, protectedFlight.items); failure != nil {
+		return 0, failure.alert, failure.err
+	}
 	flightCtx.state.HandshakeRecvSequence = protectedFlight.nextHandshakeSequence
 
 	return Flight5, nil, nil
+}
+
+func processFlight3EncryptedExtensions(
+	flightCtx *handshakeContext,
+	items []*dtlsflight.HandshakeCacheItem,
+) *flightParseFailure {
+	for _, item := range items {
+		if item == nil || item.Typ != handshake.TypeEncryptedExtensions {
+			continue
+		}
+		message := &handshake.MessageEncryptedExtensions{}
+		if err := message.Unmarshal(item.Data[handshake.HeaderLength:]); err != nil {
+			return newFlightParseFailure(alert.DecodeError, err)
+		}
+		for _, val := range message.Extensions {
+			selection, ok := val.(*extension.SRTPSelection)
+			if !ok {
+				continue
+			}
+			profile, matched := dtlsflight.FindMatchingSRTPProfile(
+				flightCtx.cfg.LocalSRTPProtectionProfiles,
+				[]extension.SRTPProtectionProfile{selection.ProtectionProfile},
+			)
+			if !matched {
+				return newFlightParseFailure(alert.InsufficientSecurity, dtlserrors.ErrClientNoMatchingSRTPProfile)
+			}
+			flightCtx.state.SetSRTPProtectionProfile(profile)
+			flightCtx.state.RemoteSRTPMasterKeyIdentifier = selection.MasterKeyIdentifier
+		}
+	}
+
+	return nil
 }
 
 func flight3PullServerHello(

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -265,7 +265,14 @@ func flight4Generate( //nolint:cyclop
 		},
 	}
 
-	encryptedExtensions := HandshakePacket(&handshake.MessageEncryptedExtensions{})
+	encryptedExtensionsMessage := &handshake.MessageEncryptedExtensions{}
+	if profile := state.SRTPProtectionProfile(); profile != 0 {
+		encryptedExtensionsMessage.Extensions = append(encryptedExtensionsMessage.Extensions, &extension.SRTPSelection{
+			ProtectionProfile:   profile,
+			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
+		})
+	}
+	encryptedExtensions := HandshakePacket(encryptedExtensionsMessage)
 	encryptedExtensions.ResetLocalSequenceNumber = true
 
 	pkts := []*dtlsflight.Packet{


### PR DESCRIPTION
I tried to use WebRTC data channels with DTLS 1.3, and the connection failed, reporting that no SRTP Protection Profile was chosen. This occurs because `flight4handler.go` generates an empty EncryptedExtensions block, leaving the client's `SelectedSRTPProtectionProfile()` at 0.

Linked to #727 and #1000