### PR TITLE
Reuse decoded handshake messages

### DIFF
--- a/flight_test.go
+++ b/flight_test.go
@@ -95,10 +95,10 @@ func flight13ParseForTestWithConn(
 			Cache:  flightCtx.cache,
 			Config: flightCtx.cfg,
 			Hooks: dtlsflight13.ParseHooks{
-				InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+				InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []dtlsflight.DecodedHandshakeCacheItem) error {
 					return dtlshandshake.AppendVerifiedInboundHandshakeCacheItems(flightCtx.transcript, cipherSuite, items)
 				},
-				ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+				ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []dtlsflight.DecodedHandshakeCacheItem) error {
 					return dtlshandshake.VerifyAndAppendProtectedHandshakeCacheItems(
 						flightCtx.transcript,
 						flightCtx.state,
@@ -554,32 +554,21 @@ func TestFlight13_5GenerateSelectsClientCertificateBySignatureScheme(t *testing.
 		Hash:      dtlshash.SHA256,
 		Signature: signature.ECDSA,
 	}
-	rawRequest, err := (&handshake.Handshake{
-		Message: &handshake.MessageCertificateRequest13{
-			CertificateRequestContext: []byte("request"),
-			Extensions: []extension.Value{
-				&extension.SignatureAlgorithms{
-					Schemes: dtlsflight.SignatureSchemeIDs([]signaturehash.Algorithm{ecdsaSHA256}),
-				},
+	request := &handshake.MessageCertificateRequest13{
+		CertificateRequestContext: []byte("request"),
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{
+				Schemes: dtlsflight.SignatureSchemeIDs([]signaturehash.Algorithm{ecdsaSHA256}),
 			},
 		},
-	}).Marshal()
-	require.NoError(t, err)
-
-	cache := dtlsflight.NewCache()
-	cache.Push(
-		rawRequest,
-		dtlsflight13.EpochHandshake,
-		0,
-		handshake.TypeCertificateRequest,
-		false,
-	)
+	}
 	cfg := testHandshakeConfig13(t)
 	cfg.LocalCertificates = []tls.Certificate{rsaCertificate, ecdsaCertificate}
+	state := newTestState13(true)
+	state.RemoteCertificateRequest = request
 
 	packets, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight5, &handshakeTestContext13{
-		state: newTestState13(true),
-		cache: cache,
+		state: state,
 		cfg:   cfg,
 	})
 	require.NoError(t, err)

--- a/internal/flight/cache.go
+++ b/internal/flight/cache.go
@@ -5,6 +5,7 @@
 package flight
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 
@@ -21,6 +22,21 @@ type Cache struct {
 	mu    sync.Mutex
 }
 
+type handshakeCacheDecodeKind uint8
+
+const (
+	handshakeCacheDecodeGeneric handshakeCacheDecodeKind = iota
+	handshakeCacheDecodeProtected13
+)
+
+type handshakeCacheDecodeContext struct {
+	kind                 handshakeCacheDecodeKind
+	keyExchangeAlgorithm ciphersuite.KeyExchangeAlgorithm
+}
+
+// HandshakeCacheDecoder decodes a complete cached handshake message.
+type HandshakeCacheDecoder func([]byte) (*handshake.Handshake, error)
+
 func NewCache() *Cache {
 	return &Cache{}
 }
@@ -30,7 +46,7 @@ func (h *Cache) Push(data []byte, epoch, messageSequence uint16, typ handshake.T
 	defer h.mu.Unlock()
 
 	h.cache = append(h.cache, &HandshakeCacheItem{
-		Data:            data,
+		Data:            bytes.Clone(data),
 		Epoch:           epoch,
 		MessageSequence: messageSequence,
 		Typ:             typ,
@@ -91,7 +107,7 @@ func (h *Cache) FullPullMapItems(
 		}
 	}
 
-	return fullPullMapCacheItems(startSeq, cipherSuite, rules, selection.Items)
+	return h.fullPullMapCacheItems(startSeq, cipherSuite, rules, selection.Items)
 }
 
 // FullPullMapOneOfItems decodes exactly one of the allowed messages at
@@ -111,7 +127,7 @@ func (h *Cache) FullPullMapOneOfItems(
 		}
 	}
 
-	return fullPullMapCacheItems(
+	return h.fullPullMapCacheItems(
 		startSeq,
 		cipherSuite,
 		[]HandshakeCachePullRule{rule},
@@ -281,14 +297,14 @@ func unexpectedHandshakePull(startSeq int) HandshakeCacheItemPullResult {
 	}
 }
 
-func fullPullMapCacheItems(
+func (h *Cache) fullPullMapCacheItems(
 	startSeq int,
 	cipherSuite dtlsconfig.CipherSuite,
 	rules []HandshakeCachePullRule,
 	ci []*HandshakeCacheItem,
 ) HandshakeCachePullResult {
 	out := make(map[handshake.Type]handshake.Message)
-	items := make([]*HandshakeCacheItem, 0, len(rules))
+	items := make([]DecodedHandshakeCacheItem, 0, len(rules))
 	seq := startSeq
 	keyExchangeAlgorithm := keyExchangeAlgorithmForCipherSuite(cipherSuite)
 	for i, r := range rules {
@@ -297,16 +313,9 @@ func fullPullMapCacheItems(
 		if item == nil {
 			continue
 		}
-		parsed := &handshake.Handshake{KeyExchangeAlgorithm: keyExchangeAlgorithm}
-		err := parsed.Unmarshal(item.Data)
-		if err == nil {
-			err = validateCachedHandshake(
-				item,
-				parsed,
-				r.Typ,
-				uint16(seq), //nolint:gosec // selection bounded seq above.
-			)
-		}
+		parsed, err := h.decodeGenericHandshakeItem(
+			item, r.Typ, uint16(seq), keyExchangeAlgorithm, //nolint:gosec // selection bounded seq above.
+		)
 		if err != nil {
 			return HandshakeCachePullResult{
 				NextSequence: startSeq,
@@ -320,7 +329,7 @@ func fullPullMapCacheItems(
 		}
 		seq++
 		out[typ] = parsed.Message
-		items = append(items, item)
+		items = append(items, DecodedHandshakeCacheItem{Raw: item, Parsed: parsed})
 	}
 	if len(items) == 0 {
 		return HandshakeCachePullResult{NextSequence: seq}
@@ -342,11 +351,118 @@ func keyExchangeAlgorithmForCipherSuite(cipherSuite dtlsconfig.CipherSuite) ciph
 	return cipherSuite.KeyExchangeAlgorithm()
 }
 
-func validateCachedHandshake( //nolint:cyclop // Each condition validates a distinct wire/cache invariant.
+func (h *Cache) decodeGenericHandshakeItem(
 	item *HandshakeCacheItem,
-	parsed *handshake.Handshake,
 	expectedType handshake.Type,
 	expectedSequence uint16,
+	keyExchangeAlgorithm ciphersuite.KeyExchangeAlgorithm,
+) (*handshake.Handshake, error) {
+	contextKeyExchangeAlgorithm := keyExchangeAlgorithm
+	if expectedType != handshake.TypeServerKeyExchange && expectedType != handshake.TypeClientKeyExchange {
+		contextKeyExchangeAlgorithm = 0
+	}
+	context := handshakeCacheDecodeContext{
+		kind:                 handshakeCacheDecodeGeneric,
+		keyExchangeAlgorithm: contextKeyExchangeAlgorithm,
+	}
+
+	return h.decodeHandshakeItem(
+		item,
+		expectedType,
+		expectedSequence,
+		context,
+		func(data []byte) (*handshake.Handshake, error) {
+			parsed := &handshake.Handshake{KeyExchangeAlgorithm: keyExchangeAlgorithm}
+			if err := parsed.Unmarshal(data); err != nil {
+				return nil, err
+			}
+
+			return parsed, nil
+		},
+	)
+}
+
+// DecodeProtectedHandshakeItem decodes and retains one DTLS 1.3 protected
+// handshake message, or returns the retained value by an earlier pull.
+func (h *Cache) DecodeProtectedHandshakeItem(
+	item *HandshakeCacheItem,
+	expectedType handshake.Type,
+	expectedSequence uint16,
+	decoder HandshakeCacheDecoder,
+) (*handshake.Handshake, error) {
+	parsed, err := h.decodeHandshakeItem(
+		item,
+		expectedType,
+		expectedSequence,
+		handshakeCacheDecodeContext{kind: handshakeCacheDecodeProtected13},
+		decoder,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: %w",
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
+	}
+
+	return parsed, nil
+}
+
+func (h *Cache) decodeHandshakeItem(
+	item *HandshakeCacheItem,
+	expectedType handshake.Type,
+	expectedSequence uint16,
+	context handshakeCacheDecodeContext,
+	decoder HandshakeCacheDecoder,
+) (*handshake.Handshake, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if item == nil || decoder == nil || item.Typ != expectedType || item.MessageSequence != expectedSequence {
+		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+	if item.hasDecoded {
+		if item.decodeContext != context {
+			return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
+		}
+		if err := validateDecodedHandshake(item, item.parsed); err != nil {
+			return nil, err
+		}
+
+		return item.parsed, nil
+	}
+
+	parsed, err := decoder(item.Data)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDecodedHandshake(item, parsed); err != nil {
+		return nil, err
+	}
+
+	item.parsed = parsed
+	item.decodeContext = context
+	item.hasDecoded = true
+
+	return parsed, nil
+}
+
+// Validate checks that the raw and parsed views identify the same complete
+// handshake message.
+func (i DecodedHandshakeCacheItem) Validate() error {
+	if err := validateDecodedHandshake(i.Raw, i.Parsed); err != nil {
+		return err
+	}
+	if i.Raw.hasDecoded && i.Raw.parsed != i.Parsed {
+		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
+	}
+
+	return nil
+}
+
+func validateDecodedHandshake( //nolint:cyclop
+	item *HandshakeCacheItem,
+	parsed *handshake.Handshake,
 ) error {
 	if item == nil || parsed == nil || parsed.Message == nil {
 		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
@@ -357,9 +473,7 @@ func validateCachedHandshake( //nolint:cyclop // Each condition validates a dist
 		return err
 	}
 	if rawHeader != parsed.Header ||
-		rawHeader.Type != expectedType ||
 		rawHeader.Type != item.Typ ||
-		rawHeader.MessageSequence != expectedSequence ||
 		rawHeader.MessageSequence != item.MessageSequence ||
 		rawHeader.FragmentOffset != 0 ||
 		rawHeader.FragmentLength != rawHeader.Length ||

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -4,8 +4,10 @@
 package flight12
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"slices"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -106,7 +108,7 @@ func flight0Parse(
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrServerNoMatchingSRTPProfile //nolint:lll
 			}
 			state.SetSRTPProtectionProfile(profile)
-			state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
+			state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(ext.MasterKeyIdentifier)
 		case *extension12.ExtendedMasterSecret:
 			if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 				state.ExtendedMasterSecret = true
@@ -116,12 +118,12 @@ func flight0Parse(
 		case *extension12.RenegotiationInfo:
 			state.RemoteSupportsRenegotiation = true
 		case *extension.ALPNOffer:
-			state.PeerSupportedProtocols = ext.Protocols
+			state.PeerSupportedProtocols = slices.Clone(ext.Protocols)
 		case *extension.ConnectionID:
 			// Only set connection ID to be sent if server supports connection
 			// IDs.
 			if cfg.ConnectionIDGenerator != nil {
-				state.RemoteConnectionID = ext.CID
+				state.RemoteConnectionID = bytes.Clone(ext.CID)
 				state.RemoteCIDOffered = true
 			}
 		case *extension.CertificateSignatureAlgorithms:

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -6,12 +6,14 @@ package flight12
 import (
 	"bytes"
 	"context"
+	"slices"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -75,7 +77,7 @@ func flight3Parse(
 					return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlserrors.ErrClientNoMatchingSRTPProfile //nolint:lll
 				}
 				state.SetSRTPProtectionProfile(profile)
-				state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
+				state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(ext.MasterKeyIdentifier)
 			case *extension12.ExtendedMasterSecret:
 				if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 					state.ExtendedMasterSecret = true
@@ -86,7 +88,7 @@ func flight3Parse(
 				// Only set connection ID to be sent if client supports connection
 				// IDs.
 				if state.LocalCIDOffered {
-					state.RemoteConnectionID = ext.CID
+					state.RemoteConnectionID = bytes.Clone(ext.CID)
 					state.RemoteCIDOffered = true
 				}
 			}
@@ -138,7 +140,7 @@ func flight3Parse(
 		if !cfg.HasSessionStore {
 			state.SessionID = []byte{}
 		} else {
-			state.SessionID = serverHelloMsg.SessionID
+			state.SessionID = bytes.Clone(serverHelloMsg.SessionID)
 		}
 
 		state.MasterSecret = []byte{}
@@ -168,20 +170,23 @@ func flight3Parse(
 	state.HandshakeRecvSequence = serverFlightPull.NextSequence
 
 	if h, ok := serverFlightPull.Messages[handshake.TypeCertificate].(*handshake.MessageCertificate); ok {
-		state.PeerCertificates = h.Certificate
+		state.PeerCertificates = util.CloneByteSlices(h.Certificate)
 	} else if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypeCertificate {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.NoCertificate}, dtlserrors.ErrInvalidCertificate
 	}
 
 	if h, ok := serverFlightPull.Messages[handshake.TypeServerKeyExchange].(*handshake.MessageServerKeyExchange); ok {
+		state.SetRemoteServerKeyExchange(h)
 		alertPtr, err := handleServerKeyExchange(conn, state, cfg, h)
 		if err != nil {
 			return 0, alertPtr, err
 		}
+	} else {
+		state.SetRemoteServerKeyExchange(nil)
 	}
 
 	if creq, ok := serverFlightPull.Messages[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok {
-		state.RemoteCertRequestAlgs = creq.SignatureHashAlgorithms
+		state.RemoteCertRequestAlgs = slices.Clone(creq.SignatureHashAlgorithms)
 		state.RemoteRequestedCertificate = true
 	}
 
@@ -256,10 +261,10 @@ func handleServerKeyExchange(
 
 	if cfg.LocalPSKCallback != nil { //nolint:nestif
 		var psk []byte
-		if psk, err = cfg.LocalPSKCallback(keyExchangeMessage.IdentityHint); err != nil {
+		if psk, err = cfg.LocalPSKCallback(bytes.Clone(keyExchangeMessage.IdentityHint)); err != nil {
 			return &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
-		state.IdentityHint = keyExchangeMessage.IdentityHint
+		state.IdentityHint = bytes.Clone(keyExchangeMessage.IdentityHint)
 		switch state.CipherSuite.KeyExchangeAlgorithm() {
 		case ciphersuite.KeyExchangeAlgorithmPsk:
 			state.PreMasterSecret = prf.PSKPreMasterSecret(psk)

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -4,6 +4,7 @@
 package flight12
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/rand"
@@ -15,6 +16,7 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
@@ -55,7 +57,7 @@ func flight4Parse(
 	}
 
 	if h, hasCert := pull.Messages[handshake.TypeCertificate].(*handshake.MessageCertificate); hasCert {
-		state.PeerCertificates = h.Certificate
+		state.PeerCertificates = util.CloneByteSlices(h.Certificate)
 		// If the client offer its certificate, just disable session resumption.
 		// Otherwise, we have to store the certificate identitfication and expire time.
 		// And we have to check whether this certificate expired, revoked or changed.
@@ -128,10 +130,10 @@ func flight4Parse(
 		var preMasterSecret []byte
 		if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypePreSharedKey {
 			var psk []byte
-			if psk, err = cfg.LocalPSKCallback(clientKeyExchange.IdentityHint); err != nil {
+			if psk, err = cfg.LocalPSKCallback(bytes.Clone(clientKeyExchange.IdentityHint)); err != nil {
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 			}
-			state.IdentityHint = clientKeyExchange.IdentityHint
+			state.IdentityHint = bytes.Clone(clientKeyExchange.IdentityHint)
 			switch state.CipherSuite.KeyExchangeAlgorithm() {
 			case ciphersuite.KeyExchangeAlgorithmPsk:
 				preMasterSecret = prf.PSKPreMasterSecret(psk)

--- a/internal/flight/flight12/flight5handler.go
+++ b/internal/flight/flight12/flight5handler.go
@@ -85,7 +85,10 @@ func flight5Generate(
 		}
 		reqInfo := dtlsconfig.CertificateRequestInfo{}
 		if r, ok2 := pull.Messages[handshake.TypeCertificateRequest].(*handshake.MessageCertificateRequest); ok2 {
-			reqInfo.AcceptableCAs = r.CertificateAuthoritiesNames
+			reqInfo.AcceptableCAs = make([][]byte, len(r.CertificateAuthoritiesNames))
+			for i := range r.CertificateAuthoritiesNames {
+				reqInfo.AcceptableCAs[i] = bytes.Clone(r.CertificateAuthoritiesNames[i])
+			}
 		} else {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, dtlserrors.ErrClientCertificateRequired //nolint:lll
 		}
@@ -140,32 +143,14 @@ func flight5Generate(
 			},
 		})
 
-	serverKeyExchangeData := cache.PullAndMerge(
-		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerKeyExchange, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}, //nolint:lll
-	)
-
-	serverKeyExchange := &handshake.MessageServerKeyExchange{}
+	serverKeyExchange := state.RemoteServerKeyExchange()
 
 	// handshakeMessageServerKeyExchange is optional for PSK
-	if len(serverKeyExchangeData) == 0 {
-		alertPtr, err := handleServerKeyExchange(conn, state, cfg, &handshake.MessageServerKeyExchange{})
+	if serverKeyExchange == nil {
+		serverKeyExchange = &handshake.MessageServerKeyExchange{}
+		alertPtr, err := handleServerKeyExchange(conn, state, cfg, serverKeyExchange)
 		if err != nil {
 			return nil, alertPtr, err
-		}
-	} else {
-		rawHandshake := &handshake.Handshake{
-			KeyExchangeAlgorithm: state.CipherSuite.KeyExchangeAlgorithm(),
-		}
-		err := rawHandshake.Unmarshal(serverKeyExchangeData)
-		if err != nil {
-			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, err
-		}
-
-		switch h := rawHandshake.Message.(type) {
-		case *handshake.MessageServerKeyExchange:
-			serverKeyExchange = h
-		default:
-			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, dtlserrors.ErrInvalidContentType
 		}
 	}
 

--- a/internal/flight/flight12/flight5handler_test.go
+++ b/internal/flight/flight12/flight5handler_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flight12
+
+import (
+	"testing"
+
+	"github.com/pion/dtls/v3/internal/ciphersuite"
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlight5GenerateUsesRetainedServerKeyExchange(t *testing.T) {
+	state := dtlsstate.NewState12(true)
+	cipherSuite := ciphersuite.NewTLSPskWithAes128Ccm()
+	require.NoError(t, cipherSuite.Init(make([]byte, 48), make([]byte, 32), make([]byte, 32), true))
+	state.CipherSuite = cipherSuite
+	state.LocalVerifyData = []byte{0x01}
+	serverKeyExchange := &handshake.MessageServerKeyExchange{IdentityHint: []byte("retained")}
+	state.SetRemoteServerKeyExchange(serverKeyExchange)
+
+	cache := dtlsflight.NewCache()
+	cache.Push([]byte{byte(handshake.TypeServerKeyExchange)}, 0, 0, handshake.TypeServerKeyExchange, false)
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalPSKIdentityHint: []byte("client"),
+		LocalPSKCallback: func([]byte) ([]byte, error) {
+			require.FailNow(t, "retained ServerKeyExchange was processed twice")
+
+			return nil, nil
+		},
+	}
+
+	packets, dtlsAlert, err := flight5Generate(nil, &state, cache, cfg)
+	require.NoError(t, err)
+	assert.Nil(t, dtlsAlert)
+	assert.NotEmpty(t, packets)
+	assert.Same(t, serverKeyExchange, state.RemoteServerKeyExchange())
+}
+
+func TestHandleServerKeyExchangeClonesIdentityHint(t *testing.T) {
+	state := dtlsstate.NewState12(true)
+	state.CipherSuite = ciphersuite.NewTLSPskWithAes128Ccm()
+	message := &handshake.MessageServerKeyExchange{IdentityHint: []byte("server")}
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalPSKCallback: func(identityHint []byte) ([]byte, error) {
+			identityHint[0] = 'X'
+
+			return []byte("secret"), nil
+		},
+	}
+
+	dtlsAlert, err := handleServerKeyExchange(nil, &state, cfg, message)
+	require.NoError(t, err)
+	assert.Nil(t, dtlsAlert)
+	assert.Equal(t, []byte("server"), message.IdentityHint)
+	assert.Equal(t, []byte("server"), state.IdentityHint)
+}

--- a/internal/flight/flight13/extensions.go
+++ b/internal/flight/flight13/extensions.go
@@ -6,6 +6,7 @@ package flight13
 import (
 	"bytes"
 	"fmt"
+	"slices"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -81,19 +82,19 @@ func processClientHelloSecurityExtension(
 		if len(ext.Groups) == 0 {
 			return newClientHelloExtensionFailure(alert.InsufficientSecurity, dtlserrors.ErrNoSupportedEllipticCurves)
 		}
-		state.RemoteGroups = ext.Groups
+		state.RemoteGroups = slices.Clone(ext.Groups)
 	case *extension.SRTPOffer:
 		profile, ok := dtlsflight.FindMatchingSRTPProfile(cfg.LocalSRTPProtectionProfiles, ext.ProtectionProfiles)
 		if !ok {
 			return newClientHelloExtensionFailure(alert.InsufficientSecurity, dtlserrors.ErrServerNoMatchingSRTPProfile)
 		}
 		state.SetSRTPProtectionProfile(profile)
-		state.RemoteSRTPMasterKeyIdentifier = ext.MasterKeyIdentifier
+		state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(ext.MasterKeyIdentifier)
 	case *extension.SignatureAlgorithms:
 		seen.hasSignatureAlgorithms = true
 		state.RemoteSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
 	case *extension13.OfferedVersions:
-		state.RemoteVersions = ext.Versions
+		state.RemoteVersions = slices.Clone(ext.Versions)
 	case *extension13.OfferedPSKs:
 		seen.hasPreSharedKey = true
 	}
@@ -109,14 +110,24 @@ func processClientHelloStateExtension(
 	case *extension.ServerNameOffer:
 		state.ServerName = ext.ServerName // remote server name
 	case *extension.ALPNOffer:
-		state.PeerSupportedProtocols = ext.Protocols
+		state.PeerSupportedProtocols = slices.Clone(ext.Protocols)
 	case *extension.CertificateSignatureAlgorithms:
 		// Store the client's certificate signature schemes for later validation.
 		state.RemoteCertSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
 	case *extension13.ClientKeyShare:
-		state.RemoteKeyEntries = ext.Shares
+		state.RemoteKeyEntries = cloneKeyShareEntries(ext.Shares)
 		state.HasRemoteKeyEntries = true
 	}
+}
+
+func cloneKeyShareEntries(entries []extension13.KeyShareEntry) []extension13.KeyShareEntry {
+	cloned := make([]extension13.KeyShareEntry, len(entries))
+	for i := range entries {
+		cloned[i] = entries[i]
+		cloned[i].KeyExchange = bytes.Clone(entries[i].KeyExchange)
+	}
+
+	return cloned
 }
 
 // connectionIDExtension extracts a connection_id extension while preserving

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -248,7 +248,7 @@ func flight1Parse(
 			// TODO: negotiate version
 			state.RemoteVersions = []protocol.Version{ext.Version}
 		case *extension13.Cookie:
-			state.Cookie = ext.Cookie
+			state.Cookie = bytes.Clone(ext.Cookie)
 		case *extension13.RetryKeyShare:
 			state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: ext.SelectedGroup}}
 			state.HasRemoteKeyEntries = true

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -201,7 +201,7 @@ func applyFlight3ServerKeyShare(
 	}
 	flightCtx.state.KeyAgreementSecret = keyAgreementSecret
 	flightCtx.state.SelectedGroup = serverShare.Group
-	flightCtx.state.RemoteKeyEntries = []extension13.KeyShareEntry{*serverShare}
+	flightCtx.state.RemoteKeyEntries = cloneKeyShareEntries([]extension13.KeyShareEntry{*serverShare})
 	flightCtx.state.HasRemoteKeyEntries = true
 
 	return nil
@@ -212,7 +212,7 @@ func initializeFlight3HandshakeProtection(
 	conn dtlsflight.Conn,
 	flightCtx *handshakeContext,
 	serverHelloSeq int,
-	items []*dtlsflight.HandshakeCacheItem,
+	items []dtlsflight.DecodedHandshakeCacheItem,
 ) *flightParseFailure {
 	if failure := flightCtx.handleInboundHandshake(items); failure != nil {
 		return failure
@@ -251,13 +251,24 @@ func initializeFlight3HandshakeProtection(
 
 func handleFlight3ProtectedHandshake(
 	flightCtx *handshakeContext,
-	items []*dtlsflight.HandshakeCacheItem,
+	items []dtlsflight.DecodedHandshakeCacheItem,
 ) *flightParseFailure {
 	if flightCtx.protectedHandshakeHandler == nil {
 		return newFlightParseFailure(alert.InternalError, dtlserrors.ErrHandshakeTranscriptHashNotSelected)
 	}
 	if err := flightCtx.protectedHandshakeHandler(flightCtx.state.CipherSuite, items); err != nil {
 		return protectedFlightParseFailure(err)
+	}
+	flightCtx.state.RemoteCertificateRequest = nil
+	for _, item := range items {
+		if item.Parsed == nil {
+			continue
+		}
+		if request, ok := item.Parsed.Message.(*handshake.MessageCertificateRequest13); ok {
+			flightCtx.state.RemoteCertificateRequest = request
+
+			break
+		}
 	}
 
 	return nil

--- a/internal/flight/flight13/flight5handler.go
+++ b/internal/flight/flight13/flight5handler.go
@@ -35,11 +35,8 @@ func flight5Generate(
 func flight5ClientAuthPackets(
 	flightCtx *handshakeContext,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	certificateRequest, ok, err := flight5CertificateRequest(flightCtx.cache)
-	if err != nil {
-		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
-	}
-	if !ok {
+	certificateRequest := flightCtx.state.RemoteCertificateRequest
+	if certificateRequest == nil {
 		return []*dtlsflight.Packet{}, nil, nil
 	}
 
@@ -90,51 +87,6 @@ func flight5ClientAuthPackets(
 	}, nil, nil
 }
 
-func flight5CertificateRequest(
-	cache *dtlsflight.Cache,
-) (*handshake.MessageCertificateRequest13, bool, error) {
-	if cache == nil {
-		return nil, false, nil
-	}
-
-	items := cache.Pull(dtlsflight.HandshakeCachePullRule{
-		Typ:      handshake.TypeCertificateRequest,
-		Epoch:    EpochHandshake,
-		IsClient: false,
-		Optional: true,
-	})
-	if len(items) == 0 || items[0] == nil {
-		return nil, false, nil
-	}
-
-	item := items[0]
-	header := &handshake.Header{}
-	if err := header.Unmarshal(item.Data); err != nil {
-		return nil, false, err
-	}
-	if !validFlight5CertificateRequestItem(item, header) {
-		return nil, false, dtlserrors.ErrInvalidHandshakeTranscriptMessage
-	}
-
-	request := &handshake.MessageCertificateRequest13{}
-	if err := request.Unmarshal(item.Data[handshake.HeaderLength:]); err != nil {
-		return nil, false, err
-	}
-
-	return request, true, nil
-}
-
-func validFlight5CertificateRequestItem(
-	item *dtlsflight.HandshakeCacheItem,
-	header *handshake.Header,
-) bool {
-	return header.Type == handshake.TypeCertificateRequest &&
-		header.MessageSequence == item.MessageSequence &&
-		header.FragmentOffset == 0 &&
-		header.FragmentLength == header.Length &&
-		len(item.Data) == handshake.HeaderLength+int(header.Length)
-}
-
 func flight5ClientCertificate(
 	cfg *dtlsconfig.HandshakeConfig,
 	request *handshake.MessageCertificateRequest13,
@@ -144,7 +96,10 @@ func flight5ClientCertificate(
 	}
 	for _, ext := range request.Extensions {
 		if authorities, ok := ext.(*extension13.CertificateAuthorities); ok {
-			requestInfo.AcceptableCAs = authorities.Authorities
+			requestInfo.AcceptableCAs = make([][]byte, len(authorities.Authorities))
+			for i := range authorities.Authorities {
+				requestInfo.AcceptableCAs[i] = bytes.Clone(authorities.Authorities[i])
+			}
 
 			break
 		}

--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -51,9 +51,9 @@ type Generator func(
 	*dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error)
 
-type InboundHandshakeHandler func(dtlsconfig.CipherSuite, []*dtlsflight.HandshakeCacheItem) error
+type InboundHandshakeHandler func(dtlsconfig.CipherSuite, []dtlsflight.DecodedHandshakeCacheItem) error
 
-type ProtectedHandshakeHandler func(dtlsconfig.CipherSuite, []*dtlsflight.HandshakeCacheItem) error
+type ProtectedHandshakeHandler func(dtlsconfig.CipherSuite, []dtlsflight.DecodedHandshakeCacheItem) error
 
 type HandshakeTrafficSecretDeriver func(*dtlsstate.State13) error
 
@@ -84,7 +84,7 @@ type flightParseFailure struct {
 
 type protectedFlightPull struct {
 	nextHandshakeSequence int
-	items                 []*dtlsflight.HandshakeCacheItem
+	items                 []dtlsflight.DecodedHandshakeCacheItem
 	ready                 bool
 	failure               *flightParseFailure
 }
@@ -100,7 +100,7 @@ type handshakeContext struct {
 }
 
 func (h *handshakeContext) handleInboundHandshake(
-	items []*dtlsflight.HandshakeCacheItem,
+	items []dtlsflight.DecodedHandshakeCacheItem,
 ) *flightParseFailure {
 	if h.inboundHandshakeHandler == nil {
 		return nil
@@ -155,22 +155,26 @@ func pullProtectedHandshakeFlight(
 		return protectedFlightPull{}
 	}
 
-	items := make([]*dtlsflight.HandshakeCacheItem, 0, len(selection.Items))
+	items := make([]dtlsflight.DecodedHandshakeCacheItem, 0, len(selection.Items))
 	sequence := nextHandshakeSequence
 	for i, item := range selection.Items {
 		if item == nil {
 			continue
 		}
-		failure := validateProtectedHandshakeItem(
+		parsed, err := cache.DecodeProtectedHandshakeItem(
 			item,
 			rules[i].Typ,
 			uint16(sequence), //nolint:gosec // PullSequential bounded sequence.
+			decodeProtectedHandshake,
 		)
-		if failure != nil {
-			return protectedFlightPull{ready: true, failure: failure}
+		if err != nil {
+			return protectedFlightPull{
+				ready:   true,
+				failure: &flightParseFailure{err: err},
+			}
 		}
 		sequence++
-		items = append(items, item)
+		items = append(items, dtlsflight.DecodedHandshakeCacheItem{Raw: item, Parsed: parsed})
 	}
 
 	return protectedFlightPull{
@@ -180,38 +184,21 @@ func pullProtectedHandshakeFlight(
 	}
 }
 
-func validateProtectedHandshakeItem(
-	item *dtlsflight.HandshakeCacheItem,
-	expectedType handshake.Type,
-	expectedSequence uint16,
-) *flightParseFailure {
-	if item.MessageSequence != expectedSequence || item.Typ != expectedType {
-		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
-	}
-
+func decodeProtectedHandshake(data []byte) (*handshake.Handshake, error) {
 	header := &handshake.Header{}
-	if err := header.Unmarshal(item.Data); err != nil {
-		return newFlightParseFailure(alert.DecodeError, err)
-	}
-	if header.Type != expectedType || header.MessageSequence != expectedSequence ||
-		header.FragmentOffset != 0 ||
-		header.FragmentLength != header.Length ||
-		len(item.Data) != handshake.HeaderLength+int(header.Length) {
-		return newFlightParseFailure(alert.DecodeError, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+	if err := header.Unmarshal(data); err != nil {
+		return nil, err
 	}
 
-	if err := unmarshalProtectedHandshakeMessage(expectedType, item.Data[handshake.HeaderLength:]); err != nil {
-		return &flightParseFailure{err: fmt.Errorf(
-			"%w: %w",
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
-		)}
+	message, err := unmarshalProtectedHandshakeMessage(header.Type, data[handshake.HeaderLength:])
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	return &handshake.Handshake{Header: *header, Message: message}, nil
 }
 
-func unmarshalProtectedHandshakeMessage(typ handshake.Type, body []byte) error {
+func unmarshalProtectedHandshakeMessage(typ handshake.Type, body []byte) (handshake.Message, error) {
 	var msg handshake.Message
 	switch typ {
 	case handshake.TypeEncryptedExtensions:
@@ -225,10 +212,14 @@ func unmarshalProtectedHandshakeMessage(typ handshake.Type, body []byte) error {
 	case handshake.TypeFinished:
 		msg = &handshake.MessageFinished{}
 	default:
-		return dtlserrors.ErrInvalidHandshakeTranscriptMessage
+		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
 	}
 
-	return msg.Unmarshal(body)
+	if err := msg.Unmarshal(body); err != nil {
+		return nil, err
+	}
+
+	return msg, nil
 }
 
 func getFlightParser(f Flight) (flightParser, bool) {
@@ -328,7 +319,7 @@ func CertificateVerifyPacket(
 type serverHelloPull struct {
 	nextHandshakeSequence int
 	serverHello           *handshake.MessageServerHello
-	items                 []*dtlsflight.HandshakeCacheItem
+	items                 []dtlsflight.DecodedHandshakeCacheItem
 	ready                 bool
 	failure               *flightParseFailure
 }

--- a/internal/flight/flight13/flighthandler_test.go
+++ b/internal/flight/flight13/flighthandler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,37 @@ func TestProtectedFlightParseFailureClientCertificateRequired(t *testing.T) {
 	var classified *alert.Alert
 	require.ErrorAs(t, failure.err, &classified)
 	assert.Equal(t, failure.alert, classified)
+}
+
+func TestPullProtectedHandshakeFlightReturnsDecodedItems(t *testing.T) {
+	cache := dtlsflight.NewCache()
+	rawEncryptedExtensions := marshalProtectedTestHandshake(t, 0, &handshake.MessageEncryptedExtensions{})
+	rawFinished := marshalProtectedTestHandshake(t, 1, &handshake.MessageFinished{VerifyData: []byte{0x01}})
+	cache.Push(rawEncryptedExtensions, EpochHandshake, 0, handshake.TypeEncryptedExtensions, false)
+	cache.Push(rawFinished, EpochHandshake, 1, handshake.TypeFinished, false)
+
+	pull := pullProtectedHandshakeFlight(cache, []dtlsflight.HandshakeCachePullRule{
+		{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false},
+		{Typ: handshake.TypeFinished, Epoch: EpochHandshake, IsClient: false},
+	}, 0)
+
+	require.True(t, pull.ready)
+	require.Nil(t, pull.failure)
+	assert.Equal(t, 2, pull.nextHandshakeSequence)
+	require.Len(t, pull.items, 2)
+	assert.Equal(t, rawEncryptedExtensions, pull.items[0].Raw.Data)
+	assert.Equal(t, rawFinished, pull.items[1].Raw.Data)
+	require.IsType(t, &handshake.MessageEncryptedExtensions{}, pull.items[0].Parsed.Message)
+	require.IsType(t, &handshake.MessageFinished{}, pull.items[1].Parsed.Message)
+
+	secondPull := pullProtectedHandshakeFlight(cache, []dtlsflight.HandshakeCachePullRule{
+		{Typ: handshake.TypeEncryptedExtensions, Epoch: EpochHandshake, IsClient: false},
+		{Typ: handshake.TypeFinished, Epoch: EpochHandshake, IsClient: false},
+	}, 0)
+	require.True(t, secondPull.ready)
+	require.Nil(t, secondPull.failure)
+	assert.Same(t, pull.items[0].Parsed, secondPull.items[0].Parsed)
+	assert.Same(t, pull.items[1].Parsed, secondPull.items[1].Parsed)
 }
 
 func TestPullProtectedHandshakeFlightDistinguishesIncompleteAndInvalid(t *testing.T) {
@@ -110,6 +142,52 @@ func marshalProtectedTestHandshake(t *testing.T, sequence uint16, message handsh
 	require.NoError(t, err)
 
 	return raw
+}
+
+func TestHandleFlight3ProtectedHandshakeRetainsCertificateRequest(t *testing.T) {
+	request := &handshake.MessageCertificateRequest13{
+		Extensions: []extension.Value{
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
+		},
+	}
+	items := []dtlsflight.DecodedHandshakeCacheItem{{
+		Raw: &dtlsflight.HandshakeCacheItem{Typ: handshake.TypeCertificateRequest},
+		Parsed: &handshake.Handshake{
+			Message: request,
+		},
+	}}
+	flightCtx := &handshakeContext{
+		state: &dtlsstate.State13{Common: &dtlsstate.Common{}},
+		protectedHandshakeHandler: func(_ dtlsconfig.CipherSuite, got []dtlsflight.DecodedHandshakeCacheItem) error {
+			assert.Same(t, request, got[0].Parsed.Message)
+
+			return nil
+		},
+	}
+
+	failure := handleFlight3ProtectedHandshake(flightCtx, items)
+	require.Nil(t, failure)
+	assert.Same(t, request, flightCtx.state.RemoteCertificateRequest)
+}
+
+func TestFlight5ClientCertificateClonesCertificateAuthorities(t *testing.T) {
+	authority := []byte{0x01, 0x02}
+	request := &handshake.MessageCertificateRequest13{Extensions: []extension.Value{
+		&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
+		&extension13.CertificateAuthorities{Authorities: [][]byte{authority}},
+	}}
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalGetClientCertificate: func(info *dtlsconfig.CertificateRequestInfo) (*tls.Certificate, error) {
+			info.AcceptableCAs[0][0] = 0xff
+
+			return &tls.Certificate{}, nil
+		},
+	}
+
+	_, err := flight5ClientCertificate(cfg, request)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x02}, authority)
+	assert.Equal(t, []byte{0x01, 0x02}, request.Extensions[1].(*extension13.CertificateAuthorities).Authorities[0]) //nolint:forcetypeassert,lll
 }
 
 func TestFlight4GenerateCertificateAuthenticatedFlight(t *testing.T) {

--- a/internal/flight/handshake_cache_test.go
+++ b/internal/flight/handshake_cache_test.go
@@ -145,6 +145,17 @@ func TestHandshakeCachePullExact(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestHandshakeCachePushCopiesData(t *testing.T) {
+	data := []byte{1, 2, 3}
+	cache := dtlsflight.NewCache()
+	cache.Push(data, 0, 0, handshake.TypeFinished, true)
+	data[0] = 9
+
+	item, ok := cache.PullExact(0, true)
+	require.True(t, ok)
+	assert.Equal(t, []byte{1, 2, 3}, item.Data)
+}
+
 func TestHandshakeCacheFullPullMapItemsReturnsAcceptedRawItems(t *testing.T) {
 	cipherSuiteID := uint16(ciphersuite.TLS_AES_128_GCM_SHA256)
 	rawClientHello := marshalHandshakeCacheTestMessage(t, 0, &handshake.MessageClientHello{
@@ -173,8 +184,21 @@ func TestHandshakeCacheFullPullMapItemsReturnsAcceptedRawItems(t *testing.T) {
 	require.IsType(t, &handshake.MessageClientHello{}, pull.Messages[handshake.TypeClientHello])
 	require.IsType(t, &handshake.MessageServerHello{}, pull.Messages[handshake.TypeServerHello])
 	require.Len(t, pull.Items, 2)
-	assert.Equal(t, rawClientHello, pull.Items[0].Data)
-	assert.Equal(t, rawServerHello, pull.Items[1].Data)
+	assert.Equal(t, rawClientHello, pull.Items[0].Raw.Data)
+	assert.Equal(t, rawServerHello, pull.Items[1].Raw.Data)
+	require.NotNil(t, pull.Items[0].Parsed)
+	require.NotNil(t, pull.Items[1].Parsed)
+	assert.Same(t, pull.Messages[handshake.TypeClientHello], pull.Items[0].Parsed.Message)
+	assert.Same(t, pull.Messages[handshake.TypeServerHello], pull.Items[1].Parsed.Message)
+
+	secondPull := cache.FullPullMapItems(0, nil,
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeClientHello, Epoch: 0, IsClient: true, Optional: false},  //nolint:lll
+		dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeServerHello, Epoch: 0, IsClient: false, Optional: false}, //nolint:lll
+	)
+	require.NoError(t, secondPull.Err)
+	require.True(t, secondPull.Ready)
+	assert.Same(t, pull.Items[0].Parsed, secondPull.Items[0].Parsed)
+	assert.Same(t, pull.Items[1].Parsed, secondPull.Items[1].Parsed)
 }
 
 func TestHandshakeCachePullResultDistinguishesIncompleteAndMalformed(t *testing.T) {

--- a/internal/flight/types.go
+++ b/internal/flight/types.go
@@ -36,6 +36,17 @@ type HandshakeCacheItem struct {
 	Epoch           uint16
 	MessageSequence uint16
 	Data            []byte
+
+	parsed        *handshake.Handshake
+	decodeContext handshakeCacheDecodeContext
+	hasDecoded    bool
+}
+
+// DecodedHandshakeCacheItem retains the original cache bytes for the
+// transcript and the single parsed representation used by handshake logic.
+type DecodedHandshakeCacheItem struct {
+	Raw    *HandshakeCacheItem
+	Parsed *handshake.Handshake
 }
 
 // HandshakeCachePullResult distinguishes an incomplete flight from a complete
@@ -44,7 +55,7 @@ type HandshakeCacheItem struct {
 type HandshakeCachePullResult struct {
 	NextSequence int
 	Messages     map[handshake.Type]handshake.Message
-	Items        []*HandshakeCacheItem
+	Items        []DecodedHandshakeCacheItem
 	Ready        bool
 	// Err always wraps an *alert.Alert.
 	Err error

--- a/internal/handshake/handshake_context.go
+++ b/internal/handshake/handshake_context.go
@@ -144,10 +144,10 @@ func (c *handshakeContext) parseDependencies() dtlsflight13.ParseDependencies {
 		Cache:  c.cache,
 		Config: c.cfg,
 		Hooks: dtlsflight13.ParseHooks{
-			InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+			InboundHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []dtlsflight.DecodedHandshakeCacheItem) error {
 				return AppendVerifiedInboundHandshakeCacheItems(c.transcript, cipherSuite, items)
 			},
-			ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []*dtlsflight.HandshakeCacheItem) error {
+			ProtectedHandshake: func(cipherSuite dtlsconfig.CipherSuite, items []dtlsflight.DecodedHandshakeCacheItem) error {
 				return VerifyAndAppendProtectedHandshakeCacheItems(
 					c.transcript,
 					c.state,

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -404,9 +404,23 @@ func (p *postHandshake) processPostHandshakeMessages(ctx context.Context, conn C
 			return nil
 		}
 
-		message := &handshake.Handshake{}
-		if err := message.Unmarshal(item.Data); err != nil {
-			description := alert.DecodeError
+		message, err := p.cache.DecodeProtectedHandshakeItem(
+			item,
+			item.Typ,
+			uint16(p.state.HandshakeRecvSequence), //nolint:gosec // bounded above
+			func(data []byte) (*handshake.Handshake, error) {
+				parsed := &handshake.Handshake{}
+				if err := parsed.Unmarshal(data); err != nil {
+					return nil, err
+				}
+
+				return parsed, nil
+			},
+		)
+		if err != nil {
+			var dtlsAlert *alert.Alert
+			errors.As(err, &dtlsAlert)
+			description := dtlsAlert.Description
 			if errors.Is(err, dtlserrors.ErrInvalidKeyUpdate) {
 				description = alert.IllegalParameter
 			}

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -17,6 +17,8 @@ import (
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
@@ -384,6 +386,37 @@ func TestProcessPostHandshakeMessagesDecodeAlert(t *testing.T) {
 			assert.Zero(t, state.HandshakeRecvSequence)
 		})
 	}
+}
+
+func TestProcessPostHandshakeMessagesPreservesExtensionAlert(t *testing.T) {
+	wire, err := (&handshake.Handshake{
+		Message: &handshake.MessageNewSessionTicket{
+			Ticket: []byte{0x01},
+			Extensions: []extension.Value{
+				&extension13.MaxEarlyData{Size: 1},
+				&extension13.MaxEarlyData{Size: 2},
+			},
+		},
+	}).Marshal()
+	require.NoError(t, err)
+
+	state := dtlsstate.NewState13(true)
+	cache := dtlsflight.NewCache()
+	cache.Push(wire, dtlsflight13.EpochApplication, 0, handshake.TypeNewSessionTicket, false)
+	post := newPostHandshake(handshakeContext{
+		state: &state,
+		cache: cache,
+		cfg:   &dtlsconfig.HandshakeConfig{},
+	})
+	conn := &postHandshakeAlertConn{}
+
+	err = post.processPostHandshakeMessages(context.Background(), conn)
+	require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
+	assert.Equal(t, []postHandshakeAlert{{
+		level:       alert.Fatal,
+		description: alert.IllegalParameter,
+	}}, conn.notifications)
+	assert.Zero(t, state.HandshakeRecvSequence)
 }
 
 func TestHandleUnexpectedPostHandshakeMessageAlert(t *testing.T) {

--- a/internal/handshake/protected_flight.go
+++ b/internal/handshake/protected_flight.go
@@ -23,7 +23,7 @@ func VerifyAndAppendProtectedHandshakeCacheItems(
 	state *dtlsstate.State13,
 	cfg *dtlsconfig.HandshakeConfig,
 	cipherSuite dtlsconfig.CipherSuite,
-	items []*dtlsflight.HandshakeCacheItem,
+	items []dtlsflight.DecodedHandshakeCacheItem,
 ) error {
 	if transcript == nil {
 		return dtlserrors.ErrHandshakeTranscriptHashNotSelected
@@ -71,21 +71,21 @@ type protectedHandshakeFlight struct {
 	hasFinished          bool
 }
 
-func (f *protectedHandshakeFlight) process(item *dtlsflight.HandshakeCacheItem) error {
-	hs, err := parseProtectedHandshakeCacheItem(item)
-	if err != nil {
+func (f *protectedHandshakeFlight) process(item dtlsflight.DecodedHandshakeCacheItem) error {
+	if err := item.Validate(); err != nil {
 		return err
 	}
+	hs := item.Parsed
 
 	switch msg := hs.Message.(type) {
 	case *handshake.MessageCertificate13:
-		return f.processCertificate(item, hs, msg)
+		return f.processCertificate(item.Raw, hs, msg)
 	case *handshake.MessageCertificateVerify:
-		return f.processCertificateVerify(item, hs, msg)
+		return f.processCertificateVerify(item.Raw, hs, msg)
 	case *handshake.MessageFinished:
-		return f.processFinished(item, hs, msg)
+		return f.processFinished(item.Raw, hs, msg)
 	default:
-		return f.append(item, hs)
+		return f.append(item.Raw, hs)
 	}
 }
 
@@ -174,57 +174,6 @@ func (f *protectedHandshakeFlight) append(
 		parsedHandshake,
 		item.Data,
 	)
-}
-
-func parseProtectedHandshakeCacheItem(item *dtlsflight.HandshakeCacheItem) (*handshake.Handshake, error) {
-	if item == nil {
-		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
-	}
-
-	header := &handshake.Header{}
-	if err := header.Unmarshal(item.Data); err != nil {
-		return nil, err
-	}
-	if header.Type != item.Typ ||
-		header.MessageSequence != item.MessageSequence ||
-		header.FragmentOffset != 0 ||
-		header.FragmentLength != header.Length ||
-		len(item.Data) != handshake.HeaderLength+int(header.Length) {
-		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
-	}
-
-	msg, err := protectedHandshakeMessage(header.Type, item.Data[handshake.HeaderLength:])
-	if err != nil {
-		return nil, err
-	}
-
-	return &handshake.Handshake{
-		Header:  *header,
-		Message: msg,
-	}, nil
-}
-
-func protectedHandshakeMessage(typ handshake.Type, body []byte) (handshake.Message, error) {
-	var msg handshake.Message
-	switch typ {
-	case handshake.TypeEncryptedExtensions:
-		msg = &handshake.MessageEncryptedExtensions{}
-	case handshake.TypeCertificateRequest:
-		msg = &handshake.MessageCertificateRequest13{}
-	case handshake.TypeCertificate:
-		msg = &handshake.MessageCertificate13{}
-	case handshake.TypeCertificateVerify:
-		msg = &handshake.MessageCertificateVerify{}
-	case handshake.TypeFinished:
-		msg = &handshake.MessageFinished{}
-	default:
-		return nil, dtlserrors.ErrInvalidHandshakeTranscriptMessage
-	}
-	if err := msg.Unmarshal(body); err != nil {
-		return nil, err
-	}
-
-	return msg, nil
 }
 
 func rawCertificatesFromCertificate(certificate *handshake.MessageCertificate13) [][]byte {

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -528,17 +528,26 @@ func (t *Transcript) AppendVerifiedInbound(
 func AppendVerifiedInboundHandshakeCacheItems(
 	transcript *Transcript,
 	cipherSuite dtlsconfig.CipherSuite,
-	items []*dtlsflight.HandshakeCacheItem,
+	items []dtlsflight.DecodedHandshakeCacheItem,
 ) error {
 	if transcript == nil {
 		return nil
 	}
 
 	for _, item := range items {
-		if requiresExplicitAuthenticationBeforeTranscriptCommit(item.Typ) {
+		if err := item.Validate(); err != nil {
+			return err
+		}
+		if requiresExplicitAuthenticationBeforeTranscriptCommit(item.Raw.Typ) {
 			return dtlserrors.ErrHandshakeTranscriptExplicitAuthenticationRequired
 		}
-		if err := transcript.AppendVerifiedInbound(item.IsClient, cipherSuite, item.Data); err != nil {
+		if err := appendParsedInboundHandshake(
+			transcript,
+			item.Raw.IsClient,
+			cipherSuite,
+			item.Parsed,
+			item.Raw.Data,
+		); err != nil {
 			return err
 		}
 	}

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -181,18 +181,44 @@ func TestAppendVerifiedInboundHandshake13DuplicateHandling(t *testing.T) {
 func TestAppendVerifiedInboundHandshakeCacheItems13RequiresExplicitAuthentication(t *testing.T) {
 	transcript := NewTranscript()
 	rawFinished := rawHandshakeMessage13(t, 0, &handshake.MessageFinished{VerifyData: []byte{0x01}})
+	parsedFinished := &handshake.Handshake{}
+	require.NoError(t, parsedFinished.Unmarshal(rawFinished))
 
-	err := AppendVerifiedInboundHandshakeCacheItems(transcript, nil, []*dtlsflight.HandshakeCacheItem{
-		{
+	err := AppendVerifiedInboundHandshakeCacheItems(transcript, nil, []dtlsflight.DecodedHandshakeCacheItem{
+		{Raw: &dtlsflight.HandshakeCacheItem{
 			Typ:             handshake.TypeFinished,
 			MessageSequence: 0,
 			Data:            rawFinished,
-		},
+		}, Parsed: parsedFinished},
 	})
 	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptExplicitAuthenticationRequired)
 	assert.Empty(t, transcript.Bytes())
 	assert.Empty(t, transcript.pending)
 	assert.Empty(t, transcript.order)
+}
+
+func TestAppendVerifiedInboundHandshakeCacheItemsRejectsRawParsedMismatch(t *testing.T) {
+	transcript := NewTranscript()
+	rawEncryptedExtensions := rawHandshakeMessage13(t, 0, &handshake.MessageEncryptedExtensions{})
+	parsedFinished := &handshake.Handshake{}
+	require.NoError(t, parsedFinished.Unmarshal(rawHandshakeMessage13(
+		t,
+		0,
+		&handshake.MessageFinished{VerifyData: []byte{0x01}},
+	)))
+
+	err := AppendVerifiedInboundHandshakeCacheItems(transcript, nil, []dtlsflight.DecodedHandshakeCacheItem{
+		{
+			Raw: &dtlsflight.HandshakeCacheItem{
+				Typ:             handshake.TypeEncryptedExtensions,
+				MessageSequence: 0,
+				Data:            rawEncryptedExtensions,
+			},
+			Parsed: parsedFinished,
+		},
+	})
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidHandshakeTranscriptMessage)
+	assert.Empty(t, transcript.Bytes())
 }
 
 func TestHandshakeTranscript13RejectsInvalidCanonicalMessage(t *testing.T) {

--- a/internal/state/clone.go
+++ b/internal/state/clone.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 )
 
 // Clone13ForVerification returns a DTLS 1.3 state snapshot containing the
@@ -58,8 +59,8 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 		TrafficKeys:                state.TrafficKeys.Clone(),
 		KeyAgreementSecret:         bytes.Clone(state.KeyAgreementSecret),
 		SelectedGroup:              state.SelectedGroup,
-		LocalKeyEntries:            slices.Clone(state.LocalKeyEntries),
-		RemoteKeyEntries:           slices.Clone(state.RemoteKeyEntries),
+		LocalKeyEntries:            cloneKeyShareEntries(state.LocalKeyEntries),
+		RemoteKeyEntries:           cloneKeyShareEntries(state.RemoteKeyEntries),
 		HasRemoteKeyEntries:        state.HasRemoteKeyEntries,
 		RemoteGroups:               slices.Clone(state.RemoteGroups),
 		Cookie:                     bytes.Clone(state.Cookie),
@@ -68,6 +69,16 @@ func Clone13ForVerification(state *State13, peerCertificates [][]byte) *State13 
 		RemoteSignatureSchemes:     slices.Clone(state.RemoteSignatureSchemes),
 		RemoteCertSignatureSchemes: slices.Clone(state.RemoteCertSignatureSchemes),
 	}
+}
+
+func cloneKeyShareEntries(entries []extension13.KeyShareEntry) []extension13.KeyShareEntry {
+	cloned := make([]extension13.KeyShareEntry, len(entries))
+	for i := range entries {
+		cloned[i] = entries[i]
+		cloned[i].KeyExchange = bytes.Clone(entries[i].KeyExchange)
+	}
+
+	return cloned
 }
 
 func cloneKeySchedule(in KeySchedule) KeySchedule {

--- a/internal/state/state12.go
+++ b/internal/state/state12.go
@@ -7,6 +7,7 @@ import (
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 // State12 holds state that is meaningful only for DTLS 1.2.
@@ -36,6 +37,19 @@ type State12 struct {
 	LocalKeySignature          []byte
 
 	PeerCertificatesVerified bool
+
+	remoteServerKeyExchange *handshake.MessageServerKeyExchange
+}
+
+// SetRemoteServerKeyExchange retains the parsed server key exchange for the
+// remainder of the handshake.
+func (s *State12) SetRemoteServerKeyExchange(message *handshake.MessageServerKeyExchange) {
+	s.remoteServerKeyExchange = message
+}
+
+// RemoteServerKeyExchange returns the parsed server key exchange.
+func (s *State12) RemoteServerKeyExchange() *handshake.MessageServerKeyExchange {
+	return s.remoteServerKeyExchange
 }
 
 // ShouldWrapConnectionID reports whether outgoing DTLS 1.2 records should

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 type TrafficSecrets struct {
@@ -120,6 +121,10 @@ type State13 struct {
 
 	RemoteSignatureSchemes     []signaturehash.Algorithm // signature_algorithms from peer
 	RemoteCertSignatureSchemes []signaturehash.Algorithm // signature_algorithms_cert from peer
+
+	// RemoteCertificateRequest is the authenticated and decoded request
+	// kept for the client's final flight.
+	RemoteCertificateRequest *handshake.MessageCertificateRequest13
 }
 
 // ShouldWrapConnectionID reports whether outgoing records should use the


### PR DESCRIPTION
#### Description
caches complete handshake messages as parsed value, then reuse that value in future processing without parsing / decoding / validating again.

DTLS 1.3 protected messages were decoded for flight parsing, then decoded again for transcript/authentication. `CertificateRequest` was decoded again in flight 5.
DTLS 1.2 `ServerKeyExchange` was parsed in flight 3, then parsed again from cache bytes in flight 5.
Repeated cache pulls also reparsed generic handshake messages.
Now the raw bytes remain for transcript hashing, while consumers share the one parsed message.

part of #1021 and a follow up on #1024 

indirectly relates to #769  

part of #727 