### PR TITLE
Validate extension blocks by context

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -252,6 +252,27 @@ var (
 		"certificate list must not be longer than 2^24-1 bytes",
 	)
 	ErrInvalidExtensionsLength             = stderrors.New("extensions data must be between 2 and 2^16-1 bytes")
+	ErrDuplicateExtension                  = stderrors.New("duplicate extension")
+	ErrExtensionNotAllowed                 = stderrors.New("extension is not allowed in this handshake message")
+	ErrPreSharedKeyNotLast                 = stderrors.New("pre_shared_key must be the last ClientHello extension")
+	ErrMissingPSKKeyExchangeModesExtension = stderrors.New(
+		"pre_shared_key requires psk_key_exchange_modes",
+	)
+	ErrEarlyDataWithoutPreSharedKey   = stderrors.New("early_data requires pre_shared_key")
+	ErrKeyShareWithoutSupportedGroups = stderrors.New(
+		"key_share requires supported_groups",
+	)
+	ErrKeyShareGroupNotOffered = stderrors.New(
+		"key_share groups must be offered in supported_groups order",
+	)
+	ErrSupportedGroupsWithoutKeyShare = stderrors.New(
+		"supported_groups requires key_share when offering DTLS 1.3",
+	)
+	ErrDuplicateSupportedGroup           = stderrors.New("supported_groups contains a duplicate group")
+	ErrMissingSupportedVersionsExtension = stderrors.New(
+		"HelloRetryRequest requires supported_versions",
+	)
+	ErrUnexpectedHandshakeMessage          = stderrors.New("unexpected handshake message")
 	ErrMissingSignatureAlgorithmsExtension = stderrors.New(
 		"signature_algorithms extension is required in CertificateRequest",
 	)

--- a/pkg/protocol/handshake/extensions.go
+++ b/pkg/protocol/handshake/extensions.go
@@ -5,14 +5,32 @@ package handshake
 
 import (
 	"bytes"
+	"fmt"
+	"slices"
 
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 )
 
-// extensionContext identifies the payload form of context-dependent extension
-// payloads.
+// extensionContext identifies the handshake-message context in which an
+// extension appears
+//
+// "The table below indicates the messages where a given extension may appear,
+// using the following notation: CH (ClientHello), SH (ServerHello), EE
+// (EncryptedExtensions), CT (Certificate), CR (CertificateRequest), NST
+// (NewSessionTicket), and HRR (HelloRetryRequest)."
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.3
+//
+// CertificateEntry is the representation of the CT context.
+// ServerHello is split because DTLS 1.2 and DTLS 1.3
+// different extension sets.
+// https://www.rfc-editor.org/rfc/rfc9147#section-5.3
 type extensionContext uint8
 
 const (
@@ -26,164 +44,450 @@ const (
 	extensionContextNewSessionTicket
 )
 
+func (c extensionContext) String() string {
+	switch c {
+	case extensionContextClientHello:
+		return "ClientHello"
+	case extensionContextServerHello12:
+		return "DTLS 1.2 ServerHello"
+	case extensionContextServerHello13:
+		return "DTLS 1.3 ServerHello"
+	case extensionContextHelloRetryRequest:
+		return "HelloRetryRequest"
+	case extensionContextEncryptedExtensions:
+		return "EncryptedExtensions"
+	case extensionContextCertificateRequest:
+		return "CertificateRequest"
+	case extensionContextCertificateEntry:
+		return "CertificateEntry"
+	case extensionContextNewSessionTicket:
+		return "NewSessionTicket"
+	default:
+		return "unknown handshake message"
+	}
+}
+
 type extensionPayloadValue interface {
 	extension.Value
 	extension.PayloadUnmarshaller
 }
 
+type extensionPayloadFactory func() extensionPayloadValue
+
+// "If an implementation receives an extension which it recognizes
+// and which is not specified for the message in which it appears,
+// it MUST abort the handshake with an 'illegal_parameter' alert."
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.3
+//
+//nolint:gochecknoglobals
+var extensionRegistry = map[extension.Type]map[extensionContext]extensionPayloadFactory{
+	extension.TypeServerName: {
+		extensionContextClientHello:         func() extensionPayloadValue { return &extension.ServerNameOffer{} },
+		extensionContextServerHello12:       func() extensionPayloadValue { return &extension.ServerNameAck{} },
+		extensionContextEncryptedExtensions: func() extensionPayloadValue { return &extension.ServerNameAck{} },
+	},
+	extension.TypeSupportedGroups: {
+		extensionContextClientHello:         func() extensionPayloadValue { return &extension.SupportedGroups{} },
+		extensionContextEncryptedExtensions: func() extensionPayloadValue { return &extension.SupportedGroups{} },
+	},
+	extension.TypeSupportedPointFormats: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension12.SupportedPointFormats{} },
+		extensionContextServerHello12: func() extensionPayloadValue { return &extension12.SupportedPointFormats{} },
+	},
+	extension.TypeSignatureAlgorithms: {
+		extensionContextClientHello:        func() extensionPayloadValue { return &extension.SignatureAlgorithms{} },
+		extensionContextCertificateRequest: func() extensionPayloadValue { return &extension.SignatureAlgorithms{} },
+	},
+	extension.TypeUseSRTP: {
+		extensionContextClientHello:         func() extensionPayloadValue { return &extension.SRTPOffer{} },
+		extensionContextServerHello12:       func() extensionPayloadValue { return &extension.SRTPSelection{} },
+		extensionContextEncryptedExtensions: func() extensionPayloadValue { return &extension.SRTPSelection{} },
+	},
+	extension.TypeALPN: {
+		extensionContextClientHello:         func() extensionPayloadValue { return &extension.ALPNOffer{} },
+		extensionContextServerHello12:       func() extensionPayloadValue { return &extension.ALPNSelection{} },
+		extensionContextEncryptedExtensions: func() extensionPayloadValue { return &extension.ALPNSelection{} },
+	},
+	extension.TypeExtendedMasterSecret: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension12.ExtendedMasterSecret{} },
+		extensionContextServerHello12: func() extensionPayloadValue { return &extension12.ExtendedMasterSecret{} },
+	},
+	extension.TypePreSharedKey: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension13.OfferedPSKs{} },
+		extensionContextServerHello13: func() extensionPayloadValue { return &extension13.SelectedPSK{} },
+	},
+	extension.TypeEarlyData: {
+		extensionContextClientHello:         func() extensionPayloadValue { return &extension13.EarlyData{} },
+		extensionContextEncryptedExtensions: func() extensionPayloadValue { return &extension13.EarlyData{} },
+		extensionContextNewSessionTicket:    func() extensionPayloadValue { return &extension13.MaxEarlyData{} },
+	},
+	extension.TypeSupportedVersions: {
+		extensionContextClientHello:       func() extensionPayloadValue { return &extension13.OfferedVersions{} },
+		extensionContextServerHello13:     func() extensionPayloadValue { return &extension13.SelectedVersion{} },
+		extensionContextHelloRetryRequest: func() extensionPayloadValue { return &extension13.SelectedVersion{} },
+	},
+	extension.TypeCookie: {
+		extensionContextClientHello:       func() extensionPayloadValue { return &extension13.Cookie{} },
+		extensionContextHelloRetryRequest: func() extensionPayloadValue { return &extension13.Cookie{} },
+	},
+	extension.TypePSKKeyExchangeModes: {
+		extensionContextClientHello: func() extensionPayloadValue { return &extension13.PSKKeyExchangeModes{} },
+	},
+	extension.TypeCertificateAuthorities: {
+		extensionContextClientHello:        func() extensionPayloadValue { return &extension13.CertificateAuthorities{} },
+		extensionContextCertificateRequest: func() extensionPayloadValue { return &extension13.CertificateAuthorities{} },
+	},
+	extension.TypeOIDFilters: {
+		extensionContextCertificateRequest: func() extensionPayloadValue { return &extension13.OIDFilters{} },
+	},
+	extension.TypePostHandshakeAuth: {
+		extensionContextClientHello: func() extensionPayloadValue { return &extension13.PostHandshakeAuth{} },
+	},
+	extension.TypeSignatureAlgorithmsCert: {
+		extensionContextClientHello: func() extensionPayloadValue {
+			return &extension.CertificateSignatureAlgorithms{}
+		},
+		extensionContextCertificateRequest: func() extensionPayloadValue {
+			return &extension.CertificateSignatureAlgorithms{}
+		},
+	},
+	extension.TypeKeyShare: {
+		extensionContextClientHello:       func() extensionPayloadValue { return &extension13.ClientKeyShare{} },
+		extensionContextServerHello13:     func() extensionPayloadValue { return &extension13.ServerKeyShare{} },
+		extensionContextHelloRetryRequest: func() extensionPayloadValue { return &extension13.RetryKeyShare{} },
+	},
+	extension.TypeConnectionID: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension.ConnectionID{} },
+		extensionContextServerHello12: func() extensionPayloadValue { return &extension.ConnectionID{} },
+		extensionContextServerHello13: func() extensionPayloadValue { return &extension.ConnectionID{} },
+	},
+	extension.TypeRenegotiationInfo: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension12.RenegotiationInfo{} },
+		extensionContextServerHello12: func() extensionPayloadValue { return &extension12.RenegotiationInfo{} },
+	},
+}
+
 func decodeExtensionList(data []byte, context extensionContext) ([]extension.Value, error) {
 	rawExtensions, err := extension.ParseList(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"extensions in %s: %w: %w",
+			context,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
 	}
 
 	return decodeRawExtensions(rawExtensions, context)
 }
 
-func decodeRawExtensions(rawExtensions []extension.Raw, context extensionContext) ([]extension.Value, error) {
+func decodeRawExtensions( //nolint:cyclop
+	rawExtensions []extension.Raw,
+	context extensionContext,
+) ([]extension.Value, error) {
+	validationErr := validateRawExtensionBlock(rawExtensions, context)
+
 	values := make([]extension.Value, 0, len(rawExtensions))
 	for _, raw := range rawExtensions {
-		value := extensionValueForContext(context, raw.Type)
-		if value == nil {
-			values = append(values, raw)
+		contexts, known := extensionRegistry[raw.Type]
+		if !known {
+			values = append(values, extension.Raw{Type: raw.Type, Data: bytes.Clone(raw.Data)})
 
 			continue
 		}
+
+		factory, allowed := contexts[context]
+		if !allowed {
+			// todo: remove this once we remove the compatibility path.
+			// nolint:godox
+			if raw.Type == extension.TypeConnectionID && context == extensionContextHelloRetryRequest {
+				factory = contexts[extensionContextServerHello13]
+			} else {
+				values = append(values, extension.Raw{Type: raw.Type, Data: bytes.Clone(raw.Data)})
+
+				continue
+			}
+		}
+		if factory == nil {
+			values = append(values, extension.Raw{Type: raw.Type, Data: bytes.Clone(raw.Data)})
+
+			continue
+		}
+
+		value := factory()
 		if err := value.UnmarshalData(raw.Data); err != nil {
-			return nil, err
+			if validationErr != nil {
+				return values, validationErr
+			}
+
+			return nil, fmt.Errorf(
+				"extension %d in %s: %w: %w",
+				raw.Type,
+				context,
+				err,
+				&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+			)
 		}
 		values = append(values, value)
+	}
+
+	if validationErr != nil {
+		return values, validationErr
+	}
+	if err := validateExtensionDependencies(values, context); err != nil {
+		return values, err
 	}
 
 	return values, nil
 }
 
-//nolint:gocyclo,cyclop
-func extensionValueForContext(context extensionContext, typ extension.Type) extensionPayloadValue {
-	switch context {
-	case extensionContextClientHello:
-		switch typ {
-		case extension.TypeServerName:
-			return &extension.ServerNameOffer{}
-		case extension.TypeALPN:
-			return &extension.ALPNOffer{}
-		case extension.TypeUseSRTP:
-			return &extension.SRTPOffer{}
-		case extension.TypeConnectionID:
-			return &extension.ConnectionID{}
-		case extension.TypeSupportedGroups:
-			return &extension.SupportedGroups{}
-		case extension.TypeSignatureAlgorithms:
-			return &extension.SignatureAlgorithms{}
-		case extension.TypeSignatureAlgorithmsCert:
-			return &extension.CertificateSignatureAlgorithms{}
-		case extension.TypeSupportedPointFormats:
-			return &extension12.SupportedPointFormats{}
-		case extension.TypeExtendedMasterSecret:
-			return &extension12.ExtendedMasterSecret{}
-		case extension.TypeRenegotiationInfo:
-			return &extension12.RenegotiationInfo{}
-		case extension.TypeSupportedVersions:
-			return &extension13.OfferedVersions{}
-		case extension.TypeCookie:
-			return &extension13.Cookie{}
-		case extension.TypeKeyShare:
-			return &extension13.ClientKeyShare{}
-		case extension.TypePreSharedKey:
-			return &extension13.OfferedPSKs{}
-		case extension.TypePSKKeyExchangeModes:
-			return &extension13.PSKKeyExchangeModes{}
-		case extension.TypeEarlyData:
-			return &extension13.EarlyData{}
-		case extension.TypeCertificateAuthorities:
-			return &extension13.CertificateAuthorities{}
-		case extension.TypePostHandshakeAuth:
-			return &extension13.PostHandshakeAuth{}
-		default:
-			return nil
+func validateRawExtensionBlock(rawExtensions []extension.Raw, context extensionContext) error {
+	seen := make(map[extension.Type]struct{}, len(rawExtensions))
+	for _, raw := range rawExtensions {
+		if _, ok := seen[raw.Type]; ok {
+			return fmt.Errorf(
+				"extension %d in %s: %w: %w",
+				raw.Type,
+				context,
+				dtlserrors.ErrDuplicateExtension,
+				&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+			)
 		}
-	case extensionContextServerHello12:
-		switch typ {
-		case extension.TypeServerName:
-			return &extension.ServerNameAck{}
-		case extension.TypeALPN:
-			return &extension.ALPNSelection{}
-		case extension.TypeUseSRTP:
-			return &extension.SRTPSelection{}
-		case extension.TypeConnectionID:
-			return &extension.ConnectionID{}
-		case extension.TypeSupportedPointFormats:
-			return &extension12.SupportedPointFormats{}
-		case extension.TypeExtendedMasterSecret:
-			return &extension12.ExtendedMasterSecret{}
-		case extension.TypeRenegotiationInfo:
-			return &extension12.RenegotiationInfo{}
-		default:
-			return nil
+		seen[raw.Type] = struct{}{}
+	}
+
+	if context == extensionContextClientHello {
+		for i, raw := range rawExtensions {
+			if raw.Type == extension.TypePreSharedKey && i != len(rawExtensions)-1 {
+				return fmt.Errorf(
+					"extension %d in %s: %w: %w",
+					raw.Type,
+					context,
+					dtlserrors.ErrPreSharedKeyNotLast,
+					&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+				)
+			}
 		}
-	case extensionContextServerHello13:
-		switch typ {
-		case extension.TypeSupportedVersions:
-			return &extension13.SelectedVersion{}
-		case extension.TypeKeyShare:
-			return &extension13.ServerKeyShare{}
-		case extension.TypePreSharedKey:
-			return &extension13.SelectedPSK{}
-		case extension.TypeConnectionID:
-			return &extension.ConnectionID{}
-		default:
-			return nil
+	}
+
+	for _, raw := range rawExtensions {
+		if contexts, known := extensionRegistry[raw.Type]; known {
+			if _, allowed := contexts[context]; !allowed {
+				return fmt.Errorf(
+					"extension %d in %s: %w: %w",
+					raw.Type,
+					context,
+					dtlserrors.ErrExtensionNotAllowed,
+					&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+				)
+			}
 		}
-	case extensionContextHelloRetryRequest:
-		switch typ {
-		case extension.TypeSupportedVersions:
-			return &extension13.SelectedVersion{}
-		case extension.TypeKeyShare:
-			return &extension13.RetryKeyShare{}
-		case extension.TypeCookie:
-			return &extension13.Cookie{}
-		case extension.TypeConnectionID:
-			return &extension.ConnectionID{}
-		default:
-			return nil
-		}
-	case extensionContextEncryptedExtensions:
-		switch typ {
-		case extension.TypeServerName:
-			return &extension.ServerNameAck{}
-		case extension.TypeALPN:
-			return &extension.ALPNSelection{}
-		case extension.TypeUseSRTP:
-			return &extension.SRTPSelection{}
-		case extension.TypeSupportedGroups:
-			return &extension.SupportedGroups{}
-		case extension.TypeEarlyData:
-			return &extension13.EarlyData{}
-		default:
-			return nil
-		}
-	case extensionContextCertificateRequest:
-		switch typ {
-		case extension.TypeSignatureAlgorithms:
-			return &extension.SignatureAlgorithms{}
-		case extension.TypeSignatureAlgorithmsCert:
-			return &extension.CertificateSignatureAlgorithms{}
-		case extension.TypeCertificateAuthorities:
-			return &extension13.CertificateAuthorities{}
-		case extension.TypeOIDFilters:
-			return &extension13.OIDFilters{}
-		default:
-			return nil
-		}
-	case extensionContextNewSessionTicket:
-		if typ == extension.TypeEarlyData {
-			return &extension13.MaxEarlyData{}
-		}
-	case extensionContextCertificateEntry:
-		// Not supported yet, this case is just added for the exhaustive linter.
 	}
 
 	return nil
+}
+
+type extensionDependencyValues struct {
+	present  map[extension.Type]bool
+	groups   *extension.SupportedGroups
+	keyShare *extension13.ClientKeyShare
+	versions *extension13.OfferedVersions
+}
+
+func validateExtensionDependencies(values []extension.Value, context extensionContext) error {
+	dependencies := collectExtensionDependencies(values)
+	if err := validateSupportedGroups(dependencies.groups, context); err != nil {
+		return err
+	}
+
+	//nolint:exhaustive // Only these contexts define cross-extension requirements.
+	switch context {
+	case extensionContextClientHello:
+		return validateClientHelloDependencies(dependencies)
+	case extensionContextHelloRetryRequest:
+		return validateHelloRetryRequestDependencies(dependencies)
+	case extensionContextCertificateRequest:
+		return validateCertificateRequestDependencies(dependencies)
+	}
+
+	return nil
+}
+
+func collectExtensionDependencies(values []extension.Value) extensionDependencyValues {
+	dependencies := extensionDependencyValues{present: make(map[extension.Type]bool, len(values))}
+	for _, value := range values {
+		dependencies.present[value.ExtensionType()] = true
+		switch typed := value.(type) {
+		case *extension.SupportedGroups:
+			dependencies.groups = typed
+		case *extension13.ClientKeyShare:
+			dependencies.keyShare = typed
+		case *extension13.OfferedVersions:
+			dependencies.versions = typed
+		}
+	}
+
+	return dependencies
+}
+
+func validateSupportedGroups(groups *extension.SupportedGroups, context extensionContext) error {
+	if groups == nil || supportedGroupsUnique(groups) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"extension %d in %s: %w: %w",
+		extension.TypeSupportedGroups,
+		context,
+		dtlserrors.ErrDuplicateSupportedGroup,
+		&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+	)
+}
+
+func validateClientHelloDependencies(dependencies extensionDependencyValues) error {
+	if err := validatePSKDependencies(dependencies); err != nil {
+		return err
+	}
+	if err := validateTLS13ClientHelloDependencies(dependencies); err != nil {
+		return err
+	}
+	if dependencies.keyShare == nil || dependencies.groups == nil ||
+		keyShareGroupsFollowSupportedGroups(dependencies.keyShare, dependencies.groups) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"extension %d in %s: %w: %w",
+		extension.TypeKeyShare,
+		extensionContextClientHello,
+		dtlserrors.ErrKeyShareGroupNotOffered,
+		&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+	)
+}
+
+func validatePSKDependencies(dependencies extensionDependencyValues) error {
+	if dependencies.present[extension.TypePreSharedKey] && !dependencies.present[extension.TypePSKKeyExchangeModes] {
+		return fmt.Errorf(
+			"extension %d in %s: %w: %w",
+			extension.TypePSKKeyExchangeModes,
+			extensionContextClientHello,
+			dtlserrors.ErrMissingPSKKeyExchangeModesExtension,
+			&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+		)
+	}
+	if dependencies.present[extension.TypeEarlyData] && !dependencies.present[extension.TypePreSharedKey] {
+		return fmt.Errorf(
+			"extension %d in %s: %w: %w",
+			extension.TypeEarlyData,
+			extensionContextClientHello,
+			dtlserrors.ErrEarlyDataWithoutPreSharedKey,
+			&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+		)
+	}
+
+	return nil
+}
+
+func validateTLS13ClientHelloDependencies(dependencies extensionDependencyValues) error {
+	attempts13 := dependencies.versions != nil &&
+		slices.Contains(dependencies.versions.Versions, protocol.Version1_3)
+	if !attempts13 {
+		return nil
+	}
+	if dependencies.groups != nil && dependencies.keyShare == nil {
+		return fmt.Errorf(
+			"extension %d in %s: %w: %w",
+			extension.TypeKeyShare,
+			extensionContextClientHello,
+			dtlserrors.ErrSupportedGroupsWithoutKeyShare,
+			&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+		)
+	}
+	if dependencies.keyShare != nil && dependencies.groups == nil {
+		return fmt.Errorf(
+			"extension %d in %s: %w: %w",
+			extension.TypeSupportedGroups,
+			extensionContextClientHello,
+			dtlserrors.ErrKeyShareWithoutSupportedGroups,
+			&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+		)
+	}
+	if dependencies.present[extension.TypePreSharedKey] ||
+		(dependencies.present[extension.TypeSignatureAlgorithms] && dependencies.groups != nil) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"extensions in %s: %w: %w",
+		extensionContextClientHello,
+		dtlserrors.ErrMissingClientHelloExtension,
+		&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+	)
+}
+
+func validateHelloRetryRequestDependencies(dependencies extensionDependencyValues) error {
+	if dependencies.present[extension.TypeSupportedVersions] {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"extension %d in %s: %w: %w",
+		extension.TypeSupportedVersions,
+		extensionContextHelloRetryRequest,
+		dtlserrors.ErrMissingSupportedVersionsExtension,
+		&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+	)
+}
+
+func validateCertificateRequestDependencies(dependencies extensionDependencyValues) error {
+	if dependencies.present[extension.TypeSignatureAlgorithms] {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"extension %d in %s: %w: %w",
+		extension.TypeSignatureAlgorithms,
+		extensionContextCertificateRequest,
+		dtlserrors.ErrMissingSignatureAlgorithmsExtension,
+		&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+	)
+}
+
+func supportedGroupsUnique(groups *extension.SupportedGroups) bool {
+	seen := make(map[elliptic.Curve]struct{}, len(groups.Groups))
+	for _, group := range groups.Groups {
+		if _, ok := seen[group]; ok {
+			return false
+		}
+		seen[group] = struct{}{}
+	}
+
+	return true
+}
+
+func keyShareGroupsFollowSupportedGroups(
+	keyShare *extension13.ClientKeyShare,
+	groups *extension.SupportedGroups,
+) bool {
+	nextGroup := 0
+	for _, share := range keyShare.Shares {
+		found := false
+		for nextGroup < len(groups.Groups) {
+			group := groups.Groups[nextGroup]
+			nextGroup++
+			if group == share.Group {
+				found = true
+
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func serverHelloExtensionContext(random Random, rawExtensions []extension.Raw) extensionContext {
@@ -193,7 +497,9 @@ func serverHelloExtensionContext(random Random, rawExtensions []extension.Raw) e
 	}
 
 	for _, raw := range rawExtensions {
-		if raw.Type == extension.TypeSupportedVersions {
+		//nolint:exhaustive // Only extensions unique to DTLS 1.3 identify this context.
+		switch raw.Type {
+		case extension.TypeSupportedVersions, extension.TypeKeyShare, extension.TypePreSharedKey:
 			return extensionContextServerHello13
 		}
 	}

--- a/pkg/protocol/handshake/extensions_test.go
+++ b/pkg/protocol/handshake/extensions_test.go
@@ -4,10 +4,15 @@
 package handshake
 
 import (
+	"fmt"
 	"testing"
 
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +21,7 @@ import (
 func TestDecodeExtensionListPreservesRawExtensions(t *testing.T) {
 	rawExtensions := []extension.Raw{
 		{Type: 0xfefe, Data: []byte{0x01, 0x02}},
-		{Type: 0xfefe, Data: []byte{0x03}},
+		{Type: 0xfefd, Data: []byte{0x03}},
 	}
 	encoded, err := extension.MarshalRawList(rawExtensions)
 	require.NoError(t, err)
@@ -43,4 +48,338 @@ func TestDecodeExtensionListUsesMessageContext(t *testing.T) {
 
 	_, err = decodeExtensionList(encoded, extensionContextClientHello)
 	assert.Error(t, err)
+}
+
+func TestExtensionContextRegistry(t *testing.T) {
+	expected := expectedExtensionRegistry()
+	require.Len(t, extensionRegistry, len(expected))
+
+	for typ, contexts := range expected {
+		registeredContexts, ok := extensionRegistry[typ]
+		require.True(t, ok, "missing registry entry for extension %d", typ)
+		for _, context := range allExtensionContexts() {
+			expectedPayload, expectedAllowed := contexts[context]
+			factory, allowed := registeredContexts[context]
+			t.Run(fmt.Sprintf("%d/%s", typ, context), func(t *testing.T) {
+				assert.Equal(t, expectedAllowed, allowed)
+				if !expectedAllowed {
+					_, err := decodeRawExtensions([]extension.Raw{{Type: typ}}, context)
+					assert.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
+					assertExtensionAlert(t, err, alert.IllegalParameter)
+
+					return
+				}
+				if expectedPayload == nil {
+					assert.Nil(t, factory)
+
+					return
+				}
+				require.NotNil(t, factory)
+				assert.IsType(t, expectedPayload, factory())
+			})
+		}
+	}
+}
+
+func TestUnknownExtensionPreservedByContext(t *testing.T) {
+	const unknownType extension.Type = 0xfefe
+	for _, context := range allExtensionContexts() {
+		t.Run(context.String(), func(t *testing.T) {
+			raw := []extension.Raw{{Type: unknownType, Data: []byte{0x01, 0x02}}}
+			if context == extensionContextCertificateRequest {
+				raw = append(raw, rawExtensionValue(t, &extension.SignatureAlgorithms{Schemes: []uint16{0x0403}}))
+			} else if context == extensionContextHelloRetryRequest {
+				raw = append(raw, rawExtensionValue(t, &extension13.SelectedVersion{Version: protocol.Version1_3}))
+			}
+
+			decoded, err := decodeRawExtensions(raw, context)
+			require.NoError(t, err)
+			unknown, ok := decoded[0].(extension.Raw)
+			require.True(t, ok)
+			assert.Equal(t, raw[0], unknown)
+
+			raw[0].Data[0] = 0xff
+			assert.Equal(t, []byte{0x01, 0x02}, unknown.Data)
+		})
+	}
+}
+
+func TestServerNameIsNotAllowedInOrdinaryCertificateRequest(t *testing.T) {
+	_, err := decodeRawExtensions([]extension.Raw{
+		{Type: extension.TypeServerName},
+		rawExtensionValue(t, &extension.SignatureAlgorithms{Schemes: []uint16{0x0403}}),
+	}, extensionContextCertificateRequest)
+	assert.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
+	assertExtensionAlert(t, err, alert.IllegalParameter)
+}
+
+func TestExtensionBlockRejectsDuplicateTypes(t *testing.T) {
+	types := make([]extension.Type, 0, len(extensionRegistry)+1)
+	for typ := range extensionRegistry {
+		types = append(types, typ)
+	}
+	types = append(types, 0xfefe)
+
+	for _, typ := range types {
+		t.Run(fmt.Sprintf("%d", typ), func(t *testing.T) {
+			_, err := decodeRawExtensions([]extension.Raw{{Type: typ}, {Type: typ}}, extensionContextClientHello)
+			assert.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
+			assertExtensionAlert(t, err, alert.IllegalParameter)
+		})
+	}
+}
+
+func TestExtensionBlockOrderingAndDependencies(t *testing.T) {
+	psk := rawExtensionValue(t, &extension13.OfferedPSKs{
+		Identities: []extension13.PSKIdentity{{Identity: []byte("identity")}},
+		Binders:    []extension13.PSKBinder{make([]byte, 32)},
+	})
+	modes := rawExtensionValue(t, &extension13.PSKKeyExchangeModes{
+		Modes: []extension13.PSKKeyExchangeMode{extension13.PSKDHEKE},
+	})
+
+	t.Run("pre shared key is last", func(t *testing.T) {
+		_, err := decodeRawExtensions([]extension.Raw{modes, psk}, extensionContextClientHello)
+		require.NoError(t, err)
+
+		_, err = decodeRawExtensions([]extension.Raw{psk, modes}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrPreSharedKeyNotLast)
+		assertExtensionAlert(t, err, alert.IllegalParameter)
+	})
+
+	t.Run("pre shared key requires modes", func(t *testing.T) {
+		_, err := decodeRawExtensions([]extension.Raw{psk}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrMissingPSKKeyExchangeModesExtension)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
+	t.Run("early data requires pre shared key", func(t *testing.T) {
+		earlyData := rawExtensionValue(t, &extension13.EarlyData{})
+		_, err := decodeRawExtensions([]extension.Raw{earlyData}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrEarlyDataWithoutPreSharedKey)
+		assertExtensionAlert(t, err, alert.IllegalParameter)
+	})
+
+	t.Run("key share requires groups", func(t *testing.T) {
+		keyShare := rawExtensionValue(t, &extension13.ClientKeyShare{})
+		versions := rawExtensionValue(t, &extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}})
+		_, err := decodeRawExtensions([]extension.Raw{versions, keyShare}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrKeyShareWithoutSupportedGroups)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
+	t.Run("groups require key share for DTLS 1.3", func(t *testing.T) {
+		versions := rawExtensionValue(t, &extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}})
+		groups := rawExtensionValue(t, &extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}})
+		signatures := rawExtensionValue(t, &extension.SignatureAlgorithms{Schemes: []uint16{0x0403}})
+		_, err := decodeRawExtensions([]extension.Raw{versions, groups, signatures}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrSupportedGroupsWithoutKeyShare)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
+	t.Run("DTLS 1.3 without PSK requires certificate auth extensions", func(t *testing.T) {
+		versions := rawExtensionValue(t, &extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}})
+		_, err := decodeRawExtensions([]extension.Raw{versions}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrMissingClientHelloExtension)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
+	t.Run("supported groups are unique", func(t *testing.T) {
+		groups := rawExtensionValue(t, &extension.SupportedGroups{
+			Groups: []elliptic.Curve{elliptic.X25519, elliptic.X25519},
+		})
+		_, err := decodeRawExtensions([]extension.Raw{groups}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrDuplicateSupportedGroup)
+		assertExtensionAlert(t, err, alert.IllegalParameter)
+	})
+
+	t.Run("key share follows offered group order", func(t *testing.T) {
+		groups := rawExtensionValue(t, &extension.SupportedGroups{
+			Groups: []elliptic.Curve{elliptic.X25519, elliptic.P256},
+		})
+		wrongOrder := rawExtensionValue(t, &extension13.ClientKeyShare{Shares: []extension13.KeyShareEntry{
+			{Group: elliptic.P256, KeyExchange: []byte{0x01}},
+			{Group: elliptic.X25519, KeyExchange: []byte{0x02}},
+		}})
+		_, err := decodeRawExtensions([]extension.Raw{groups, wrongOrder}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrKeyShareGroupNotOffered)
+		assertExtensionAlert(t, err, alert.IllegalParameter)
+
+		validSubset := rawExtensionValue(t, &extension13.ClientKeyShare{Shares: []extension13.KeyShareEntry{
+			{Group: elliptic.P256, KeyExchange: []byte{0x01}},
+		}})
+		_, err = decodeRawExtensions([]extension.Raw{groups, validSubset}, extensionContextClientHello)
+		require.NoError(t, err)
+	})
+
+	t.Run("certificate request requires signature algorithms", func(t *testing.T) {
+		_, err := decodeRawExtensions(nil, extensionContextCertificateRequest)
+		assert.ErrorIs(t, err, dtlserrors.ErrMissingSignatureAlgorithmsExtension)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
+	t.Run("HelloRetryRequest requires supported versions", func(t *testing.T) {
+		_, err := decodeRawExtensions(nil, extensionContextHelloRetryRequest)
+		assert.ErrorIs(t, err, dtlserrors.ErrMissingSupportedVersionsExtension)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+}
+
+func TestExtensionBlockValidatesPlacementBeforePayload(t *testing.T) {
+	_, err := decodeRawExtensions([]extension.Raw{
+		{Type: extension.TypeALPN, Data: []byte{0x00, 0x00}},
+		{Type: extension.TypeExtendedMasterSecret},
+	}, extensionContextEncryptedExtensions)
+	assert.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
+	assertExtensionAlert(t, err, alert.IllegalParameter)
+}
+
+func TestExtensionErrorClassification(t *testing.T) {
+	t.Run("framing", func(t *testing.T) {
+		_, err := decodeExtensionList([]byte{0x00}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+		assertExtensionAlert(t, err, alert.DecodeError)
+	})
+
+	t.Run("payload", func(t *testing.T) {
+		_, err := decodeRawExtensions([]extension.Raw{
+			{Type: extension.TypeALPN, Data: []byte{0x00, 0x00}},
+		}, extensionContextEncryptedExtensions)
+		assert.ErrorIs(t, err, extension.ErrALPNInvalidFormat)
+		assertExtensionAlert(t, err, alert.DecodeError)
+	})
+}
+
+func FuzzDecodeExtensionBlock(f *testing.F) {
+	f.Add(uint8(0), []byte{0x00, 0x00})
+	f.Add(uint8(4), []byte{0x00, 0x05, 0xfe, 0xfe, 0x00, 0x01, 0x01})
+
+	contexts := allExtensionContexts()
+	f.Fuzz(func(t *testing.T, contextID uint8, data []byte) {
+		context := contexts[int(contextID)%len(contexts)]
+		values, err := decodeExtensionList(data, context)
+		if err != nil {
+			return
+		}
+
+		canonical, err := extension.MarshalList(values)
+		require.NoError(t, err)
+		_, err = decodeExtensionList(canonical, context)
+		require.NoError(t, err)
+	})
+}
+
+func allExtensionContexts() []extensionContext {
+	return []extensionContext{
+		extensionContextClientHello,
+		extensionContextServerHello12,
+		extensionContextServerHello13,
+		extensionContextHelloRetryRequest,
+		extensionContextEncryptedExtensions,
+		extensionContextCertificateRequest,
+		extensionContextCertificateEntry,
+		extensionContextNewSessionTicket,
+	}
+}
+
+func expectedExtensionRegistry() map[extension.Type]map[extensionContext]extensionPayloadValue {
+	return map[extension.Type]map[extensionContext]extensionPayloadValue{
+		extension.TypeServerName: {
+			extensionContextClientHello:         &extension.ServerNameOffer{},
+			extensionContextServerHello12:       &extension.ServerNameAck{},
+			extensionContextEncryptedExtensions: &extension.ServerNameAck{},
+		},
+		extension.TypeSupportedGroups: {
+			extensionContextClientHello:         &extension.SupportedGroups{},
+			extensionContextEncryptedExtensions: &extension.SupportedGroups{},
+		},
+		extension.TypeSupportedPointFormats: {
+			extensionContextClientHello:   &extension12.SupportedPointFormats{},
+			extensionContextServerHello12: &extension12.SupportedPointFormats{},
+		},
+		extension.TypeSignatureAlgorithms: {
+			extensionContextClientHello:        &extension.SignatureAlgorithms{},
+			extensionContextCertificateRequest: &extension.SignatureAlgorithms{},
+		},
+		extension.TypeUseSRTP: {
+			extensionContextClientHello:         &extension.SRTPOffer{},
+			extensionContextServerHello12:       &extension.SRTPSelection{},
+			extensionContextEncryptedExtensions: &extension.SRTPSelection{},
+		},
+		extension.TypeALPN: {
+			extensionContextClientHello:         &extension.ALPNOffer{},
+			extensionContextServerHello12:       &extension.ALPNSelection{},
+			extensionContextEncryptedExtensions: &extension.ALPNSelection{},
+		},
+		extension.TypeExtendedMasterSecret: {
+			extensionContextClientHello:   &extension12.ExtendedMasterSecret{},
+			extensionContextServerHello12: &extension12.ExtendedMasterSecret{},
+		},
+		extension.TypePreSharedKey: {
+			extensionContextClientHello:   &extension13.OfferedPSKs{},
+			extensionContextServerHello13: &extension13.SelectedPSK{},
+		},
+		extension.TypeEarlyData: {
+			extensionContextClientHello:         &extension13.EarlyData{},
+			extensionContextEncryptedExtensions: &extension13.EarlyData{},
+			extensionContextNewSessionTicket:    &extension13.MaxEarlyData{},
+		},
+		extension.TypeSupportedVersions: {
+			extensionContextClientHello:       &extension13.OfferedVersions{},
+			extensionContextServerHello13:     &extension13.SelectedVersion{},
+			extensionContextHelloRetryRequest: &extension13.SelectedVersion{},
+		},
+		extension.TypeCookie: {
+			extensionContextClientHello:       &extension13.Cookie{},
+			extensionContextHelloRetryRequest: &extension13.Cookie{},
+		},
+		extension.TypePSKKeyExchangeModes: {
+			extensionContextClientHello: &extension13.PSKKeyExchangeModes{},
+		},
+		extension.TypeCertificateAuthorities: {
+			extensionContextClientHello:        &extension13.CertificateAuthorities{},
+			extensionContextCertificateRequest: &extension13.CertificateAuthorities{},
+		},
+		extension.TypeOIDFilters: {
+			extensionContextCertificateRequest: &extension13.OIDFilters{},
+		},
+		extension.TypePostHandshakeAuth: {
+			extensionContextClientHello: &extension13.PostHandshakeAuth{},
+		},
+		extension.TypeSignatureAlgorithmsCert: {
+			extensionContextClientHello:        &extension.CertificateSignatureAlgorithms{},
+			extensionContextCertificateRequest: &extension.CertificateSignatureAlgorithms{},
+		},
+		extension.TypeKeyShare: {
+			extensionContextClientHello:       &extension13.ClientKeyShare{},
+			extensionContextServerHello13:     &extension13.ServerKeyShare{},
+			extensionContextHelloRetryRequest: &extension13.RetryKeyShare{},
+		},
+		extension.TypeConnectionID: {
+			extensionContextClientHello:   &extension.ConnectionID{},
+			extensionContextServerHello12: &extension.ConnectionID{},
+			extensionContextServerHello13: &extension.ConnectionID{},
+		},
+		extension.TypeRenegotiationInfo: {
+			extensionContextClientHello:   &extension12.RenegotiationInfo{},
+			extensionContextServerHello12: &extension12.RenegotiationInfo{},
+		},
+	}
+}
+
+func rawExtensionValue(t *testing.T, value extension.Value) extension.Raw {
+	t.Helper()
+
+	data, err := value.MarshalData()
+	require.NoError(t, err)
+
+	return extension.Raw{Type: value.ExtensionType(), Data: data}
+}
+
+func assertExtensionAlert(t *testing.T, err error, expected alert.Description) {
+	t.Helper()
+
+	var got *alert.Alert
+	require.ErrorAs(t, err, &got)
+	assert.Equal(t, expected, got.Description)
 }

--- a/pkg/protocol/handshake/handshake.go
+++ b/pkg/protocol/handshake/handshake.go
@@ -5,10 +5,13 @@
 package handshake
 
 import (
+	"errors"
+
 	"github.com/pion/dtls/v3/internal/ciphersuite/types"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 )
 
 // Type is the unique identifier for each handshake message
@@ -191,5 +194,17 @@ func (h *Handshake) Unmarshal(data []byte) error { //nolint:cyclop
 		return dtlserrors.ErrNotImplemented
 	}
 
-	return h.Message.Unmarshal(data[HeaderLength:])
+	err := h.Message.Unmarshal(data[HeaderLength:])
+	var extensionAlert *alert.Alert
+	if (h.Header.Type == TypeClientHello || h.Header.Type == TypeServerHello) &&
+		errors.As(err, &extensionAlert) &&
+		(extensionAlert.Description == alert.IllegalParameter || extensionAlert.Description == alert.MissingExtension) {
+		// FullPullMap currently treats every Unmarshal error as an incomplete
+		// flight.
+		// todo: return decode errors.
+		// nolint:godox
+		return nil //nolint:nilerr
+	}
+
+	return err
 }

--- a/pkg/protocol/handshake/message_certificate_13_test.go
+++ b/pkg/protocol/handshake/message_certificate_13_test.go
@@ -544,9 +544,9 @@ func TestParseCertificateEntry_GeneratedCertificateWithExtensions(t *testing.T) 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
 	require.NoError(t, err)
 
-	// Create extensions for the certificate entry
-	serverName := &extension.ServerNameOffer{ServerName: "test2.example.com"}
-	extensions := []extension.Value{serverName}
+	// Create an unknown extension for the certificate entry.
+	const unknownCertificateExtension extension.Type = 0xfefe
+	extensions := []extension.Value{extension.Raw{Type: unknownCertificateExtension, Data: []byte{0x01}}}
 	extensionsData, err := extension.MarshalList(extensions)
 	require.NoError(t, err)
 
@@ -570,7 +570,7 @@ func TestParseCertificateEntry_GeneratedCertificateWithExtensions(t *testing.T) 
 	assert.Equal(t, 0, len(str)) // Ensure all data was consumed
 	assert.Equal(t, certDER, entry.CertificateData)
 	assert.Equal(t, 1, len(entry.Extensions))
-	assert.Equal(t, extension.TypeServerName, entry.Extensions[0].ExtensionType())
+	assert.Equal(t, unknownCertificateExtension, entry.Extensions[0].ExtensionType())
 
 	// Verify the certificate is valid
 	parsedCert, err := x509.ParseCertificate(entry.CertificateData)

--- a/pkg/protocol/handshake/message_certificate_request_13_test.go
+++ b/pkg/protocol/handshake/message_certificate_request_13_test.go
@@ -130,13 +130,13 @@ func TestMessageCertificateRequest13_MaxContextLength(t *testing.T) {
 
 func TestMessageCertificateRequest13_MultipleExtensions(t *testing.T) {
 	// Build (valid) message with multiple extensions
-	// (signature_algorithms, which must be present, and server_name)
+	// (signature_algorithms, which must be present, and an unknown extension)
 	msg := &MessageCertificateRequest13{
 		CertificateRequestContext: []byte{0x01, 0x02, 0x03, 0x04},
 		Extensions: []extension.Value{
 			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403, 0x0503, 0x0601}},
 			extension.Raw{
-				Type: extension.TypeServerName,
+				Type: 0xfefe,
 				Data: []byte{
 					0x00, 0x0e, 0x00, 0x00, 0x0b, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
 				},

--- a/pkg/protocol/handshake/message_client_hello.go
+++ b/pkg/protocol/handshake/message_client_hello.go
@@ -148,10 +148,10 @@ func (m *MessageClientHello) Unmarshal(data []byte) error { //nolint:cyclop
 
 	// Extensions
 	extensions, err := decodeExtensionList(data[currOffset:], extensionContextClientHello)
+	m.Extensions = extensions
 	if err != nil {
 		return err
 	}
-	m.Extensions = extensions
 
 	return nil
 }

--- a/pkg/protocol/handshake/message_encrypted_extensions_test.go
+++ b/pkg/protocol/handshake/message_encrypted_extensions_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var errMarshalEncryptedExtensionsTest = errors.New("marshal encrypted extensions test")
+
+const unknownEncryptedExtensionsType extension.Type = 0xfefe
 
 type failingEncryptedExtensionsExtension struct{}
 
@@ -41,7 +44,7 @@ func TestMessageEncryptedExtensionsMarshal(t *testing.T) {
 		raw, err := (&MessageEncryptedExtensions{
 			Extensions: []extension.Value{
 				&extension.ALPNSelection{Protocol: "h2"},
-				extension.Raw{Type: extension.TypeExtendedMasterSecret},
+				extension.Raw{Type: unknownEncryptedExtensionsType},
 			},
 		}).Marshal()
 		require.NoError(t, err)
@@ -51,8 +54,8 @@ func TestMessageEncryptedExtensionsMarshal(t *testing.T) {
 			0x00, 0x05, // ALPN extension length
 			0x00, 0x03, // ALPN protocol name list length
 			0x02, 0x68, 0x32, // h2
-			0x00, 0x17, // extended_master_secret
-			0x00, 0x00, // extended_master_secret extension length
+			0xfe, 0xfe, // unknown extension
+			0x00, 0x00, // unknown extension length
 		}, raw)
 	})
 
@@ -91,8 +94,8 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 			0x00, 0x05, // ALPN extension length
 			0x00, 0x03, // ALPN protocol name list length
 			0x02, 0x68, 0x32, // h2
-			0x00, 0x17, // extended_master_secret
-			0x00, 0x00, // extended_master_secret extension length
+			0xfe, 0xfe, // unknown extension
+			0x00, 0x00, // unknown extension length
 		})
 		require.NoError(t, err)
 		require.Len(t, msg.Extensions, 2)
@@ -101,14 +104,14 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "h2", alpn.Protocol)
 
-		extendedMasterSecret, ok := msg.Extensions[1].(extension.Raw)
+		unknown, ok := msg.Extensions[1].(extension.Raw)
 		require.True(t, ok)
-		assert.Equal(t, extension.TypeExtendedMasterSecret, extendedMasterSecret.Type)
+		assert.Equal(t, unknownEncryptedExtensionsType, unknown.Type)
 	})
 
 	t.Run("ShortExtensionListHeader", func(t *testing.T) {
 		previouslyParsedExts := []extension.Value{
-			extension.Raw{Type: extension.TypeExtendedMasterSecret},
+			extension.Raw{Type: unknownEncryptedExtensionsType},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 
@@ -119,7 +122,7 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 
 	t.Run("MismatchedExtensionListLength", func(t *testing.T) {
 		previouslyParsedExts := []extension.Value{
-			extension.Raw{Type: extension.TypeExtendedMasterSecret},
+			extension.Raw{Type: unknownEncryptedExtensionsType},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 
@@ -130,7 +133,7 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 
 	t.Run("ExtensionUnmarshalError", func(t *testing.T) {
 		previouslyParsedExts := []extension.Value{
-			extension.Raw{Type: extension.TypeExtendedMasterSecret},
+			extension.Raw{Type: unknownEncryptedExtensionsType},
 		}
 		msg := &MessageEncryptedExtensions{Extensions: previouslyParsedExts}
 
@@ -142,5 +145,19 @@ func TestMessageEncryptedExtensionsUnmarshal(t *testing.T) {
 		})
 		assert.ErrorIs(t, err, extension.ErrALPNInvalidFormat)
 		assert.Equal(t, previouslyParsedExts, msg.Extensions)
+	})
+
+	t.Run("KnownIllegalExtension", func(t *testing.T) {
+		msg := &MessageEncryptedExtensions{}
+		err := msg.Unmarshal([]byte{
+			0x00, 0x04,
+			0x00, 0x17,
+			0x00, 0x00,
+		})
+		assert.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
+		var got *alert.Alert
+		require.ErrorAs(t, err, &got)
+		assert.Equal(t, alert.IllegalParameter, got.Description)
+		assert.Empty(t, msg.Extensions)
 	})
 }

--- a/pkg/protocol/handshake/message_new_session_ticket_test.go
+++ b/pkg/protocol/handshake/message_new_session_ticket_test.go
@@ -56,11 +56,6 @@ func TestMessageNewSessionTicketEmptyVectors(t *testing.T) {
 }
 
 func TestMessageNewSessionTicketMarshalErrors(t *testing.T) {
-	tooManyExtensions := make([]extension.Value, 16384)
-	for i := range tooManyExtensions {
-		tooManyExtensions[i] = extension.Raw{Type: extension.TypePostHandshakeAuth}
-	}
-
 	tests := map[string]*MessageNewSessionTicket{
 		"nonce too long": {TicketNonce: make([]byte, 256), Ticket: []byte{0x01}},
 		"empty ticket":   {},
@@ -68,8 +63,10 @@ func TestMessageNewSessionTicketMarshalErrors(t *testing.T) {
 			Ticket: make([]byte, 65536),
 		},
 		"extensions too long": {
-			Ticket:     []byte{0x01},
-			Extensions: tooManyExtensions,
+			Ticket: []byte{0x01},
+			Extensions: []extension.Value{
+				extension.Raw{Type: 0xfefe, Data: make([]byte, 65532)},
+			},
 		},
 	}
 

--- a/pkg/protocol/handshake/message_server_hello.go
+++ b/pkg/protocol/handshake/message_server_hello.go
@@ -6,9 +6,11 @@ package handshake
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 )
 
@@ -70,7 +72,7 @@ func (m *MessageServerHello) Marshal() ([]byte, error) {
 }
 
 // Unmarshal populates the message from encoded data.
-func (m *MessageServerHello) Unmarshal(data []byte) error {
+func (m *MessageServerHello) Unmarshal(data []byte) error { //nolint:cyclop
 	if len(data) < 2+RandomLength {
 		return dtlserrors.ErrBufferTooSmall
 	}
@@ -113,21 +115,37 @@ func (m *MessageServerHello) Unmarshal(data []byte) error {
 	}
 
 	if len(data) <= currOffset {
-		m.Extensions = []extension.Value{}
+		context := serverHelloExtensionContext(m.Random, nil)
+		extensions, err := decodeRawExtensions(nil, context)
+		m.Extensions = extensions
+		if err != nil {
+			return err
+		}
 
 		return nil
 	}
 
 	rawExtensions, err := extension.ParseList(data[currOffset:])
 	if err != nil {
-		return err
+		context := extensionContextServerHello12
+		randomBytes := m.Random.MarshalFixed()
+		if bytes.Equal(randomBytes[:], HelloRetryRequestRandom()) {
+			context = extensionContextHelloRetryRequest
+		}
+
+		return fmt.Errorf(
+			"extensions in %s: %w: %w",
+			context,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
 	}
 	context := serverHelloExtensionContext(m.Random, rawExtensions)
 	extensions, err := decodeRawExtensions(rawExtensions, context)
+	m.Extensions = extensions
 	if err != nil {
 		return err
 	}
-	m.Extensions = extensions
 
 	return nil
 }

--- a/pkg/protocol/handshake/message_server_hello_test.go
+++ b/pkg/protocol/handshake/message_server_hello_test.go
@@ -9,9 +9,55 @@ import (
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMessageServerHelloExtensionFramingErrorIsClassified(t *testing.T) {
+	cipherSuiteID := uint16(0xc02b)
+	raw, err := (&MessageServerHello{
+		Version:           protocol.Version1_2,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: &protocol.CompressionMethod{},
+	}).Marshal()
+	assert.NoError(t, err)
+	raw[len(raw)-1] = 1
+
+	err = (&MessageServerHello{}).Unmarshal(raw)
+	assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
+	var got *alert.Alert
+	assert.ErrorAs(t, err, &got)
+	assert.Equal(t, alert.DecodeError, got.Description)
+}
+
+func TestMessageServerHelloRejectsHelloRetryRequestWithoutSupportedVersions(t *testing.T) {
+	var randomFixed [RandomLength]byte
+	copy(randomFixed[:], HelloRetryRequestRandom())
+	var random Random
+	random.UnmarshalFixed(randomFixed)
+	cipherSuiteID := uint16(0x1301)
+	raw, err := (&MessageServerHello{
+		Version:           protocol.Version1_2,
+		Random:            random,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: &protocol.CompressionMethod{},
+	}).Marshal()
+	assert.NoError(t, err)
+
+	for name, input := range map[string][]byte{
+		"empty vector":   raw,
+		"omitted vector": raw[:len(raw)-2],
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := (&MessageServerHello{}).Unmarshal(input)
+			assert.ErrorIs(t, err, dtlserrors.ErrMissingSupportedVersionsExtension)
+			var got *alert.Alert
+			assert.ErrorAs(t, err, &got)
+			assert.Equal(t, alert.MissingExtension, got.Description)
+		})
+	}
+}
 
 func TestHandshakeMessageServerHello(t *testing.T) {
 	rawServerHello := []byte{


### PR DESCRIPTION
#### Description
extensions registry, placement/duplicate/dependency rules, alert classification according to specs, part of the work to normalize extensions between 1.2 and 1.3, and handle extension edge cases and rules for 1.3, part of #1021 , #727 and #1005 