### PR TITLE
Propagate handshake cache errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2278,6 +2278,12 @@ func (c *Conn) negotiateVersionServer(ctx context.Context) error {
 			return err
 		}
 		if ok, err := c.pickVersionFromClientHello(); err != nil {
+			var negotiationAlert *alert.Alert
+			errors.As(err, &negotiationAlert)
+			if alertErr := c.notify(ctx, negotiationAlert.Level, negotiationAlert.Description); alertErr != nil {
+				return errors.Join(err, alertErr)
+			}
+
 			return err
 		} else if ok {
 			return nil
@@ -2317,6 +2323,12 @@ func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet
 			return nil, err
 		}
 		if ok, err := c.pickVersionFromServerResponse(); err != nil {
+			var negotiationAlert *alert.Alert
+			errors.As(err, &negotiationAlert)
+			if alertErr := c.notify(ctx, negotiationAlert.Level, negotiationAlert.Description); alertErr != nil {
+				return nil, errors.Join(err, alertErr)
+			}
+
 			return nil, err
 		} else if ok {
 			return pkts, nil
@@ -2329,17 +2341,19 @@ func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet
 // ClientHello and, if found, sets localVersion and remoteVersions.
 // Returns true once the version can be decided.
 func (c *Conn) pickVersionFromClientHello() (bool, error) {
-	_, msgs, ok := c.handshakeCache.FullPullMap(0, dtlsstate.CommonState(c.state).CipherSuite,
+	pull := c.handshakeCache.FullPullMapItems(0, dtlsstate.CommonState(c.state).CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: c.handshakeConfig.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 	)
+	if pull.Err != nil {
+		return false, pull.Err
+	}
+	if !pull.Ready {
+		return false, nil
+	}
+	ch, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
 	if !ok {
 		return false, nil
 	}
-	ch, ok := msgs[handshake.TypeClientHello].(*handshake.MessageClientHello)
-	if !ok {
-		return false, nil
-	}
-
 	var remote []protocol.Version
 	seenSupportedVersions := false
 	for _, e := range ch.Extensions {
@@ -2356,7 +2370,11 @@ func (c *Conn) pickVersionFromClientHello() (bool, error) {
 
 	chosen, ok := dtlsconfig.SelectVersion(remote, c.handshakeConfig.MinVersion, c.handshakeConfig.MaxVersion)
 	if !ok {
-		return false, dtlserrors.ErrNoCommonProtocolVersion
+		return false, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrNoCommonProtocolVersion,
+			&alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
+		)
 	}
 
 	c.setNegotiatedVersion(remote, chosen)
@@ -2373,7 +2391,24 @@ func (c *Conn) pickVersionFromClientHello() (bool, error) {
 //   - ServerHello without supported_versions: fall back to ServerHello.Version.
 //   - HelloVerifyRequest (1.2 cookie request): version is 1.2.
 func (c *Conn) pickVersionFromServerResponse() (bool, error) {
-	if sh, ok := c.findCachedServerMessage(handshake.TypeServerHello).(*handshake.MessageServerHello); ok {
+	pull := c.handshakeCache.FullPullMapOneOfItems(
+		0,
+		dtlsstate.CommonState(c.state).CipherSuite,
+		dtlsflight.HandshakeCachePullRule{
+			Typ: handshake.TypeServerHello, Epoch: c.handshakeConfig.InitialEpoch, IsClient: false,
+		},
+		dtlsflight.HandshakeCachePullRule{
+			Typ: handshake.TypeHelloVerifyRequest, Epoch: c.handshakeConfig.InitialEpoch, IsClient: false,
+		},
+	)
+	if pull.Err != nil {
+		return false, pull.Err
+	}
+	if !pull.Ready {
+		return false, nil
+	}
+
+	if sh, ok := pull.Messages[handshake.TypeServerHello].(*handshake.MessageServerHello); ok {
 		if err := c.pickVersionFromServerHello(sh); err != nil {
 			return false, err
 		}
@@ -2381,7 +2416,7 @@ func (c *Conn) pickVersionFromServerResponse() (bool, error) {
 		return true, nil
 	}
 
-	if hvr, ok := c.findCachedServerMessage(handshake.TypeHelloVerifyRequest).(*handshake.MessageHelloVerifyRequest); ok {
+	if hvr, ok := pull.Messages[handshake.TypeHelloVerifyRequest].(*handshake.MessageHelloVerifyRequest); ok {
 		if err := c.selectRemoteVersion([]protocol.Version{hvr.Version}); err != nil {
 			return false, err
 		}
@@ -2407,7 +2442,11 @@ func remoteVersionsFromServerHello(sh *handshake.MessageServerHello) ([]protocol
 		return remoteVersionsFromHelloRetryRequest(remote, seenSupportedVersions, err)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"%w: %w",
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+		)
 	}
 	if !seenSupportedVersions {
 		return []protocol.Version{sh.Version}, nil
@@ -2421,11 +2460,26 @@ func remoteVersionsFromHelloRetryRequest(
 	seenSupportedVersions bool,
 	err error,
 ) ([]protocol.Version, error) {
-	if err != nil || !seenSupportedVersions {
-		return nil, dtlserrors.ErrInvalidHelloRetryRequest
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+		)
+	}
+	if !seenSupportedVersions {
+		return nil, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+		)
 	}
 	if !remote[0].Equal(protocol.Version1_3) {
-		return nil, dtlserrors.ErrUnsupportedProtocolVersion
+		return nil, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrUnsupportedProtocolVersion,
+			&alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
+		)
 	}
 
 	return remote, nil
@@ -2434,7 +2488,11 @@ func remoteVersionsFromHelloRetryRequest(
 func (c *Conn) selectRemoteVersion(remote []protocol.Version) error {
 	chosen, ok := dtlsconfig.SelectVersion(remote, c.handshakeConfig.MinVersion, c.handshakeConfig.MaxVersion)
 	if !ok {
-		return dtlserrors.ErrNoCommonProtocolVersion
+		return fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrNoCommonProtocolVersion,
+			&alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
+		)
 	}
 	c.setNegotiatedVersion(remote, chosen)
 
@@ -2452,19 +2510,6 @@ func (c *Conn) setNegotiatedVersion(remote []protocol.Version, chosen protocol.V
 	}
 
 	c.state = dtlsstate.Activate12(c.state)
-}
-
-// findCachedServerMessage pulls the most recent handshake message of the
-// given type sent by the peer from the cache, if any.
-func (c *Conn) findCachedServerMessage(messageType handshake.Type) handshake.Message {
-	_, msgs, ok := c.handshakeCache.FullPullMap(0, dtlsstate.CommonState(c.state).CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: messageType, Epoch: c.handshakeConfig.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
-	)
-	if !ok {
-		return nil
-	}
-
-	return msgs[messageType]
 }
 
 // stampHandshakeSequence assigns the DTLS message_sequence to each handshake

--- a/conn_test.go
+++ b/conn_test.go
@@ -2409,9 +2409,175 @@ func TestPickVersionFromServerResponseRejectsHelloRetryRequestWithoutSupportedVe
 
 	ok, err := conn.pickVersionFromServerResponse()
 
-	assert.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
+	assert.ErrorIs(t, err, dtlserrors.ErrMissingSupportedVersionsExtension)
+	var classified *alert.Alert
+	require.ErrorAs(t, err, &classified)
+	assert.Equal(t, alert.MissingExtension, classified.Description)
 	assert.False(t, ok)
 	assert.Equal(t, protocol.Version{}, dtlsstate.CommonState(conn.state).LocalVersion)
+}
+
+func TestPickVersionFromServerResponseRejectsUnexpectedMessage(t *testing.T) {
+	cfg := testVersionNegotiationHandshakeConfig13(t)
+	cfg.MinVersion = protocol.Version1_2
+	cfg.MaxVersion = protocol.Version1_3
+	raw, err := (&handshake.Handshake{
+		Message: &handshake.MessageFinished{VerifyData: []byte{0x01}},
+	}).Marshal()
+	require.NoError(t, err)
+
+	conn := &Conn{
+		handshakeCache:  dtlsflight.NewCache(),
+		handshakeConfig: cfg,
+	}
+	conn.handshakeCache.Push(raw, cfg.InitialEpoch, 0, handshake.TypeFinished, false)
+
+	ok, err := conn.pickVersionFromServerResponse()
+
+	assert.ErrorIs(t, err, dtlserrors.ErrUnexpectedHandshakeMessage)
+	var classified *alert.Alert
+	require.ErrorAs(t, err, &classified)
+	assert.Equal(t, alert.UnexpectedMessage, classified.Description)
+	assert.False(t, ok)
+}
+
+func TestPickVersionFromServerResponsePreservesDecodeAlert(t *testing.T) {
+	cfg := testVersionNegotiationHandshakeConfig13(t)
+	cfg.MinVersion = protocol.Version1_2
+	cfg.MaxVersion = protocol.Version1_3
+	conn := &Conn{
+		handshakeCache:  dtlsflight.NewCache(),
+		handshakeConfig: cfg,
+	}
+	conn.handshakeCache.Push(
+		[]byte{byte(handshake.TypeServerHello)},
+		cfg.InitialEpoch,
+		0,
+		handshake.TypeServerHello,
+		false,
+	)
+
+	ok, err := conn.pickVersionFromServerResponse()
+
+	assert.ErrorIs(t, err, dtlserrors.ErrBufferTooSmall)
+	var classified *alert.Alert
+	require.ErrorAs(t, err, &classified)
+	assert.Equal(t, alert.DecodeError, classified.Description)
+	assert.False(t, ok)
+}
+
+func TestDualStackVersionNegotiationSendsClassifiedAlerts(t *testing.T) {
+	t.Run("server rejects illegal ClientHello extensions", func(t *testing.T) {
+		ca, cb := dpipe.Pipe()
+		defer func() {
+			_ = ca.Close()
+			_ = cb.Close()
+		}()
+
+		certificate, err := selfsign.GenerateSelfSigned()
+		require.NoError(t, err)
+		server, err := ServerWithOptions(
+			dtlsnet.PacketConnFromConn(cb),
+			cb.RemoteAddr(),
+			WithCertificates(certificate),
+			WithMinVersion(protocol.Version1_2),
+			WithMaxVersion(protocol.Version1_3),
+		)
+		require.NoError(t, err)
+		defer func() { _ = server.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		result := make(chan error, 1)
+		go func() { result <- server.HandshakeContext(ctx) }()
+
+		raw := marshalVersionNegotiationRecord(t, &handshake.MessageClientHello{
+			Version:            protocol.Version1_2,
+			CipherSuiteIDs:     []uint16{uint16(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)},
+			CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+			Extensions: []extension.Value{
+				extension.Raw{Type: 0xfefe},
+				extension.Raw{Type: 0xfefe},
+			},
+		})
+		_, err = ca.Write(raw)
+		require.NoError(t, err)
+
+		assert.Equal(t, alert.IllegalParameter, readVersionNegotiationAlert(t, ca))
+		assert.ErrorIs(t, <-result, dtlserrors.ErrDuplicateExtension)
+	})
+
+	t.Run("client rejects unexpected response", func(t *testing.T) {
+		ca, cb := dpipe.Pipe()
+		defer func() {
+			_ = ca.Close()
+			_ = cb.Close()
+		}()
+
+		client, err := ClientWithOptions(
+			dtlsnet.PacketConnFromConn(cb),
+			cb.RemoteAddr(),
+			WithInsecureSkipVerify(true),
+			WithMinVersion(protocol.Version1_2),
+			WithMaxVersion(protocol.Version1_3),
+		)
+		require.NoError(t, err)
+		defer func() { _ = client.Close() }()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		result := make(chan error, 1)
+		go func() { result <- client.HandshakeContext(ctx) }()
+
+		require.NoError(t, ca.SetReadDeadline(time.Now().Add(time.Second)))
+		_, err = ca.Read(make([]byte, 8192)) // Initial ClientHello.
+		require.NoError(t, err)
+		_, err = ca.Write(marshalVersionNegotiationRecord(t, &handshake.MessageFinished{VerifyData: []byte{0x01}}))
+		require.NoError(t, err)
+
+		assert.Equal(t, alert.UnexpectedMessage, readVersionNegotiationAlert(t, ca))
+		assert.ErrorIs(t, <-result, dtlserrors.ErrUnexpectedHandshakeMessage)
+	})
+}
+
+func marshalVersionNegotiationRecord(t *testing.T, message handshake.Message) []byte {
+	t.Helper()
+
+	raw, err := (&recordlayer.RecordLayer{
+		Header: recordlayer.Header{Version: protocol.Version1_2},
+		Content: &handshake.Handshake{
+			Message: message,
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func readVersionNegotiationAlert(t *testing.T, conn net.Conn) alert.Description {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+	for {
+		raw := make([]byte, 8192)
+		n, err := conn.Read(raw)
+		require.NoError(t, err)
+		records, err := recordlayer.UnpackDatagram(raw[:n])
+		require.NoError(t, err)
+		for _, rawRecord := range records {
+			header := &recordlayer.Header{}
+			require.NoError(t, header.Unmarshal(rawRecord))
+			if header.ContentType != protocol.ContentTypeAlert {
+				continue
+			}
+
+			record := &recordlayer.RecordLayer{}
+			require.NoError(t, record.Unmarshal(rawRecord))
+			dtlsAlert, ok := record.Content.(*alert.Alert)
+			require.True(t, ok)
+
+			return dtlsAlert.Description
+		}
+	}
 }
 
 func TestPickVersionFromServerResponseRejectsServerHelloWithClientHelloSupportedVersionsEncoding(t *testing.T) {

--- a/flight_test.go
+++ b/flight_test.go
@@ -929,10 +929,10 @@ func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *test
 			cfg:   cfg,
 		})
 
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
+	require.ErrorIs(t, err, dtlserrors.ErrMissingSupportedVersionsExtension)
 	require.NotNil(t, dtlsAlert)
 	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
-	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
+	assert.Equal(t, alert.MissingExtension, dtlsAlert.Description)
 	assert.Zero(t, nextFlight)
 	assert.False(t, state.HasRemoteKeyEntries)
 }
@@ -2084,14 +2084,8 @@ func TestFlight13_3ParseRejectsMissingSupportedVersions(t *testing.T) {
 	_, _, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg})
 	require.NoError(t, err)
 
-	group := cfg.EllipticCurves[0]
-	serverKeypair, err := elliptic.GenerateKeypair(group)
-	require.NoError(t, err)
-
 	random := handshake.Random{RandomBytes: [handshake.RandomBytesLength]byte{0x01}}
-	rawServerHello := marshalServerHello(t, cfg, random, []extension.Value{
-		&extension13.ServerKeyShare{Share: extension13.KeyShareEntry{Group: group, KeyExchange: serverKeypair.PublicKey}},
-	})
+	rawServerHello := marshalServerHello(t, cfg, random, nil)
 
 	cache := dtlsflight.NewCache()
 	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
@@ -2443,7 +2437,7 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 		assert.Equal(t, cfg.EllipticCurves, state.RemoteGroups)
 	})
 
-	t.Run("AllowsPreSharedKeyWithoutCertificateAuthExtensions", func(t *testing.T) {
+	t.Run("RejectsPreSharedKeyWithoutModes", func(t *testing.T) {
 		cfg := testHandshakeConfig13(t)
 		state := newTestState13(false)
 		cache := dtlsflight.NewCache()
@@ -2465,9 +2459,10 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 				cfg:   cfg,
 			})
 
-		require.NoError(t, err)
-		require.Nil(t, dtlsAlert)
-		assert.Equal(t, dtlsflight13.Flight2, nextFlight)
+		require.ErrorIs(t, err, dtlserrors.ErrMissingPSKKeyExchangeModesExtension)
+		require.NotNil(t, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
+		assert.Zero(t, nextFlight)
 	})
 
 	t.Run("RejectsMissingSignatureAlgorithms", func(t *testing.T) {
@@ -2528,7 +2523,7 @@ func TestFlight13_0ParseRequiresCertificateAuthClientHelloExtensions(t *testing.
 				cfg:   cfg,
 			})
 
-		require.ErrorIs(t, err, dtlserrors.ErrMissingClientHelloExtension)
+		require.ErrorIs(t, err, dtlserrors.ErrKeyShareWithoutSupportedGroups)
 		require.NotNil(t, dtlsAlert)
 		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension}, dtlsAlert)
 		assert.Zero(t, nextFlight)
@@ -3649,6 +3644,7 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 		firstPresent bool
 		firstCID     []byte
 		secondCIDs   [][]byte
+		expectedErr  error
 	}{
 		"RemovedEmptyOffer": {
 			firstPresent: true,
@@ -3666,6 +3662,7 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 			firstPresent: true,
 			firstCID:     []byte{0x01},
 			secondCIDs:   [][]byte{{0x01}, {0x01}},
+			expectedErr:  dtlserrors.ErrDuplicateExtension,
 		},
 	}
 
@@ -3690,7 +3687,11 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 				t, dtlsflight13.Flight2, context.Background(), flight13_2Context(state, cache, cfg),
 			)
 
-			require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+			expectedErr := test.expectedErr
+			if expectedErr == nil {
+				expectedErr = dtlserrors.ErrInvalidClientHello
+			}
+			require.ErrorIs(t, err, expectedErr)
 			require.NotNil(t, dtlsAlert)
 			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
 			assert.Zero(t, nextFlight)
@@ -3915,7 +3916,7 @@ func TestFlight13_0ParseRejectsDuplicateConnectionID(t *testing.T) {
 		},
 	)
 
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+	require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
 	require.NotNil(t, dtlsAlert)
 	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
 	assert.Zero(t, nextFlight)
@@ -4068,7 +4069,7 @@ func TestFlight13_3ParseRejectsDuplicateConnectionID(t *testing.T) {
 		t, true, []byte{0x01}, [][]byte{{0x10}, {0x11}},
 	)
 
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
+	require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
 	require.NotNil(t, dtlsAlert)
 	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
 	assert.Zero(t, nextFlight)
@@ -4097,7 +4098,7 @@ func TestFlight13_1ParseRejectsConnectionIDInHelloRetryRequest(t *testing.T) {
 		},
 	)
 
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
+	require.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
 	require.NotNil(t, dtlsAlert)
 	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
 	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)

--- a/internal/flight/cache.go
+++ b/internal/flight/cache.go
@@ -5,11 +5,14 @@
 package flight
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
@@ -74,61 +77,208 @@ func (h *Cache) Pull(rules ...HandshakeCachePullRule) []*HandshakeCacheItem {
 	return out
 }
 
-// FullPullMap pulls all handshakes between rules[0] to rules[len(rules)-1] as map.
-func (h *Cache) FullPullMap(
-	startSeq int,
-	cipherSuite dtlsconfig.CipherSuite,
-	rules ...HandshakeCachePullRule,
-) (int, map[handshake.Type]handshake.Message, bool) {
-	seq, msgs, _, ok := h.FullPullMapItems(startSeq, cipherSuite, rules...)
-
-	return seq, msgs, ok
-}
-
 func (h *Cache) FullPullMapItems(
 	startSeq int,
 	cipherSuite dtlsconfig.CipherSuite,
 	rules ...HandshakeCachePullRule,
-) (int, map[handshake.Type]handshake.Message, []*HandshakeCacheItem, bool) {
+) HandshakeCachePullResult {
+	selection := h.PullSequential(startSeq, rules...)
+	if selection.Err != nil || !selection.Ready {
+		return HandshakeCachePullResult{
+			NextSequence: startSeq,
+			Ready:        selection.Ready,
+			Err:          selection.Err,
+		}
+	}
+
+	return fullPullMapCacheItems(startSeq, cipherSuite, rules, selection.Items)
+}
+
+// FullPullMapOneOfItems decodes exactly one of the allowed messages at
+// startSeq. A different message from the same peer and epoch is an
+// unexpected_message failure.
+func (h *Cache) FullPullMapOneOfItems(
+	startSeq int,
+	cipherSuite dtlsconfig.CipherSuite,
+	rules ...HandshakeCachePullRule,
+) HandshakeCachePullResult {
+	rule, item, ready, err := h.pullOneOf(startSeq, rules)
+	if err != nil || !ready {
+		return HandshakeCachePullResult{
+			NextSequence: startSeq,
+			Ready:        ready,
+			Err:          err,
+		}
+	}
+
+	return fullPullMapCacheItems(
+		startSeq,
+		cipherSuite,
+		[]HandshakeCachePullRule{rule},
+		[]*HandshakeCacheItem{item},
+	)
+}
+
+func (h *Cache) pullOneOf( //nolint:cyclop
+	startSeq int,
+	rules []HandshakeCachePullRule,
+) (HandshakeCachePullRule, *HandshakeCacheItem, bool, error) {
+	if startSeq < 0 || startSeq > int(^uint16(0)) {
+		return HandshakeCachePullRule{}, nil, true, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrHandshakeSequenceOverflow,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
+	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	ci, ok := h.pullLastCacheItems(rules)
-	if !ok {
-		return startSeq, nil, nil, false
-	}
-
-	return fullPullMapCacheItems(startSeq, cipherSuite, rules, ci)
-}
-
-func (h *Cache) pullLastCacheItems(rules []HandshakeCachePullRule) ([]*HandshakeCacheItem, bool) {
-	items := make([]*HandshakeCacheItem, len(rules))
-	for i, rule := range rules {
-		items[i] = h.lastCacheItemForRule(rule)
-		if !rule.Optional && items[i] == nil {
-			return nil, false
-		}
-	}
-
-	return items, true
-}
-
-func (h *Cache) lastCacheItemForRule(rule HandshakeCachePullRule) *HandshakeCacheItem {
-	var last *HandshakeCacheItem
-	for _, c := range h.cache {
-		if !cacheItemMatchesRule(c, rule) {
+	var selectedRule HandshakeCachePullRule
+	var selectedItem *HandshakeCacheItem
+	conflict := false
+	for _, item := range h.cache {
+		if item.MessageSequence != uint16(startSeq) { //nolint:gosec // startSeq is bounded above.
 			continue
 		}
-		if last == nil || last.MessageSequence < c.MessageSequence {
-			last = c
+
+		matchedMetadata := false
+		matchedRule := -1
+		for i, rule := range rules {
+			if item.IsClient != rule.IsClient || item.Epoch != rule.Epoch {
+				continue
+			}
+			matchedMetadata = true
+			if item.Typ == rule.Typ {
+				matchedRule = i
+
+				break
+			}
+		}
+		if !matchedMetadata {
+			continue
+		}
+		if matchedRule < 0 {
+			conflict = true
+
+			continue
+		}
+		if selectedItem != nil && selectedItem.Typ != item.Typ {
+			conflict = true
+
+			continue
+		}
+
+		selectedRule = rules[matchedRule]
+		selectedItem = item
+	}
+
+	if conflict {
+		return HandshakeCachePullRule{}, nil, true, fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrUnexpectedHandshakeMessage,
+			&alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage},
+		)
+	}
+	if selectedItem == nil {
+		return HandshakeCachePullRule{}, nil, false, nil
+	}
+
+	return selectedRule, selectedItem, true, nil
+}
+
+// PullSequential selects messages at consecutive sequence numbers. Missing
+// messages are incomplete.
+func (h *Cache) PullSequential( //nolint:cyclop,gocognit // Ordered required/optional conflict handling.
+	startSeq int,
+	rules ...HandshakeCachePullRule,
+) HandshakeCacheItemPullResult {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	items := make([]*HandshakeCacheItem, len(rules))
+	seq := startSeq
+	selected := 0
+	for i, rule := range rules {
+		if seq < 0 || seq > int(^uint16(0)) {
+			return HandshakeCacheItemPullResult{
+				NextSequence: startSeq,
+				Ready:        true,
+				Err: fmt.Errorf(
+					"%w: %w",
+					dtlserrors.ErrHandshakeSequenceOverflow,
+					&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+				),
+			}
+		}
+
+		conflicts := make([]*HandshakeCacheItem, 0, 1)
+		for _, item := range h.cache {
+			if item.IsClient != rule.IsClient || item.Epoch != rule.Epoch ||
+				item.MessageSequence != uint16(seq) { //nolint:gosec // seq is bounded above.
+				continue
+			}
+			if item.Typ == rule.Typ {
+				items[i] = item
+			} else {
+				conflicts = append(conflicts, item)
+			}
+		}
+
+		if items[i] == nil {
+			if rule.Optional {
+				for _, conflict := range conflicts {
+					if !matchesAnyHandshakePullRule(conflict, rules[i+1:]) {
+						return unexpectedHandshakePull(startSeq)
+					}
+				}
+
+				continue
+			}
+			if len(conflicts) != 0 {
+				return unexpectedHandshakePull(startSeq)
+			}
+
+			return HandshakeCacheItemPullResult{NextSequence: startSeq}
+		}
+		if len(conflicts) != 0 {
+			return unexpectedHandshakePull(startSeq)
+		}
+
+		selected++
+		seq++
+	}
+	if selected == 0 {
+		return HandshakeCacheItemPullResult{NextSequence: startSeq}
+	}
+
+	return HandshakeCacheItemPullResult{
+		NextSequence: seq,
+		Items:        items,
+		Ready:        true,
+	}
+}
+
+func matchesAnyHandshakePullRule(item *HandshakeCacheItem, rules []HandshakeCachePullRule) bool {
+	for _, rule := range rules {
+		if item.Typ == rule.Typ && item.IsClient == rule.IsClient && item.Epoch == rule.Epoch {
+			return true
 		}
 	}
 
-	return last
+	return false
 }
 
-func cacheItemMatchesRule(item *HandshakeCacheItem, rule HandshakeCachePullRule) bool {
-	return item.Typ == rule.Typ && item.IsClient == rule.IsClient && item.Epoch == rule.Epoch
+func unexpectedHandshakePull(startSeq int) HandshakeCacheItemPullResult {
+	return HandshakeCacheItemPullResult{
+		NextSequence: startSeq,
+		Ready:        true,
+		Err: fmt.Errorf(
+			"%w: %w",
+			dtlserrors.ErrUnexpectedHandshakeMessage,
+			&alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage},
+		),
+	}
 }
 
 func fullPullMapCacheItems(
@@ -136,7 +286,7 @@ func fullPullMapCacheItems(
 	cipherSuite dtlsconfig.CipherSuite,
 	rules []HandshakeCachePullRule,
 	ci []*HandshakeCacheItem,
-) (int, map[handshake.Type]handshake.Message, []*HandshakeCacheItem, bool) {
+) HandshakeCachePullResult {
 	out := make(map[handshake.Type]handshake.Message)
 	items := make([]*HandshakeCacheItem, 0, len(rules))
 	seq := startSeq
@@ -147,23 +297,41 @@ func fullPullMapCacheItems(
 		if item == nil {
 			continue
 		}
-		rawHandshake, ok := unmarshalCachedHandshake(item, keyExchangeAlgorithm)
-		if !ok {
-			return startSeq, nil, nil, false
+		parsed := &handshake.Handshake{KeyExchangeAlgorithm: keyExchangeAlgorithm}
+		err := parsed.Unmarshal(item.Data)
+		if err == nil {
+			err = validateCachedHandshake(
+				item,
+				parsed,
+				r.Typ,
+				uint16(seq), //nolint:gosec // selection bounded seq above.
+			)
 		}
-		if uint16(seq) != rawHandshake.Header.MessageSequence { //nolint:gosec // G115
-			// There is a gap. Some messages are not arrived.
-			return startSeq, nil, nil, false
+		if err != nil {
+			return HandshakeCachePullResult{
+				NextSequence: startSeq,
+				Ready:        true,
+				Err: fmt.Errorf(
+					"%w: %w",
+					err,
+					&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+				),
+			}
 		}
 		seq++
-		out[typ] = rawHandshake.Message
+		out[typ] = parsed.Message
 		items = append(items, item)
 	}
 	if len(items) == 0 {
-		return seq, nil, nil, false
+		return HandshakeCachePullResult{NextSequence: seq}
 	}
 
-	return seq, out, items, true
+	return HandshakeCachePullResult{
+		NextSequence: seq,
+		Messages:     out,
+		Items:        items,
+		Ready:        true,
+	}
 }
 
 func keyExchangeAlgorithmForCipherSuite(cipherSuite dtlsconfig.CipherSuite) ciphersuite.KeyExchangeAlgorithm {
@@ -174,18 +342,33 @@ func keyExchangeAlgorithmForCipherSuite(cipherSuite dtlsconfig.CipherSuite) ciph
 	return cipherSuite.KeyExchangeAlgorithm()
 }
 
-func unmarshalCachedHandshake(
+func validateCachedHandshake( //nolint:cyclop // Each condition validates a distinct wire/cache invariant.
 	item *HandshakeCacheItem,
-	keyExchangeAlgorithm ciphersuite.KeyExchangeAlgorithm,
-) (*handshake.Handshake, bool) {
-	rawHandshake := &handshake.Handshake{
-		KeyExchangeAlgorithm: keyExchangeAlgorithm,
-	}
-	if err := rawHandshake.Unmarshal(item.Data); err != nil {
-		return nil, false
+	parsed *handshake.Handshake,
+	expectedType handshake.Type,
+	expectedSequence uint16,
+) error {
+	if item == nil || parsed == nil || parsed.Message == nil {
+		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
 	}
 
-	return rawHandshake, true
+	var rawHeader handshake.Header
+	if err := rawHeader.Unmarshal(item.Data); err != nil {
+		return err
+	}
+	if rawHeader != parsed.Header ||
+		rawHeader.Type != expectedType ||
+		rawHeader.Type != item.Typ ||
+		rawHeader.MessageSequence != expectedSequence ||
+		rawHeader.MessageSequence != item.MessageSequence ||
+		rawHeader.FragmentOffset != 0 ||
+		rawHeader.FragmentLength != rawHeader.Length ||
+		len(item.Data) != handshake.HeaderLength+int(rawHeader.Length) ||
+		parsed.Message.Type() != rawHeader.Type {
+		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+
+	return nil
 }
 
 // PullAndMerge calls pull and then merges the results, ignoring any null entries.

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -24,7 +24,7 @@ import (
 // https://datatracker.ietf.org/doc/html/rfc5746#section-3.3.
 const renegotiationInfoSCSV uint16 = 0x00ff
 
-//nolint:cyclop,gocognit
+//nolint:cyclop,gocognit,gocyclo
 func flight0Parse(
 	_ context.Context,
 	_ dtlsflight.Conn,
@@ -32,10 +32,13 @@ func flight0Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	seq, msgs, ok := cache.FullPullMap(0, state.CipherSuite,
+	pull := cache.FullPullMapItems(0, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: cfg.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
@@ -47,12 +50,11 @@ func flight0Parse(
 	state.RemoteConnectionID = nil
 	state.RemoteCIDOffered = false
 
-	state.HandshakeRecvSequence = seq
-
-	var clientHello *handshake.MessageClientHello
+	state.HandshakeRecvSequence = pull.NextSequence
 
 	// Validate type
-	if clientHello, ok = msgs[handshake.TypeClientHello].(*handshake.MessageClientHello); !ok {
+	clientHello, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -29,22 +29,25 @@ func flight1Parse(
 ) (Flight, *alert.Alert, error) {
 	// HelloVerifyRequest can be skipped by the server,
 	// so allow ServerHello during flight1 also
-	seq, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeHelloVerifyRequest, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true},        //nolint:lll
+	pull := cache.FullPullMapOneOfItems(state.HandshakeRecvSequence, state.CipherSuite,
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeHelloVerifyRequest, Epoch: cfg.InitialEpoch, IsClient: false}, //nolint:lll
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false},        //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	if _, ok := msgs[handshake.TypeServerHello]; ok {
+	if _, ok := pull.Messages[handshake.TypeServerHello]; ok {
 		// Flight1 and flight2 were skipped.
 		// Parse as flight3.
 		return flight3Parse(ctx, conn, state, cache, cfg)
 	}
 
-	if h, ok := msgs[handshake.TypeHelloVerifyRequest].(*handshake.MessageHelloVerifyRequest); ok {
+	if h, ok := pull.Messages[handshake.TypeHelloVerifyRequest].(*handshake.MessageHelloVerifyRequest); ok {
 		// DTLS 1.2 clients must not assume that the server will use the protocol version
 		// specified in HelloVerifyRequest message. RFC 6347 Section 4.2.1
 		if !h.Version.Equal(protocol.Version1_0) && !h.Version.Equal(protocol.Version1_2) {
@@ -52,7 +55,7 @@ func flight1Parse(
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
 		state.Cookie = bytes.Clone(h.Cookie)
-		state.HandshakeRecvSequence = seq
+		state.HandshakeRecvSequence = pull.NextSequence
 
 		return Flight3, nil, nil
 	}

--- a/internal/flight/flight12/flight1handler_test.go
+++ b/internal/flight/flight12/flight1handler_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/logging"
@@ -38,10 +40,9 @@ func (f *flight1TestMockCipherSuite) IsInitialized() bool {
 	return true
 }
 
-// When "server hello" arrives later than "certificate",
-// "server key exchange", "certificate request", "server hello done",
-// is it normal for the flight1Parse method to handle it.
-func TestFlight1_Process_ServerHelloLateArrival(t *testing.T) { //nolint:maintidx
+// A later ServerHello exposes an invalid cached message occupying the next
+// sequence number; parsing must fail instead of treating it as packet loss.
+func TestFlight1_Process_RejectsInvalidLateServerFlight(t *testing.T) { //nolint:maintidx
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(5 * time.Second)
 	defer lim.Stop()
@@ -276,6 +277,6 @@ func TestFlight1_Process_ServerHelloLateArrival(t *testing.T) { //nolint:maintid
 	cache.Push(serverHello, 0, 0, handshake.TypeServerHello, false)
 	cache.Push(certificate1, 0, 1, handshake.TypeCertificate, false)
 	_, alt, err = parseForTest(t, Flight1, t.Context(), mockConn, state, cache, cfg)
-	assert.NoError(t, err)
-	assert.Nil(t, alt)
+	assert.ErrorIs(t, err, dtlserrors.ErrUnexpectedHandshakeMessage)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, alt)
 }

--- a/internal/flight/flight12/flight2handler.go
+++ b/internal/flight/flight12/flight2handler.go
@@ -24,20 +24,22 @@ func flight2Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	seq, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: cfg.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// Client may retransmit the first ClientHello when HelloVerifyRequest is dropped.
 		// Parse as flight 0 in this case.
 		return flight0Parse(ctx, conn, state, cache, cfg)
 	}
-	state.HandshakeRecvSequence = seq
-
-	var clientHello *handshake.MessageClientHello
+	state.HandshakeRecvSequence = pull.NextSequence
 
 	// Validate type
-	if clientHello, ok = msgs[handshake.TypeClientHello].(*handshake.MessageClientHello); !ok {
+	clientHello, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -33,32 +33,34 @@ func flight3Parse(
 	// Clients may receive multiple HelloVerifyRequest messages with different cookies.
 	// Clients SHOULD handle this by sending a new ClientHello with a cookie in response
 	// to the new HelloVerifyRequest. RFC 6347 Section 4.2.1
-	seq, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeHelloVerifyRequest, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
+	serverResponsePull := cache.FullPullMapOneOfItems(state.HandshakeRecvSequence, state.CipherSuite,
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeHelloVerifyRequest, Epoch: cfg.InitialEpoch, IsClient: false}, //nolint:lll
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false},        //nolint:lll
 	)
-	if ok {
-		if h, msgOk := msgs[handshake.TypeHelloVerifyRequest].(*handshake.MessageHelloVerifyRequest); msgOk {
-			// DTLS 1.2 clients must not assume that the server will use the protocol version
-			// specified in HelloVerifyRequest message. RFC 6347 Section 4.2.1
-			if !h.Version.Equal(protocol.Version1_0) && !h.Version.Equal(protocol.Version1_2) {
-				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, dtlserrors.ErrUnsupportedProtocolVersion //nolint:lll
-			}
-			state.Cookie = bytes.Clone(h.Cookie)
-			state.HandshakeRecvSequence = seq
-
-			return Flight3, nil, nil
-		}
+	if serverResponsePull.Err != nil {
+		return 0, nil, serverResponsePull.Err
 	}
-
-	_, msgs, ok = cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}, //nolint:lll
-	)
-	if !ok {
+	if !serverResponsePull.Ready {
 		// Don't have enough messages. Keep reading
 		return 0, nil, nil
 	}
+	serverResponse := serverResponsePull.Messages[handshake.TypeHelloVerifyRequest]
+	h, hasHelloVerifyRequest := serverResponse.(*handshake.MessageHelloVerifyRequest)
+	if hasHelloVerifyRequest {
+		// DTLS 1.2 clients must not assume that the server will use the protocol version
+		// specified in HelloVerifyRequest message. RFC 6347 Section 4.2.1
+		if !h.Version.Equal(protocol.Version1_0) && !h.Version.Equal(protocol.Version1_2) {
+			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, dtlserrors.ErrUnsupportedProtocolVersion //nolint:lll
+		}
+		state.Cookie = bytes.Clone(h.Cookie)
+		state.HandshakeRecvSequence = serverResponsePull.NextSequence
 
-	if serverHelloMsg, msgOk := msgs[handshake.TypeServerHello].(*handshake.MessageServerHello); msgOk { //nolint:nestif
+		return Flight3, nil, nil
+	}
+
+	serverResponse = serverResponsePull.Messages[handshake.TypeServerHello]
+	serverHelloMsg, hasServerHello := serverResponse.(*handshake.MessageServerHello)
+	if hasServerHello { //nolint:nestif
 		if !serverHelloMsg.Version.Equal(protocol.Version1_2) {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 				dtlserrors.ErrUnsupportedProtocolVersion
@@ -142,39 +144,43 @@ func flight3Parse(
 		state.MasterSecret = []byte{}
 	}
 
+	var serverFlightPull dtlsflight.HandshakeCachePullResult
 	if cfg.LocalPSKCallback != nil {
-		seq, msgs, ok = cache.FullPullMap(state.HandshakeRecvSequence+1, state.CipherSuite,
+		serverFlightPull = cache.FullPullMapItems(state.HandshakeRecvSequence+1, state.CipherSuite,
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerKeyExchange, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHelloDone, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false},  //nolint:lll
 		)
 	} else {
-		seq, msgs, ok = cache.FullPullMap(state.HandshakeRecvSequence+1, state.CipherSuite,
+		serverFlightPull = cache.FullPullMapItems(state.HandshakeRecvSequence+1, state.CipherSuite,
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificate, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true},        //nolint:lll
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerKeyExchange, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}, //nolint:lll
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificateRequest, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHelloDone, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false},   //nolint:lll
 		)
 	}
-	if !ok {
+	if serverFlightPull.Err != nil {
+		return 0, nil, serverFlightPull.Err
+	}
+	if !serverFlightPull.Ready {
 		// Don't have enough messages. Keep reading
 		return 0, nil, nil
 	}
-	state.HandshakeRecvSequence = seq
+	state.HandshakeRecvSequence = serverFlightPull.NextSequence
 
-	if h, ok := msgs[handshake.TypeCertificate].(*handshake.MessageCertificate); ok {
+	if h, ok := serverFlightPull.Messages[handshake.TypeCertificate].(*handshake.MessageCertificate); ok {
 		state.PeerCertificates = h.Certificate
 	} else if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypeCertificate {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.NoCertificate}, dtlserrors.ErrInvalidCertificate
 	}
 
-	if h, ok := msgs[handshake.TypeServerKeyExchange].(*handshake.MessageServerKeyExchange); ok {
+	if h, ok := serverFlightPull.Messages[handshake.TypeServerKeyExchange].(*handshake.MessageServerKeyExchange); ok {
 		alertPtr, err := handleServerKeyExchange(conn, state, cfg, h)
 		if err != nil {
 			return 0, alertPtr, err
 		}
 	}
 
-	if creq, ok := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
+	if creq, ok := serverFlightPull.Messages[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
 		state.RemoteCertRequestAlgs = creq.SignatureHashAlgorithms
 		state.RemoteRequestedCertificate = true
 	}
@@ -198,16 +204,19 @@ func handleResumption(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
 
-	_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence+1, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence+1, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: false, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	var finished *handshake.MessageFinished
-	if finished, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	finished, ok := pull.Messages[handshake.TypeFinished].(*handshake.MessageFinished)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 	plainText := cache.PullAndMerge(

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -27,16 +27,19 @@ func flight4bParse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	var finished *handshake.MessageFinished
-	if finished, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	finished, ok := pull.Messages[handshake.TypeFinished].(*handshake.MessageFinished)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -35,23 +35,26 @@ func flight4Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	seq, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificate, Epoch: cfg.InitialEpoch, IsClient: true, Optional: true},        //nolint:lll
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientKeyExchange, Epoch: cfg.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificateVerify, Epoch: cfg.InitialEpoch, IsClient: true, Optional: true},  //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
 	// Validate type
-	var clientKeyExchange *handshake.MessageClientKeyExchange
-	if clientKeyExchange, ok = msgs[handshake.TypeClientKeyExchange].(*handshake.MessageClientKeyExchange); !ok {
+	clientKeyExchange, ok := pull.Messages[handshake.TypeClientKeyExchange].(*handshake.MessageClientKeyExchange)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 
-	if h, hasCert := msgs[handshake.TypeCertificate].(*handshake.MessageCertificate); hasCert {
+	if h, hasCert := pull.Messages[handshake.TypeCertificate].(*handshake.MessageCertificate); hasCert {
 		state.PeerCertificates = h.Certificate
 		// If the client offer its certificate, just disable session resumption.
 		// Otherwise, we have to store the certificate identitfication and expire time.
@@ -62,7 +65,7 @@ func flight4Parse(
 	}
 
 	//nolint:nestif
-	if verify, hasVerify := msgs[handshake.TypeCertificateVerify].(*handshake.MessageCertificateVerify); hasVerify {
+	if verify, hasVerify := pull.Messages[handshake.TypeCertificateVerify].(*handshake.MessageCertificateVerify); hasVerify {
 		if state.PeerCertificates == nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.NoCertificate}, dtlserrors.ErrCertificateVerifyNoCertificate
 		}
@@ -196,16 +199,19 @@ func flight4Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
 
-	seq, msgs, ok = cache.FullPullMap(seq, state.CipherSuite,
+	finishedPull := cache.FullPullMapItems(pull.NextSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if finishedPull.Err != nil {
+		return 0, nil, finishedPull.Err
+	}
+	if !finishedPull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
-	state.HandshakeRecvSequence = seq
+	state.HandshakeRecvSequence = finishedPull.NextSequence
 
-	if _, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	if _, ok = finishedPull.Messages[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flight5bhandler.go
+++ b/internal/flight/flight12/flight5bhandler.go
@@ -23,15 +23,18 @@ func flight5bParse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence-1, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence-1, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: false, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	if _, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	if _, ok := pull.Messages[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flight5handler.go
+++ b/internal/flight/flight12/flight5handler.go
@@ -30,16 +30,19 @@ func flight5Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: false, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	var finished *handshake.MessageFinished
-	if finished, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	finished, ok := pull.Messages[handshake.TypeFinished].(*handshake.MessageFinished)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 	plainText := cache.PullAndMerge(handshakeRulesThroughClientFinished(cfg.InitialEpoch)...)
@@ -72,13 +75,16 @@ func flight5Generate(
 	var signer crypto.Signer
 	var pkts []*dtlsflight.Packet
 	if state.RemoteRequestedCertificate { //nolint:nestif
-		_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence-2, state.CipherSuite,
+		pull := cache.FullPullMapItems(state.HandshakeRecvSequence-2, state.CipherSuite,
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificateRequest, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}) //nolint:lll
-		if !ok {
+		if pull.Err != nil {
+			return nil, nil, pull.Err
+		}
+		if !pull.Ready {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, dtlserrors.ErrClientCertificateRequired //nolint:lll
 		}
 		reqInfo := dtlsconfig.CertificateRequestInfo{}
-		if r, ok2 := msgs[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok2 {
+		if r, ok2 := pull.Messages[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok2 {
 			reqInfo.AcceptableCAs = r.CertificateAuthoritiesNames
 		} else {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, dtlserrors.ErrClientCertificateRequired //nolint:lll
@@ -91,6 +97,7 @@ func flight5Generate(
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, dtlserrors.ErrNotAcceptableCertificateChain //nolint:lll
 		}
 		if certificate.Certificate != nil {
+			var ok bool
 			signer, ok = certificate.PrivateKey.(crypto.Signer)
 			if !ok {
 				return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, dtlserrors.ErrInvalidPrivateKey

--- a/internal/flight/flight12/flight6handler.go
+++ b/internal/flight/flight12/flight6handler.go
@@ -23,15 +23,18 @@ func flight6Parse(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) (Flight, *alert.Alert, error) {
-	_, msgs, ok := cache.FullPullMap(state.HandshakeRecvSequence-1, state.CipherSuite,
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence-1, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeFinished, Epoch: cfg.InitialEpoch + 1, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	if _, ok = msgs[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
+	if _, ok := pull.Messages[handshake.TypeFinished].(*handshake.MessageFinished); !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 

--- a/internal/flight/flight12/flighthandler.go
+++ b/internal/flight/flight12/flighthandler.go
@@ -6,6 +6,7 @@ package flight12
 
 import (
 	"context"
+	"errors"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
@@ -101,6 +102,9 @@ func Parse(
 	}
 
 	nextFlight, dtlsAlert, err := parse(ctx, conn, state, cache, cfg)
+	if dtlsAlert == nil && err != nil {
+		errors.As(err, &dtlsAlert)
+	}
 
 	return nextFlight, dtlsAlert, err, true
 }

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -31,10 +31,13 @@ func flight0Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
 			dtlserrors.ErrInvalidProtocolVersionState
 	}
-	seq, msgs, items, ok := cache.FullPullMapItems(0, state.CipherSuite,
+	pull := cache.FullPullMapItems(0, state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: cfg.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
@@ -43,12 +46,11 @@ func flight0Parse(
 	// https://datatracker.ietf.org/doc/html/rfc9146#name-the-connection_id-extension
 	state.ResetConnectionIDs()
 
-	state.HandshakeRecvSequence = seq
-
-	var clientHello *handshake.MessageClientHello
+	state.HandshakeRecvSequence = pull.NextSequence
 
 	// Validate type
-	if clientHello, ok = msgs[handshake.TypeClientHello].(*handshake.MessageClientHello); !ok {
+	clientHello, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
+	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
 
@@ -100,7 +102,7 @@ func flight0Parse(
 	}
 
 	if flightCtx.inboundHandshakeHandler != nil {
-		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, items); err != nil {
+		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, pull.Items); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
 	}

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -187,15 +187,18 @@ func flight1Parse(
 		return flight3Parse(ctx, conn, flightCtx)
 	}
 
-	seq, msgs, items, ok := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false, Optional: true}, //nolint:lll
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		// No valid message received. Keep reading
 		return 0, nil, nil
 	}
 
-	sh, ok := msgs[handshake.TypeServerHello].(*handshake.MessageServerHello)
+	sh, ok := pull.Messages[handshake.TypeServerHello].(*handshake.MessageServerHello)
 	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
@@ -213,8 +216,11 @@ func flight1Parse(
 	}
 	if err := validateHelloRetryRequestSelectedVersion(sh.Extensions); err != nil {
 		description := alert.IllegalParameter
-		if errors.Is(err, dtlserrors.ErrUnsupportedProtocolVersion) {
+		switch {
+		case errors.Is(err, dtlserrors.ErrUnsupportedProtocolVersion):
 			description = alert.ProtocolVersion
+		case errors.Is(err, dtlserrors.ErrMissingSupportedVersionsExtension):
+			description = alert.MissingExtension
 		}
 
 		return 0, &alert.Alert{Level: alert.Fatal, Description: description}, err
@@ -250,11 +256,11 @@ func flight1Parse(
 	}
 
 	if flightCtx.inboundHandshakeHandler != nil {
-		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, items); err != nil {
+		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, pull.Items); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
 	}
-	state.HandshakeRecvSequence = seq
+	state.HandshakeRecvSequence = pull.NextSequence
 
 	return Flight3, nil, nil
 }

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -18,20 +18,23 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
-func flight2Parse(
+func flight2Parse( //nolint:cyclop
 	_ context.Context,
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
 ) (Flight, *alert.Alert, error) {
-	seq, msgs, items, ok := flightCtx.cache.FullPullMapItems(
+	pull := flightCtx.cache.FullPullMapItems(
 		flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: flightCtx.cfg.InitialEpoch, IsClient: true, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return 0, nil, pull.Err
+	}
+	if !pull.Ready {
 		return 0, nil, nil
 	}
 
-	clientHello, ok := msgs[handshake.TypeClientHello].(*handshake.MessageClientHello)
+	clientHello, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
 	if !ok {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, nil
 	}
@@ -59,10 +62,10 @@ func flight2Parse(
 	if failure := generateClientKeyShareSecret(flightCtx.state, flightCtx.cfg); failure != nil {
 		return 0, failure.alert, failure.err
 	}
-	if failure := flightCtx.handleInboundHandshake(items); failure != nil {
+	if failure := flightCtx.handleInboundHandshake(pull.Items); failure != nil {
 		return 0, failure.alert, failure.err
 	}
-	flightCtx.state.HandshakeRecvSequence = seq
+	flightCtx.state.HandshakeRecvSequence = pull.NextSequence
 
 	return Flight4, nil, nil
 }

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -90,15 +90,21 @@ func flight3Parse(
 func flight3PullServerHello(
 	flightCtx *handshakeContext,
 ) serverHelloPull {
-	seq, msgs, items, ok := flightCtx.cache.FullPullMapItems(
+	pull := flightCtx.cache.FullPullMapItems(
 		flightCtx.state.HandshakeRecvSequence, flightCtx.state.CipherSuite,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: flightCtx.cfg.InitialEpoch, IsClient: false, Optional: false}, //nolint:lll
 	)
-	if !ok {
+	if pull.Err != nil {
+		return serverHelloPull{
+			ready:   true,
+			failure: &flightParseFailure{err: pull.Err},
+		}
+	}
+	if !pull.Ready {
 		return serverHelloPull{}
 	}
 
-	serverHello, ok := msgs[handshake.TypeServerHello].(*handshake.MessageServerHello)
+	serverHello, ok := pull.Messages[handshake.TypeServerHello].(*handshake.MessageServerHello)
 	if !ok {
 		return serverHelloPull{
 			ready:   true,
@@ -107,9 +113,9 @@ func flight3PullServerHello(
 	}
 
 	return serverHelloPull{
-		nextHandshakeSequence: seq,
+		nextHandshakeSequence: pull.NextSequence,
 		serverHello:           serverHello,
-		items:                 items,
+		items:                 pull.Items,
 		ready:                 true,
 	}
 }
@@ -134,7 +140,7 @@ func processFlight3ServerHello(
 
 	selectedCipherSuite, dtlsAlert, err := selectServerHelloCipherSuite(serverHello, flightCtx.cfg)
 	if err != nil {
-		return &flightParseFailure{alert: dtlsAlert, err: err}
+		return newFlightParseFailure(dtlsAlert.Description, err)
 	}
 	flightCtx.state.CipherSuite = selectedCipherSuite
 	flightCtx.state.RemoteRandom = serverHello.Random
@@ -257,7 +263,7 @@ func handleFlight3ProtectedHandshake(
 	return nil
 }
 
-// nolint:cyclop
+//nolint:cyclop,gocognit,nestif
 func flight3Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
@@ -282,14 +288,9 @@ func flight3Generate(
 	})
 
 	if flightCtx.state.SelectedGroup != 0 {
-		extensions = append(extensions, []extension.Value{
-			&extension.SupportedGroups{
-				Groups: flightCtx.cfg.EllipticCurves,
-			},
-			&extension12.SupportedPointFormats{
-				PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
-			},
-		}...)
+		extensions = append(extensions, &extension12.SupportedPointFormats{
+			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
+		})
 	}
 
 	if len(flightCtx.cfg.SupportedProtocols) > 0 {
@@ -324,6 +325,9 @@ func flight3Generate(
 		}
 		maps.Copy(flightCtx.state.LocalKeypairs, newKeypairs)
 	}
+	extensions = append(extensions, &extension.SupportedGroups{
+		Groups: supportedGroupsForKeyShares(flightCtx.state.LocalKeyEntries, flightCtx.cfg.EllipticCurves),
+	})
 	extensions = append(extensions, &extension13.ClientKeyShare{
 		Shares: flightCtx.state.LocalKeyEntries,
 	})
@@ -392,4 +396,23 @@ func flight3Generate(
 			},
 		},
 	}, nil, nil
+}
+
+func supportedGroupsForKeyShares(
+	shares []extension13.KeyShareEntry,
+	configured []elliptic.Curve,
+) []elliptic.Curve {
+	groups := make([]elliptic.Curve, 0, len(configured))
+	for _, share := range shares {
+		if !slices.Contains(groups, share.Group) {
+			groups = append(groups, share.Group)
+		}
+	}
+	for _, group := range configured {
+		if !slices.Contains(groups, group) {
+			groups = append(groups, group)
+		}
+	}
+
+	return groups
 }

--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto"
 	"errors"
+	"fmt"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -115,8 +116,13 @@ func newFlightParseFailure(
 	description alert.Description,
 	err error,
 ) *flightParseFailure {
+	dtlsAlert := &alert.Alert{Level: alert.Fatal, Description: description}
+	if err != nil {
+		err = fmt.Errorf("%w: %w", dtlsAlert, err)
+	}
+
 	return &flightParseFailure{
-		alert: &alert.Alert{Level: alert.Fatal, Description: description},
+		alert: dtlsAlert,
 		err:   err,
 	}
 }
@@ -138,35 +144,37 @@ func pullProtectedHandshakeFlight(
 	rules []dtlsflight.HandshakeCachePullRule,
 	nextHandshakeSequence int,
 ) protectedFlightPull {
-	pulled := cache.Pull(rules...)
-	for i, rule := range rules {
-		if !rule.Optional && pulled[i] == nil {
-			return protectedFlightPull{}
+	selection := cache.PullSequential(nextHandshakeSequence, rules...)
+	if selection.Err != nil {
+		return protectedFlightPull{
+			ready:   true,
+			failure: &flightParseFailure{err: selection.Err},
 		}
 	}
+	if !selection.Ready {
+		return protectedFlightPull{}
+	}
 
-	items := make([]*dtlsflight.HandshakeCacheItem, 0, len(pulled))
-	for i, item := range pulled {
+	items := make([]*dtlsflight.HandshakeCacheItem, 0, len(selection.Items))
+	sequence := nextHandshakeSequence
+	for i, item := range selection.Items {
 		if item == nil {
 			continue
 		}
-		if failure := validateProtectedHandshakeItem(
+		failure := validateProtectedHandshakeItem(
 			item,
 			rules[i].Typ,
-			uint16(nextHandshakeSequence), //nolint:gosec // G115
-		); failure != nil {
-			if failure.err == nil {
-				return protectedFlightPull{}
-			}
-
+			uint16(sequence), //nolint:gosec // PullSequential bounded sequence.
+		)
+		if failure != nil {
 			return protectedFlightPull{ready: true, failure: failure}
 		}
-		nextHandshakeSequence++
+		sequence++
 		items = append(items, item)
 	}
 
 	return protectedFlightPull{
-		nextHandshakeSequence: nextHandshakeSequence,
+		nextHandshakeSequence: selection.NextSequence,
 		items:                 items,
 		ready:                 true,
 	}
@@ -177,10 +185,7 @@ func validateProtectedHandshakeItem(
 	expectedType handshake.Type,
 	expectedSequence uint16,
 ) *flightParseFailure {
-	if item.MessageSequence != expectedSequence {
-		return &flightParseFailure{}
-	}
-	if item.Typ != expectedType {
+	if item.MessageSequence != expectedSequence || item.Typ != expectedType {
 		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
 	}
 
@@ -188,17 +193,19 @@ func validateProtectedHandshakeItem(
 	if err := header.Unmarshal(item.Data); err != nil {
 		return newFlightParseFailure(alert.DecodeError, err)
 	}
-	if header.Type != expectedType || header.MessageSequence != expectedSequence {
-		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
-	}
-	if header.FragmentOffset != 0 ||
+	if header.Type != expectedType || header.MessageSequence != expectedSequence ||
+		header.FragmentOffset != 0 ||
 		header.FragmentLength != header.Length ||
 		len(item.Data) != handshake.HeaderLength+int(header.Length) {
 		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
 	}
 
 	if err := unmarshalProtectedHandshakeMessage(expectedType, item.Data[handshake.HeaderLength:]); err != nil {
-		return newFlightParseFailure(alert.DecodeError, err)
+		return &flightParseFailure{err: fmt.Errorf(
+			"%w: %w",
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)}
 	}
 
 	return nil
@@ -288,6 +295,9 @@ func Parse(
 	}
 
 	nextFlight, dtlsAlert, err := parse(ctx, conn, newHandshakeContext(dependencies))
+	if dtlsAlert == nil && err != nil {
+		errors.As(err, &dtlsAlert)
+	}
 
 	return nextFlight, dtlsAlert, err, true
 }
@@ -349,8 +359,11 @@ func ServerHelloSelectedVersions(extensions []extension.Value) ([]protocol.Versi
 
 func validateHelloRetryRequestSelectedVersion(extensions []extension.Value) error {
 	versions, seenSupportedVersions, err := ServerHelloSelectedVersions(extensions)
-	if err != nil || !seenSupportedVersions {
+	if err != nil {
 		return dtlserrors.ErrInvalidHelloRetryRequest
+	}
+	if !seenSupportedVersions {
+		return dtlserrors.ErrMissingSupportedVersionsExtension
 	}
 	if !versions[0].Equal(protocol.Version1_3) {
 		return dtlserrors.ErrUnsupportedProtocolVersion

--- a/internal/flight/flight13/flighthandler_test.go
+++ b/internal/flight/flight13/flighthandler_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +29,87 @@ func TestProtectedFlightParseFailureClientCertificateRequired(t *testing.T) {
 	assert.Equal(t, alert.Fatal, failure.alert.Level)
 	assert.Equal(t, alert.CertificateRequired, failure.alert.Description)
 	assert.ErrorIs(t, failure.err, dtlserrors.ErrClientCertificateRequired)
+	var classified *alert.Alert
+	require.ErrorAs(t, failure.err, &classified)
+	assert.Equal(t, failure.alert, classified)
+}
+
+func TestPullProtectedHandshakeFlightDistinguishesIncompleteAndInvalid(t *testing.T) {
+	rule := []dtlsflight.HandshakeCachePullRule{
+		{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false},
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		pull := pullProtectedHandshakeFlight(dtlsflight.NewCache(), rule, 0)
+		assert.False(t, pull.ready)
+		assert.Nil(t, pull.failure)
+	})
+
+	t.Run("sequence gap", func(t *testing.T) {
+		cache := dtlsflight.NewCache()
+		raw := marshalProtectedTestHandshake(t, 1, &handshake.MessageEncryptedExtensions{})
+		cache.Push(raw, EpochHandshake, 1, handshake.TypeEncryptedExtensions, false)
+
+		pull := pullProtectedHandshakeFlight(cache, rule, 0)
+		assert.False(t, pull.ready)
+		assert.Nil(t, pull.failure)
+	})
+
+	t.Run("sequence overflow", func(t *testing.T) {
+		pull := pullProtectedHandshakeFlight(dtlsflight.NewCache(), rule, -1)
+		require.True(t, pull.ready)
+		require.NotNil(t, pull.failure)
+		assert.ErrorIs(t, pull.failure.err, dtlserrors.ErrHandshakeSequenceOverflow)
+		var classified *alert.Alert
+		require.ErrorAs(t, pull.failure.err, &classified)
+		assert.Equal(t, alert.DecodeError, classified.Description)
+	})
+
+	t.Run("malformed payload", func(t *testing.T) {
+		header := handshake.Header{
+			Type: handshake.TypeEncryptedExtensions, Length: 1, MessageSequence: 0, FragmentLength: 1,
+		}
+		raw, err := header.Marshal()
+		require.NoError(t, err)
+		raw = append(raw, 0x00)
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, EpochHandshake, 0, handshake.TypeEncryptedExtensions, false)
+
+		pull := pullProtectedHandshakeFlight(cache, rule, 0)
+		require.True(t, pull.ready)
+		require.NotNil(t, pull.failure)
+		var classified *alert.Alert
+		require.ErrorAs(t, pull.failure.err, &classified)
+		assert.Equal(t, alert.DecodeError, classified.Description)
+	})
+
+	t.Run("known illegal placement", func(t *testing.T) {
+		cache := dtlsflight.NewCache()
+		raw := marshalProtectedTestHandshake(t, 0, &handshake.MessageEncryptedExtensions{
+			Extensions: []extension.Value{extension.Raw{Type: extension.TypeExtendedMasterSecret}},
+		})
+		cache.Push(raw, EpochHandshake, 0, handshake.TypeEncryptedExtensions, false)
+
+		pull := pullProtectedHandshakeFlight(cache, rule, 0)
+		require.True(t, pull.ready)
+		require.NotNil(t, pull.failure)
+		assert.ErrorIs(t, pull.failure.err, dtlserrors.ErrExtensionNotAllowed)
+		var classified *alert.Alert
+		require.ErrorAs(t, pull.failure.err, &classified)
+		assert.Equal(t, alert.IllegalParameter, classified.Description)
+	})
+}
+
+func marshalProtectedTestHandshake(t *testing.T, sequence uint16, message handshake.Message) []byte {
+	t.Helper()
+
+	raw, err := (&handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: sequence},
+		Message: message,
+	}).Marshal()
+	require.NoError(t, err)
+
+	return raw
 }
 
 func TestFlight4GenerateCertificateAuthenticatedFlight(t *testing.T) {

--- a/internal/flight/handshake_cache_test.go
+++ b/internal/flight/handshake_cache_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,18 +162,270 @@ func TestHandshakeCacheFullPullMapItemsReturnsAcceptedRawItems(t *testing.T) {
 	cache.Push(rawServerHello, 0, 1, handshake.TypeServerHello, false)
 	cache.Push(rawClientHello, 0, 0, handshake.TypeClientHello, true)
 
-	seq, msgs, items, ok := cache.FullPullMapItems(0, nil,
+	pull := cache.FullPullMapItems(0, nil,
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false},  //nolint:lll
 		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: 0, IsClient: false, Optional: false}, //nolint:lll
 	)
 
-	require.True(t, ok)
-	assert.Equal(t, 2, seq)
-	require.IsType(t, &handshake.MessageClientHello{}, msgs[handshake.TypeClientHello])
-	require.IsType(t, &handshake.MessageServerHello{}, msgs[handshake.TypeServerHello])
-	require.Len(t, items, 2)
-	assert.Equal(t, rawClientHello, items[0].Data)
-	assert.Equal(t, rawServerHello, items[1].Data)
+	require.NoError(t, pull.Err)
+	require.True(t, pull.Ready)
+	assert.Equal(t, 2, pull.NextSequence)
+	require.IsType(t, &handshake.MessageClientHello{}, pull.Messages[handshake.TypeClientHello])
+	require.IsType(t, &handshake.MessageServerHello{}, pull.Messages[handshake.TypeServerHello])
+	require.Len(t, pull.Items, 2)
+	assert.Equal(t, rawClientHello, pull.Items[0].Data)
+	assert.Equal(t, rawServerHello, pull.Items[1].Data)
+}
+
+func TestHandshakeCachePullResultDistinguishesIncompleteAndMalformed(t *testing.T) {
+	rule := dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false,
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		pull := dtlsflight.NewCache().FullPullMapItems(7, nil, rule)
+		assert.False(t, pull.Ready)
+		assert.NoError(t, pull.Err)
+		assert.Equal(t, 7, pull.NextSequence)
+	})
+
+	t.Run("sequence gap", func(t *testing.T) {
+		raw := marshalHandshakeCacheTestMessage(t, 1, &handshake.MessageClientHello{
+			Version:            protocol.Version1_2,
+			CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+		})
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, 0, 1, handshake.TypeClientHello, true)
+
+		pull := cache.FullPullMapItems(0, nil, rule)
+		assert.False(t, pull.Ready)
+		assert.NoError(t, pull.Err)
+		assert.Equal(t, 0, pull.NextSequence)
+	})
+
+	t.Run("malformed complete message", func(t *testing.T) {
+		cache := dtlsflight.NewCache()
+		cache.Push([]byte{byte(handshake.TypeClientHello)}, 0, 0, handshake.TypeClientHello, true)
+
+		pull := cache.FullPullMapItems(0, nil, rule)
+		assert.True(t, pull.Ready)
+		assert.ErrorIs(t, pull.Err, dtlserrors.ErrBufferTooSmall)
+		var got *alert.Alert
+		require.ErrorAs(t, pull.Err, &got)
+		assert.Equal(t, alert.DecodeError, got.Description)
+	})
+}
+
+func TestHandshakeCachePullValidatesMetadataAndHeader(t *testing.T) {
+	valid := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+	})
+	rule := dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false,
+	}
+
+	tests := map[string]struct {
+		data []byte
+		typ  handshake.Type
+		seq  uint16
+	}{
+		"header sequence": {
+			data: marshalHandshakeCacheTestMessage(t, 1, &handshake.MessageClientHello{
+				Version:            protocol.Version1_2,
+				CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+			}),
+			typ: handshake.TypeClientHello,
+		},
+		"header type": {
+			data: marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageServerHello{
+				Version:           protocol.Version1_2,
+				CipherSuiteID:     new(uint16),
+				CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+			}),
+			typ: handshake.TypeClientHello,
+		},
+		"fragment offset": {
+			data: func() []byte {
+				data := append([]byte(nil), valid...)
+				data[8] = 1
+
+				return data
+			}(),
+			typ: handshake.TypeClientHello,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := dtlsflight.NewCache()
+			cache.Push(test.data, 0, test.seq, test.typ, true)
+
+			pull := cache.FullPullMapItems(0, nil, rule)
+			require.True(t, pull.Ready)
+			assert.ErrorIs(t, pull.Err, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+			var got *alert.Alert
+			require.ErrorAs(t, pull.Err, &got)
+			assert.Equal(t, alert.DecodeError, got.Description)
+		})
+	}
+}
+
+func TestHandshakeCachePullPreservesExtensionAlert(t *testing.T) {
+	raw := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+		Extensions: []extension.Value{
+			extension.Raw{Type: 0xfefe},
+			extension.Raw{Type: 0xfefe},
+		},
+	})
+	cache := dtlsflight.NewCache()
+	cache.Push(raw, 0, 0, handshake.TypeClientHello, true)
+
+	pull := cache.FullPullMapItems(0, nil, dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false,
+	})
+	require.True(t, pull.Ready)
+	assert.ErrorIs(t, pull.Err, dtlserrors.ErrDuplicateExtension)
+	var got *alert.Alert
+	require.ErrorAs(t, pull.Err, &got)
+	assert.Equal(t, alert.IllegalParameter, got.Description)
+}
+
+func TestHandshakeCachePullRejectsUnexpectedMessageAtRequiredSequence(t *testing.T) {
+	cache := dtlsflight.NewCache()
+	cache.Push([]byte{byte(handshake.TypeServerHello)}, 0, 0, handshake.TypeServerHello, true)
+
+	pull := cache.FullPullMapItems(0, nil, dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false,
+	})
+	require.True(t, pull.Ready)
+	assert.ErrorIs(t, pull.Err, dtlserrors.ErrUnexpectedHandshakeMessage)
+	var got *alert.Alert
+	require.ErrorAs(t, pull.Err, &got)
+	assert.Equal(t, alert.UnexpectedMessage, got.Description)
+}
+
+func TestHandshakeCachePullOptionalRules(t *testing.T) {
+	helloVerifyRule := dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeHelloVerifyRequest, Epoch: 0, IsClient: false, Optional: true,
+	}
+	serverHelloRule := dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeServerHello, Epoch: 0, IsClient: false, Optional: true,
+	}
+
+	t.Run("skip to later rule", func(t *testing.T) {
+		cipherSuiteID := uint16(ciphersuite.TLS_AES_128_GCM_SHA256)
+		raw := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageServerHello{
+			Version:           protocol.Version1_2,
+			CipherSuiteID:     &cipherSuiteID,
+			CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		})
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, 0, 0, handshake.TypeServerHello, false)
+
+		pull := cache.FullPullMapItems(0, nil, helloVerifyRule, serverHelloRule)
+		require.NoError(t, pull.Err)
+		require.True(t, pull.Ready)
+		require.IsType(t, &handshake.MessageServerHello{}, pull.Messages[handshake.TypeServerHello])
+	})
+
+	t.Run("unexpected message", func(t *testing.T) {
+		raw := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageCertificate{})
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, 0, 0, handshake.TypeCertificate, false)
+
+		pull := cache.FullPullMapItems(0, nil, helloVerifyRule, serverHelloRule)
+		require.True(t, pull.Ready)
+		assert.ErrorIs(t, pull.Err, dtlserrors.ErrUnexpectedHandshakeMessage)
+		var got *alert.Alert
+		require.ErrorAs(t, pull.Err, &got)
+		assert.Equal(t, alert.UnexpectedMessage, got.Description)
+	})
+}
+
+func TestHandshakeCacheFullPullMapOneOfItems(t *testing.T) {
+	rules := []dtlsflight.HandshakeCachePullRule{
+		{Typ: handshake.TypeServerHello, Epoch: 0, IsClient: false},
+		{Typ: handshake.TypeHelloVerifyRequest, Epoch: 0, IsClient: false},
+	}
+
+	t.Run("allowed message", func(t *testing.T) {
+		raw := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageHelloVerifyRequest{
+			Version: protocol.Version1_2,
+			Cookie:  []byte{0x01},
+		})
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, 0, 0, handshake.TypeHelloVerifyRequest, false)
+
+		pull := cache.FullPullMapOneOfItems(0, nil, rules...)
+		require.NoError(t, pull.Err)
+		require.True(t, pull.Ready)
+		assert.Equal(t, 1, pull.NextSequence)
+		require.IsType(t, &handshake.MessageHelloVerifyRequest{}, pull.Messages[handshake.TypeHelloVerifyRequest])
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		pull := dtlsflight.NewCache().FullPullMapOneOfItems(0, nil, rules...)
+		assert.False(t, pull.Ready)
+		assert.NoError(t, pull.Err)
+	})
+
+	t.Run("unexpected message", func(t *testing.T) {
+		raw := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageCertificate{})
+		cache := dtlsflight.NewCache()
+		cache.Push(raw, 0, 0, handshake.TypeCertificate, false)
+
+		pull := cache.FullPullMapOneOfItems(0, nil, rules...)
+		require.True(t, pull.Ready)
+		assert.ErrorIs(t, pull.Err, dtlserrors.ErrUnexpectedHandshakeMessage)
+		var got *alert.Alert
+		require.ErrorAs(t, pull.Err, &got)
+		assert.Equal(t, alert.UnexpectedMessage, got.Description)
+	})
+
+	t.Run("conflicting allowed messages", func(t *testing.T) {
+		cipherSuiteID := uint16(ciphersuite.TLS_AES_128_GCM_SHA256)
+		serverHello := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageServerHello{
+			Version:           protocol.Version1_2,
+			CipherSuiteID:     &cipherSuiteID,
+			CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		})
+		helloVerifyRequest := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageHelloVerifyRequest{
+			Version: protocol.Version1_2,
+			Cookie:  []byte{0x01},
+		})
+		cache := dtlsflight.NewCache()
+		cache.Push(serverHello, 0, 0, handshake.TypeServerHello, false)
+		cache.Push(helloVerifyRequest, 0, 0, handshake.TypeHelloVerifyRequest, false)
+
+		pull := cache.FullPullMapOneOfItems(0, nil, rules...)
+		require.True(t, pull.Ready)
+		assert.ErrorIs(t, pull.Err, dtlserrors.ErrUnexpectedHandshakeMessage)
+		var got *alert.Alert
+		require.ErrorAs(t, pull.Err, &got)
+		assert.Equal(t, alert.UnexpectedMessage, got.Description)
+	})
+}
+
+func TestHandshakeCachePullRejectsSequenceOverflow(t *testing.T) {
+	rule := dtlsflight.HandshakeCachePullRule{
+		Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false,
+	}
+	pull := dtlsflight.NewCache().FullPullMapItems(-1, nil, rule)
+	require.True(t, pull.Ready)
+	assert.ErrorIs(t, pull.Err, dtlserrors.ErrHandshakeSequenceOverflow)
+	var got *alert.Alert
+	require.ErrorAs(t, pull.Err, &got)
+	assert.Equal(t, alert.DecodeError, got.Description)
+
+	pull = dtlsflight.NewCache().FullPullMapOneOfItems(-1, nil, rule)
+	require.True(t, pull.Ready)
+	assert.ErrorIs(t, pull.Err, dtlserrors.ErrHandshakeSequenceOverflow)
+	got = nil
+	require.ErrorAs(t, pull.Err, &got)
+	assert.Equal(t, alert.DecodeError, got.Description)
 }
 
 func marshalHandshakeCacheTestMessage(t *testing.T, seq uint16, message handshake.Message) []byte {

--- a/internal/flight/types.go
+++ b/internal/flight/types.go
@@ -38,6 +38,28 @@ type HandshakeCacheItem struct {
 	Data            []byte
 }
 
+// HandshakeCachePullResult distinguishes an incomplete flight from a complete
+// malformed message. Err is non-nil only when a selected complete message
+// could not be decoded or failed cache/header validation.
+type HandshakeCachePullResult struct {
+	NextSequence int
+	Messages     map[handshake.Type]handshake.Message
+	Items        []*HandshakeCacheItem
+	Ready        bool
+	// Err always wraps an *alert.Alert.
+	Err error
+}
+
+// HandshakeCacheItemPullResult is an ordered cache selection before message
+// payloads are decoded. Items is aligned with the requested pull rules.
+type HandshakeCacheItemPullResult struct {
+	NextSequence int
+	Items        []*HandshakeCacheItem
+	Ready        bool
+	// Err always wraps an *alert.Alert.
+	Err error
+}
+
 type HandshakeCachePullRule struct {
 	Typ      handshake.Type
 	Epoch    uint16

--- a/internal/handshake/fsm.go
+++ b/internal/handshake/fsm.go
@@ -5,6 +5,7 @@ package dtlshandshake
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -54,6 +55,9 @@ func runHandshakeFSM(
 
 // notifyAlert sends a DTLS alert if present and prefers the original error.
 func notifyAlert(ctx context.Context, conn Conn, dtlsAlert *alert.Alert, err error) error {
+	if dtlsAlert == nil && err != nil {
+		errors.As(err, &dtlsAlert)
+	}
 	if dtlsAlert == nil {
 		return err
 	}

--- a/pkg/protocol/handshake/extensions.go
+++ b/pkg/protocol/handshake/extensions.go
@@ -182,11 +182,10 @@ func decodeExtensionList(data []byte, context extensionContext) ([]extension.Val
 	return decodeRawExtensions(rawExtensions, context)
 }
 
-func decodeRawExtensions( //nolint:cyclop
-	rawExtensions []extension.Raw,
-	context extensionContext,
-) ([]extension.Value, error) {
-	validationErr := validateRawExtensionBlock(rawExtensions, context)
+func decodeRawExtensions(rawExtensions []extension.Raw, context extensionContext) ([]extension.Value, error) {
+	if err := validateRawExtensionBlock(rawExtensions, context); err != nil {
+		return nil, err
+	}
 
 	values := make([]extension.Value, 0, len(rawExtensions))
 	for _, raw := range rawExtensions {
@@ -199,15 +198,13 @@ func decodeRawExtensions( //nolint:cyclop
 
 		factory, allowed := contexts[context]
 		if !allowed {
-			// todo: remove this once we remove the compatibility path.
-			// nolint:godox
-			if raw.Type == extension.TypeConnectionID && context == extensionContextHelloRetryRequest {
-				factory = contexts[extensionContextServerHello13]
-			} else {
-				values = append(values, extension.Raw{Type: raw.Type, Data: bytes.Clone(raw.Data)})
-
-				continue
-			}
+			return nil, fmt.Errorf(
+				"extension %d in %s: %w: %w",
+				raw.Type,
+				context,
+				dtlserrors.ErrExtensionNotAllowed,
+				&alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
+			)
 		}
 		if factory == nil {
 			values = append(values, extension.Raw{Type: raw.Type, Data: bytes.Clone(raw.Data)})
@@ -217,10 +214,6 @@ func decodeRawExtensions( //nolint:cyclop
 
 		value := factory()
 		if err := value.UnmarshalData(raw.Data); err != nil {
-			if validationErr != nil {
-				return values, validationErr
-			}
-
 			return nil, fmt.Errorf(
 				"extension %d in %s: %w: %w",
 				raw.Type,
@@ -232,11 +225,8 @@ func decodeRawExtensions( //nolint:cyclop
 		values = append(values, value)
 	}
 
-	if validationErr != nil {
-		return values, validationErr
-	}
 	if err := validateExtensionDependencies(values, context); err != nil {
-		return values, err
+		return nil, err
 	}
 
 	return values, nil

--- a/pkg/protocol/handshake/handshake.go
+++ b/pkg/protocol/handshake/handshake.go
@@ -5,13 +5,10 @@
 package handshake
 
 import (
-	"errors"
-
 	"github.com/pion/dtls/v3/internal/ciphersuite/types"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
-	"github.com/pion/dtls/v3/pkg/protocol/alert"
 )
 
 // Type is the unique identifier for each handshake message
@@ -194,17 +191,5 @@ func (h *Handshake) Unmarshal(data []byte) error { //nolint:cyclop
 		return dtlserrors.ErrNotImplemented
 	}
 
-	err := h.Message.Unmarshal(data[HeaderLength:])
-	var extensionAlert *alert.Alert
-	if (h.Header.Type == TypeClientHello || h.Header.Type == TypeServerHello) &&
-		errors.As(err, &extensionAlert) &&
-		(extensionAlert.Description == alert.IllegalParameter || extensionAlert.Description == alert.MissingExtension) {
-		// FullPullMap currently treats every Unmarshal error as an incomplete
-		// flight.
-		// todo: return decode errors.
-		// nolint:godox
-		return nil //nolint:nilerr
-	}
-
-	return err
+	return h.Message.Unmarshal(data[HeaderLength:])
 }

--- a/pkg/protocol/handshake/message_client_hello.go
+++ b/pkg/protocol/handshake/message_client_hello.go
@@ -148,10 +148,10 @@ func (m *MessageClientHello) Unmarshal(data []byte) error { //nolint:cyclop
 
 	// Extensions
 	extensions, err := decodeExtensionList(data[currOffset:], extensionContextClientHello)
-	m.Extensions = extensions
 	if err != nil {
 		return err
 	}
+	m.Extensions = extensions
 
 	return nil
 }

--- a/pkg/protocol/handshake/message_server_hello.go
+++ b/pkg/protocol/handshake/message_server_hello.go
@@ -117,10 +117,10 @@ func (m *MessageServerHello) Unmarshal(data []byte) error { //nolint:cyclop
 	if len(data) <= currOffset {
 		context := serverHelloExtensionContext(m.Random, nil)
 		extensions, err := decodeRawExtensions(nil, context)
-		m.Extensions = extensions
 		if err != nil {
 			return err
 		}
+		m.Extensions = extensions
 
 		return nil
 	}
@@ -142,10 +142,10 @@ func (m *MessageServerHello) Unmarshal(data []byte) error { //nolint:cyclop
 	}
 	context := serverHelloExtensionContext(m.Random, rawExtensions)
 	extensions, err := decodeRawExtensions(rawExtensions, context)
-	m.Extensions = extensions
 	if err != nil {
 		return err
 	}
+	m.Extensions = extensions
 
 	return nil
 }


### PR DESCRIPTION
#### Description
This is a big refactor and improvement, a follow up on #1023 and part of #1021 

This mainly makes the cache pulls distinguish incomplete handshakes from complete invalid ones. preserve alert classification in the standard error chain (now that Alerts are standard errors #1022 ).
And thanks to the rules added in #1023 (and some here) this does:
1. reject wrong-type/sequence conflicts instead of waiting indefinitely.
2. preserve illegal_parameter, missing_extension, and unexpected_message errors
3. migrate DTLS 1.2 and 1.3 flight paths to error pulls (so we have the same errors / handling).
4. add coverage for malformed, conflicting, overflow, and dual-stack cases part of #1005

