### PR TITLE
Snapshot final clientHello offers

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -4343,7 +4343,7 @@ func TestDTLSDualStackClientRejectsNonClientHelloBeforeWrite(t *testing.T) {
 	defer cancel()
 
 	err = client.HandshakeContext(ctx)
-	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
 	assert.Equal(t, int32(0), writes.Load())
 }
 

--- a/internal/extensionnegotiation/negotiation.go
+++ b/internal/extensionnegotiation/negotiation.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package extensionnegotiation finalizes and retains ClientHello offers.
+package extensionnegotiation
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"slices"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+)
+
+// ClientHelloSnapshot is an immutable copy of a validated ClientHello body.
+type ClientHelloSnapshot struct {
+	body       []byte
+	extensions []extension.Raw
+}
+
+// Valid reports whether the snapshot contains a ClientHello.
+func (s ClientHelloSnapshot) Valid() bool { return len(s.body) != 0 }
+
+// Extension returns a copy of the extension with typ.
+func (s ClientHelloSnapshot) Extension(typ extension.Type) (extension.Raw, bool) {
+	for _, raw := range s.extensions {
+		if raw.Type == typ {
+			raw.Data = bytes.Clone(raw.Data)
+
+			return raw, true
+		}
+	}
+
+	return extension.Raw{}, false
+}
+
+// ClientHelloSnapshots retains the initial and most recent offers.
+// Its snapshots are immutable.
+type ClientHelloSnapshots struct {
+	initial ClientHelloSnapshot
+	current ClientHelloSnapshot
+}
+
+// Initial returns the initial offer.
+func (s ClientHelloSnapshots) Initial() ClientHelloSnapshot { return s.initial }
+
+// Current returns the most recent offer.
+func (s ClientHelloSnapshots) Current() ClientHelloSnapshot { return s.current }
+
+// Reset removes all retained offers.
+func (s *ClientHelloSnapshots) Reset() { *s = ClientHelloSnapshots{} }
+
+// Record retains snapshot as the current offer.
+func (s *ClientHelloSnapshots) Record(snapshot ClientHelloSnapshot) {
+	if !snapshot.Valid() {
+		return
+	}
+	if !s.initial.Valid() {
+		s.initial = snapshot
+	}
+	s.current = snapshot
+}
+
+// RecordWire retains the exact ClientHello body from an unfragmented DTLS
+// handshake.
+func (s *ClientHelloSnapshots) RecordWire(rawHandshake []byte) error {
+	var header handshake.Header
+	if err := header.Unmarshal(rawHandshake); err != nil {
+		return fmt.Errorf(
+			"%w: header: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
+	}
+	if header.Type != handshake.TypeClientHello ||
+		header.FragmentOffset != 0 || header.FragmentLength != header.Length ||
+		int(header.Length) != len(rawHandshake)-handshake.HeaderLength {
+		return fmt.Errorf(
+			"%w: invalid wire handshake: %w",
+			dtlserrors.ErrInvalidClientHello,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
+	}
+
+	snapshot, err := snapshotClientHello(rawHandshake[handshake.HeaderLength:])
+	if err != nil {
+		return fmt.Errorf(
+			"%w: wire handshake: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
+		)
+	}
+	s.Record(snapshot)
+
+	return nil
+}
+
+// FinalizeClientHello clones and validates a ClientHello before and after the
+// hook.
+func FinalizeClientHello(
+	base *handshake.MessageClientHello,
+	hook func(handshake.MessageClientHello) handshake.Message,
+) (*handshake.MessageClientHello, ClientHelloSnapshot, error) {
+	clientHello, err := canonicalClientHello(base)
+	if err != nil {
+		return nil, ClientHelloSnapshot{}, err
+	}
+
+	message := handshake.Message(clientHello)
+	if hook != nil {
+		message = hook(*clientHello)
+	}
+	clientHello, err = canonicalClientHello(message)
+	if err != nil {
+		return nil, ClientHelloSnapshot{}, err
+	}
+
+	body, err := clientHello.Marshal()
+	if err != nil {
+		return nil, ClientHelloSnapshot{}, fmt.Errorf(
+			"%w: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+	snapshot, err := snapshotClientHello(body)
+	if err != nil {
+		return nil, ClientHelloSnapshot{}, fmt.Errorf(
+			"%w: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+
+	return clientHello, snapshot, nil
+}
+
+func snapshotClientHello(body []byte) (ClientHelloSnapshot, error) {
+	extensionData, err := clientHelloExtensions(body)
+	if err != nil {
+		return ClientHelloSnapshot{}, err
+	}
+	extensions, err := extension.ParseList(extensionData)
+	if err != nil {
+		return ClientHelloSnapshot{}, fmt.Errorf("extensions: %w", err)
+	}
+
+	return ClientHelloSnapshot{body: bytes.Clone(body), extensions: extensions}, nil
+}
+
+func clientHelloExtensions(body []byte) ([]byte, error) {
+	if len(body) < 2+handshake.RandomLength {
+		return nil, dtlserrors.ErrBufferTooSmall
+	}
+
+	remainder := body[2+handshake.RandomLength:]
+	for _, width := range []int{1, 1, 2, 1} { // session ID, cookie, cipher suites, compression
+		if len(remainder) < width {
+			return nil, dtlserrors.ErrBufferTooSmall
+		}
+		length := int(remainder[0])
+		if width == 2 {
+			length = int(binary.BigEndian.Uint16(remainder))
+		}
+		if len(remainder)-width < length {
+			return nil, dtlserrors.ErrBufferTooSmall
+		}
+		remainder = remainder[width+length:]
+	}
+
+	return remainder, nil
+}
+
+func canonicalClientHello(message handshake.Message) (*handshake.MessageClientHello, error) {
+	clientHello, ok := message.(*handshake.MessageClientHello)
+	if !ok || clientHello == nil {
+		return nil, fmt.Errorf(
+			"%w: hook returned %T: %w",
+			dtlserrors.ErrInvalidClientHello,
+			message,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+	if slices.Contains(clientHello.CompressionMethods, nil) || containsNilExtension(clientHello.Extensions) {
+		return nil, fmt.Errorf(
+			"%w: hook returned a nil ClientHello value: %w",
+			dtlserrors.ErrInvalidClientHello,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+
+	raw, err := clientHello.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+	canonical := &handshake.MessageClientHello{}
+	if err := canonical.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf(
+			"%w: %w: %w",
+			dtlserrors.ErrInvalidClientHello,
+			err,
+			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
+		)
+	}
+
+	return canonical, nil
+}
+
+func containsNilExtension(values []extension.Value) bool {
+	for _, value := range values {
+		if value == nil {
+			return true
+		}
+		reflected := reflect.ValueOf(value)
+		if reflected.Kind() == reflect.Pointer && reflected.IsNil() {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/extensionnegotiation/negotiation_test.go
+++ b/internal/extensionnegotiation/negotiation_test.go
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extensionnegotiation
+
+import (
+	"bytes"
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const unknownExtensionType extension.Type = 0xfefe
+
+func clientHelloForTest(extensions ...extension.Value) *handshake.MessageClientHello {
+	return &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		SessionID:          []byte{0x01, 0x02},
+		CipherSuiteIDs:     []uint16{0x1301},
+		CompressionMethods: []*protocol.CompressionMethod{{}},
+		Extensions:         extensions,
+	}
+}
+
+func requireAlert(t *testing.T, err error, description alert.Description) {
+	t.Helper()
+
+	var protocolAlert *alert.Alert
+	require.ErrorAs(t, err, &protocolAlert)
+	assert.Equal(t, description, protocolAlert.Description)
+}
+
+func TestFinalizeClientHelloDetachesHookValues(t *testing.T) {
+	input := []byte{0x10}
+	base := clientHelloForTest(extension.Raw{Type: unknownExtensionType, Data: input})
+	var hookResult *handshake.MessageClientHello
+
+	final, snapshot, err := FinalizeClientHello(base, func(ch handshake.MessageClientHello) handshake.Message {
+		raw := ch.Extensions[0].(extension.Raw) //nolint:forcetypeassert
+		raw.Data[0] = 0x20
+		ch.Extensions[0] = raw
+		hookResult = &ch
+
+		return hookResult
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x10}, input)
+
+	hookRaw := hookResult.Extensions[0].(extension.Raw) //nolint:forcetypeassert
+	hookRaw.Data[0] = 0xff
+	finalRaw := final.Extensions[0].(extension.Raw) //nolint:forcetypeassert
+	assert.Equal(t, []byte{0x20}, finalRaw.Data)
+	snapshotRaw, ok := snapshot.Extension(unknownExtensionType)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x20}, snapshotRaw.Data)
+}
+
+func TestFinalizeClientHelloRejectsInvalidHookOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		hook        func(handshake.MessageClientHello) handshake.Message
+		want        error
+		description alert.Description
+	}{
+		{
+			name: "wrong message type",
+			hook: func(handshake.MessageClientHello) handshake.Message {
+				return &handshake.MessageServerHello{}
+			},
+			description: alert.InternalError,
+		},
+		{
+			name: "typed nil message",
+			hook: func(handshake.MessageClientHello) handshake.Message {
+				return (*handshake.MessageClientHello)(nil)
+			},
+			description: alert.InternalError,
+		},
+		{
+			name: "nil compression method",
+			hook: func(ch handshake.MessageClientHello) handshake.Message {
+				ch.CompressionMethods = []*protocol.CompressionMethod{nil}
+
+				return &ch
+			},
+			description: alert.InternalError,
+		},
+		{
+			name: "typed nil extension",
+			hook: func(ch handshake.MessageClientHello) handshake.Message {
+				ch.Extensions = []extension.Value{(*extension.ConnectionID)(nil)}
+
+				return &ch
+			},
+			description: alert.InternalError,
+		},
+		{
+			name: "duplicate extension",
+			hook: func(ch handshake.MessageClientHello) handshake.Message {
+				ch.Extensions = []extension.Value{&extension.ConnectionID{}, &extension.ConnectionID{}}
+
+				return &ch
+			},
+			want:        dtlserrors.ErrDuplicateExtension,
+			description: alert.IllegalParameter,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := FinalizeClientHello(clientHelloForTest(), test.hook)
+			require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+			if test.want != nil {
+				require.ErrorIs(t, err, test.want)
+			}
+			requireAlert(t, err, test.description)
+		})
+	}
+}
+
+func TestRecordWirePreservesExactClientHello(t *testing.T) {
+	clientHello := clientHelloForTest(&extension12.SupportedPointFormats{
+		PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed, 1},
+	})
+	clientHello.CompressionMethods = []*protocol.CompressionMethod{{ID: 0}, {ID: 0xfe}}
+	raw, err := (&handshake.Handshake{Message: clientHello}).Marshal()
+	require.NoError(t, err)
+	wantBody := bytes.Clone(raw[handshake.HeaderLength:])
+
+	var history ClientHelloSnapshots
+	require.NoError(t, history.RecordWire(raw))
+	snapshot := history.Current()
+	assert.Equal(t, wantBody, snapshot.body)
+	pointFormats, ok := snapshot.Extension(extension.TypeSupportedPointFormats)
+	require.True(t, ok)
+	assert.Equal(t, []byte{2, 0, 1}, pointFormats.Data)
+
+	raw[len(raw)-1] = 0xff
+	assert.Equal(t, wantBody, snapshot.body)
+}
+
+func TestRecordWireRejectsWrongHandshakeType(t *testing.T) {
+	raw, err := (&handshake.Handshake{Message: clientHelloForTest()}).Marshal()
+	require.NoError(t, err)
+	raw[0] = byte(handshake.TypeServerHello)
+
+	var history ClientHelloSnapshots
+	err = history.RecordWire(raw)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+	requireAlert(t, err, alert.DecodeError)
+}
+
+func TestClientHelloSnapshotsRetainInitialAndCurrentOffers(t *testing.T) {
+	var history ClientHelloSnapshots
+	for _, value := range []byte{0x01, 0x02} {
+		_, snapshot, err := FinalizeClientHello(
+			clientHelloForTest(extension.Raw{Type: unknownExtensionType, Data: []byte{value}}), nil,
+		)
+		require.NoError(t, err)
+		history.Record(snapshot)
+	}
+
+	initial, ok := history.Initial().Extension(unknownExtensionType)
+	require.True(t, ok)
+	current, ok := history.Current().Extension(unknownExtensionType)
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x01}, initial.Data)
+	assert.Equal(t, []byte{0x02}, current.Data)
+
+	initial.Data[0] = 0xff
+	initial, _ = history.Initial().Extension(unknownExtensionType)
+	assert.Equal(t, []byte{0x01}, initial.Data)
+}

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -151,6 +151,11 @@ func flight0Parse(
 		}
 	}
 
+	state.RemoteClientHelloSnapshots.Reset()
+	if err := state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+		return 0, nil, err
+	}
+
 	nextFlight := Flight2
 
 	if cfg.InsecureSkipHelloVerify {

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -9,6 +9,7 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
@@ -70,6 +71,8 @@ func flight1Generate(
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
+	state.LocalClientHelloSnapshots.Reset()
+
 	var zeroEpoch uint16
 	state.SetLocalEpoch(zeroEpoch)
 	state.SetRemoteEpoch(zeroEpoch)
@@ -88,14 +91,13 @@ func flight1Generate(
 		state.LocalRandom.RandomBytes = cfg.HelloRandomBytesGenerator()
 	}
 
-	extensions := []extension.Value{
-		&extension.SignatureAlgorithms{
+	var extensions []extension.Value
+	if len(cfg.LocalSignatureSchemes) > 0 {
+		extensions = append(extensions, &extension.SignatureAlgorithms{
 			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
-		},
-		&extension12.RenegotiationInfo{
-			RenegotiatedConnection: 0,
-		},
+		})
 	}
+	extensions = append(extensions, &extension12.RenegotiationInfo{RenegotiatedConnection: 0})
 
 	if len(cfg.LocalCertSignatureSchemes) > 0 {
 		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
@@ -174,13 +176,12 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	var content handshake.Handshake
-
-	if cfg.ClientHelloMessageHook != nil {
-		content = handshake.Handshake{Message: cfg.ClientHelloMessageHook(*clientHello)}
-	} else {
-		content = handshake.Handshake{Message: clientHello}
+	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	if err != nil {
+		return nil, nil, err
 	}
+	state.LocalClientHelloSnapshots.Record(snapshot)
+	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{
 		{

--- a/internal/flight/flight12/flight2handler.go
+++ b/internal/flight/flight12/flight2handler.go
@@ -55,6 +55,10 @@ func flight2Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlserrors.ErrCookieMismatch
 	}
 
+	if err := state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+		return 0, nil, err
+	}
+
 	return Flight4, nil, nil
 }
 

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
@@ -301,20 +302,20 @@ func handleServerKeyExchange(
 	return nil, nil //nolint:nilnil
 }
 
+//nolint:cyclop
 func flight3Generate(
 	_ dtlsflight.Conn,
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	extensions := []extension.Value{
-		&extension.SignatureAlgorithms{
+	var extensions []extension.Value
+	if len(cfg.LocalSignatureSchemes) > 0 {
+		extensions = append(extensions, &extension.SignatureAlgorithms{
 			Schemes: dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes),
-		},
-		&extension12.RenegotiationInfo{
-			RenegotiatedConnection: 0,
-		},
+		})
 	}
+	extensions = append(extensions, &extension12.RenegotiationInfo{RenegotiatedConnection: 0})
 
 	if len(cfg.LocalCertSignatureSchemes) > 0 {
 		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
@@ -370,13 +371,12 @@ func flight3Generate(
 		Extensions:         extensions,
 	}
 
-	var content handshake.Handshake
-
-	if cfg.ClientHelloMessageHook != nil {
-		content = handshake.Handshake{Message: cfg.ClientHelloMessageHook(*clientHello)}
-	} else {
-		content = handshake.Handshake{Message: clientHello}
+	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	if err != nil {
+		return nil, nil, err
 	}
+	state.LocalClientHelloSnapshots.Record(snapshot)
+	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{
 		{

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestFlight3GenerateReusesHookOnlyConnectionIDAfterVersionDowngrade(t *testing.T) {
 	for name, cid := range map[string][]byte{
-		"Empty":    nil,
+		"Empty":    {},
 		"NonEmpty": {0xcc},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/flight/flight13/extensions.go
+++ b/internal/flight/flight13/extensions.go
@@ -154,59 +154,20 @@ func connectionIDExtension(extensions []extension.Value) ([]byte, bool, bool) {
 
 func captureClientHelloConnectionIDOffer(
 	state *dtlsstate.State13,
-	message handshake.Message,
-) error {
-	clientHello, ok := message.(*handshake.MessageClientHello)
-	if !ok {
-		state.SetLocalConnectionID(nil)
-		state.LocalCIDOffered = false
-
-		return nil
-	}
-
-	localCID, present, duplicate := connectionIDExtension(clientHello.Extensions)
-	if duplicate {
-		state.SetLocalConnectionID(nil)
-		state.LocalCIDOffered = false
-
-		return dtlserrors.ErrInvalidClientHello
-	}
-	if !present {
-		state.SetLocalConnectionID(nil)
-		state.LocalCIDOffered = false
-
-		return nil
-	}
-
+	clientHello *handshake.MessageClientHello,
+) {
+	localCID, present, _ := connectionIDExtension(clientHello.Extensions)
 	state.SetLocalConnectionID(localCID)
-	state.LocalCIDOffered = true
-
-	return nil
+	state.LocalCIDOffered = present
 }
 
 func validateRepeatedClientHelloConnectionIDOffer(
 	state *dtlsstate.State13,
-	message handshake.Message,
+	clientHello *handshake.MessageClientHello,
 ) error {
-	clientHello, ok := message.(*handshake.MessageClientHello)
-	if !ok {
-		state.SetLocalConnectionID(nil)
-		state.LocalCIDOffered = false
-
-		return nil
-	}
-
-	localCID, present, duplicate := connectionIDExtension(clientHello.Extensions)
-	expectedCID := state.LocalConnectionID()
-	expectedPresent := state.LocalCIDOffered
-	if duplicate {
-		return fmt.Errorf("%w: duplicate connection_id extension", dtlserrors.ErrInvalidClientHello)
-	}
-	if present != expectedPresent {
-		return fmt.Errorf("%w: unexpected connection_id extension", dtlserrors.ErrInvalidClientHello)
-	}
-	if !bytes.Equal(localCID, expectedCID) {
-		return fmt.Errorf("%w: unexpected connection_id value", dtlserrors.ErrInvalidClientHello)
+	localCID, present, _ := connectionIDExtension(clientHello.Extensions)
+	if present != state.LocalCIDOffered || !bytes.Equal(localCID, state.LocalConnectionID()) {
+		return fmt.Errorf("%w: connection_id changed", dtlserrors.ErrInvalidClientHello)
 	}
 
 	return nil

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -45,6 +45,7 @@ func flight0Parse(
 	// Connection Identifiers must be negotiated afresh on session resumption.
 	// https://datatracker.ietf.org/doc/html/rfc9146#name-the-connection_id-extension
 	state.ResetConnectionIDs()
+	state.RemoteClientHelloSnapshots.Reset()
 
 	state.HandshakeRecvSequence = pull.NextSequence
 
@@ -58,7 +59,6 @@ func flight0Parse(
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 			dtlserrors.ErrUnsupportedProtocolVersion
 	}
-
 	state.RemoteRandom = clientHello.Random
 
 	cipherSuites := []dtlsconfig.CipherSuite{}
@@ -105,6 +105,9 @@ func flight0Parse(
 		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, pull.Items); err != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
+	}
+	if err := state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+		return 0, nil, err
 	}
 
 	return nextFlight, nil, nil

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -10,6 +10,7 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -29,6 +30,7 @@ func flight1Generate(
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 	state.ResetConnectionIDs()
+	state.LocalClientHelloSnapshots.Reset()
 
 	state.SetLocalEpoch(EpochInitial)
 	state.SetRemoteEpoch(EpochInitial)
@@ -148,14 +150,15 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	message := handshake.Message(clientHello)
-	if cfg.ClientHelloMessageHook != nil {
-		message = cfg.ClientHelloMessageHook(*clientHello)
-	}
-	if err := captureClientHelloConnectionIDOffer(state, message); err != nil {
+	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	if err != nil {
+		state.ResetConnectionIDs()
+
 		return nil, nil, err
 	}
-	content := handshake.Handshake{Message: message}
+	captureClientHelloConnectionIDOffer(state, clientHello)
+	state.LocalClientHelloSnapshots.Record(snapshot)
+	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{
 		{

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -43,7 +43,6 @@ func flight2Parse( //nolint:cyclop
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 			dtlserrors.ErrUnsupportedProtocolVersion
 	}
-
 	cookie := clientHelloCookie(clientHello.Extensions)
 
 	if len(cookie) == 0 {
@@ -64,6 +63,9 @@ func flight2Parse( //nolint:cyclop
 	}
 	if failure := flightCtx.handleInboundHandshake(pull.Items); failure != nil {
 		return 0, failure.alert, failure.err
+	}
+	if err := flightCtx.state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+		return 0, nil, err
 	}
 	flightCtx.state.HandshakeRecvSequence = pull.NextSequence
 

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -11,6 +11,7 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
@@ -388,14 +389,18 @@ func flight3Generate(
 		Extensions:         extensions,
 	}
 
-	message := handshake.Message(clientHello)
-	if flightCtx.cfg.ClientHelloMessageHook != nil {
-		message = flightCtx.cfg.ClientHelloMessageHook(*clientHello)
-	}
-	if err := validateRepeatedClientHelloConnectionIDOffer(flightCtx.state, message); err != nil {
+	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(
+		clientHello,
+		flightCtx.cfg.ClientHelloMessageHook,
+	)
+	if err != nil {
 		return nil, nil, err
 	}
-	content := handshake.Handshake{Message: message}
+	if err := validateRepeatedClientHelloConnectionIDOffer(flightCtx.state, clientHello); err != nil {
+		return nil, nil, err
+	}
+	flightCtx.state.LocalClientHelloSnapshots.Record(snapshot)
+	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{
 		{

--- a/internal/state/common.go
+++ b/internal/state/common.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
@@ -63,6 +64,11 @@ type Common struct {
 	LocalVersion protocol.Version
 	// RemoteVersions are the DTLS versions advertised by the peer.
 	RemoteVersions []protocol.Version
+
+	// ClientHello snapshots are transient negotiation state.
+	// they aren't serialized with resumable connection state.
+	LocalClientHelloSnapshots  extensionnegotiation.ClientHelloSnapshots
+	RemoteClientHelloSnapshots extensionnegotiation.ClientHelloSnapshots
 }
 
 func (s *Common) RemoteEpoch() uint16 {


### PR DESCRIPTION
#### Description
Validate ClientHello hook output before sending, builds on #1025 and #1024 and is part of #2021 and  #727
this stores initial / current ClientHello snapshots in transient common state and captures incoming and outgoing CH1/CH2 in DTLS 1.2 and 1.3 flights. 
by extension of the change, this does:
Simplifies CID hook checks. relates to #775 and #1026
Avoid emitting an invalid empty signature_algorithms extension (this bug exists in v3)
adds snapshot and hook-validation, which will be the final foundation for common DTLS 1.2 and 1.3 extension validation in one place outside of flights.
