### PR TITLE
Reject unsolicited ServerHello extensions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pion/dtls/v3/internal/closer"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight12 "github.com/pion/dtls/v3/internal/flight/flight12"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
@@ -2428,6 +2429,13 @@ func (c *Conn) pickVersionFromServerResponse() (bool, error) {
 }
 
 func (c *Conn) pickVersionFromServerHello(sh *handshake.MessageServerHello) error {
+	common := dtlsstate.CommonState(c.state)
+	if err := extensionnegotiation.ValidateServerHelloResponse(
+		common.LocalClientHelloSnapshots.Current(),
+		sh,
+	); err != nil {
+		return err
+	}
 	remote, err := remoteVersionsFromServerHello(sh)
 	if err != nil {
 		return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
@@ -2385,6 +2386,38 @@ func testVersionNegotiationHandshakeConfig13(t *testing.T) *dtlsconfig.Handshake
 		LocalCertSignatureSchemes:   nil,
 		LocalSRTPProtectionProfiles: nil,
 	}
+}
+
+func TestPickVersionFromServerHelloRejectsUnsolicitedExtension(t *testing.T) {
+	const offeredType extension.Type = 0xfefe
+	_, offer, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CipherSuiteIDs:     []uint16{0x1301},
+		CompressionMethods: []*protocol.CompressionMethod{{}},
+		Extensions:         []extension.Value{extension.Raw{Type: offeredType, Data: []byte{0x01}}},
+	}, nil)
+	require.NoError(t, err)
+
+	cfg := testVersionNegotiationHandshakeConfig13(t)
+	cfg.MinVersion = protocol.Version1_2
+	common := &dtlsstate.Common{}
+	common.LocalClientHelloSnapshots.Record(offer)
+	conn := &Conn{
+		handshakeConfig: cfg,
+		state:           &dtlsstate.State13{Common: common},
+	}
+	err = conn.pickVersionFromServerHello(&handshake.MessageServerHello{
+		Version: protocol.Version1_2,
+		Extensions: []extension.Value{
+			extension.Raw{Type: 0xfefd, Data: []byte{0x02}},
+		},
+	})
+
+	require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+	var classified *alert.Alert
+	require.ErrorAs(t, err, &classified)
+	assert.Equal(t, alert.UnsupportedExtension, classified.Description)
+	assert.Equal(t, protocol.Version{}, common.LocalVersion)
 }
 
 func TestPickVersionFromServerResponseRejectsHelloRetryRequestWithoutSupportedVersions(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -252,8 +252,10 @@ var (
 		"certificate list must not be longer than 2^24-1 bytes",
 	)
 	ErrInvalidExtensionsLength             = stderrors.New("extensions data must be between 2 and 2^16-1 bytes")
+	ErrNilExtension                        = stderrors.New("extension must not be nil")
 	ErrDuplicateExtension                  = stderrors.New("duplicate extension")
 	ErrExtensionNotAllowed                 = stderrors.New("extension is not allowed in this handshake message")
+	ErrUnsolicitedExtension                = stderrors.New("server sent an extension that was not offered")
 	ErrPreSharedKeyNotLast                 = stderrors.New("pre_shared_key must be the last ClientHello extension")
 	ErrMissingPSKKeyExchangeModesExtension = stderrors.New(
 		"pre_shared_key requires psk_key_exchange_modes",

--- a/internal/extensionnegotiation/negotiation.go
+++ b/internal/extensionnegotiation/negotiation.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"reflect"
 	"slices"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -108,7 +107,7 @@ func FinalizeClientHello(
 	base *handshake.MessageClientHello,
 	hook func(handshake.MessageClientHello) handshake.Message,
 ) (*handshake.MessageClientHello, ClientHelloSnapshot, error) {
-	clientHello, err := canonicalClientHello(base)
+	clientHello, err := validatedClientHello(base)
 	if err != nil {
 		return nil, ClientHelloSnapshot{}, err
 	}
@@ -117,7 +116,7 @@ func FinalizeClientHello(
 	if hook != nil {
 		message = hook(*clientHello)
 	}
-	clientHello, err = canonicalClientHello(message)
+	clientHello, err = validatedClientHello(message)
 	if err != nil {
 		return nil, ClientHelloSnapshot{}, err
 	}
@@ -180,7 +179,65 @@ func clientHelloExtensions(body []byte) ([]byte, error) {
 	return remainder, nil
 }
 
-func canonicalClientHello(message handshake.Message) (*handshake.MessageClientHello, error) {
+// ValidateServerHelloResponse validates response types against the exact final ClientHello
+// offer.
+//
+// DTLS 1.2:
+// "An extension type MUST NOT appear in the ServerHello unless the same
+// extension type appeared in the corresponding ClientHello."
+//
+// https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.4
+//
+// DTLS 1.3:
+// "Implementations MUST NOT send extension responses (i.e., in the ServerHello,
+// EncryptedExtensions, HelloRetryRequest, and Certificate messages)
+// if the remote endpoint did not send the corresponding extension requests"
+// https://www.rfc-editor.org/info/rfc9846/#section-4.3
+//
+// DTLS 1.2 exception:
+// "sending a "renegotiation_info" extension in response to a ClientHello
+// containing only the SCSV is an explicit exception"
+//
+// https://www.rfc-editor.org/rfc/rfc5746#section-3.6
+func ValidateServerHelloResponse(
+	offer ClientHelloSnapshot,
+	serverHello *handshake.MessageServerHello,
+) error {
+	random := serverHello.Random.MarshalFixed()
+	isHelloRetryRequest := bytes.Equal(random[:], handshake.HelloRetryRequestRandom())
+	offeredTypes := make(map[extension.Type]struct{}, len(offer.extensions))
+	for _, value := range offer.extensions {
+		offeredTypes[value.Type] = struct{}{}
+	}
+
+	for _, value := range serverHello.Extensions {
+		typ := value.ExtensionType()
+		_, offered := offeredTypes[typ]
+		if offered ||
+			(isHelloRetryRequest && typ == extension.TypeCookie) ||
+			(!isHelloRetryRequest && typ == extension.TypeRenegotiationInfo &&
+				clientHelloHasCipherSuite(offer, 0x00ff)) {
+			continue
+		}
+
+		return fmt.Errorf(
+			"extension %d: %w: %w",
+			typ,
+			dtlserrors.ErrUnsolicitedExtension,
+			&alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
+		)
+	}
+
+	return nil
+}
+
+func clientHelloHasCipherSuite(offer ClientHelloSnapshot, id uint16) bool {
+	var clientHello handshake.MessageClientHello
+
+	return clientHello.Unmarshal(offer.body) == nil && slices.Contains(clientHello.CipherSuiteIDs, id)
+}
+
+func validatedClientHello(message handshake.Message) (*handshake.MessageClientHello, error) {
 	clientHello, ok := message.(*handshake.MessageClientHello)
 	if !ok || clientHello == nil {
 		return nil, fmt.Errorf(
@@ -190,7 +247,7 @@ func canonicalClientHello(message handshake.Message) (*handshake.MessageClientHe
 			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
 		)
 	}
-	if slices.Contains(clientHello.CompressionMethods, nil) || containsNilExtension(clientHello.Extensions) {
+	if slices.Contains(clientHello.CompressionMethods, nil) {
 		return nil, fmt.Errorf(
 			"%w: hook returned a nil ClientHello value: %w",
 			dtlserrors.ErrInvalidClientHello,
@@ -218,18 +275,4 @@ func canonicalClientHello(message handshake.Message) (*handshake.MessageClientHe
 	}
 
 	return canonical, nil
-}
-
-func containsNilExtension(values []extension.Value) bool {
-	for _, value := range values {
-		if value == nil {
-			return true
-		}
-		reflected := reflect.ValueOf(value)
-		if reflected.Kind() == reflect.Pointer && reflected.IsNil() {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/extensionnegotiation/negotiation_test.go
+++ b/internal/extensionnegotiation/negotiation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,20 @@ func clientHelloForTest(extensions ...extension.Value) *handshake.MessageClientH
 		CompressionMethods: []*protocol.CompressionMethod{{}},
 		Extensions:         extensions,
 	}
+}
+
+func snapshotForTest(
+	t *testing.T,
+	cipherSuiteIDs []uint16,
+	extensions ...extension.Value,
+) ClientHelloSnapshot {
+	t.Helper()
+	clientHello := clientHelloForTest(extensions...)
+	clientHello.CipherSuiteIDs = cipherSuiteIDs
+	_, snapshot, err := FinalizeClientHello(clientHello, nil)
+	require.NoError(t, err)
+
+	return snapshot
 }
 
 func requireAlert(t *testing.T, err error, description alert.Description) {
@@ -94,9 +109,9 @@ func TestFinalizeClientHelloRejectsInvalidHookOutput(t *testing.T) {
 			description: alert.InternalError,
 		},
 		{
-			name: "typed nil extension",
+			name: "nil extension",
 			hook: func(ch handshake.MessageClientHello) handshake.Message {
-				ch.Extensions = []extension.Value{(*extension.ConnectionID)(nil)}
+				ch.Extensions = []extension.Value{nil}
 
 				return &ch
 			},
@@ -178,4 +193,75 @@ func TestClientHelloSnapshotsRetainInitialAndCurrentOffers(t *testing.T) {
 	initial.Data[0] = 0xff
 	initial, _ = history.Initial().Extension(unknownExtensionType)
 	assert.Equal(t, []byte{0x01}, initial.Data)
+}
+
+func TestValidateServerHelloResponse(t *testing.T) {
+	tests := map[string]struct {
+		offer       ClientHelloSnapshot
+		serverHello *handshake.MessageServerHello
+		wantError   bool
+	}{
+		"offered extension": {
+			offer: snapshotForTest(t, []uint16{0x1301},
+				&extension.ALPNOffer{Protocols: []string{"webrtc"}},
+			),
+			serverHello: serverHelloForTest(&extension.ALPNSelection{Protocol: "webrtc"}),
+		},
+		"offered unknown response": {
+			offer: snapshotForTest(t, []uint16{0x1301},
+				extension.Raw{Type: unknownExtensionType, Data: []byte{0x01}},
+			),
+			serverHello: serverHelloForTest(extension.Raw{Type: unknownExtensionType, Data: []byte{0x02}}),
+		},
+		"HRR cookie exception": {
+			offer:       snapshotForTest(t, []uint16{0x1301}),
+			serverHello: helloRetryRequestForTest(&extension13.Cookie{Cookie: []byte{0x01}}),
+		},
+		"SCSV renegotiation exception": {
+			offer:       snapshotForTest(t, []uint16{0x00ff}),
+			serverHello: serverHelloForTest(&extension12.RenegotiationInfo{}),
+		},
+		"unsolicited known response": {
+			offer:       snapshotForTest(t, []uint16{0x1301}),
+			serverHello: serverHelloForTest(&extension.ConnectionID{}),
+			wantError:   true,
+		},
+		"unsolicited unknown response": {
+			offer:       snapshotForTest(t, []uint16{0x1301}),
+			serverHello: serverHelloForTest(extension.Raw{Type: unknownExtensionType}),
+			wantError:   true,
+		},
+		"renegotiation without SCSV": {
+			offer:       snapshotForTest(t, []uint16{0x1301}),
+			serverHello: serverHelloForTest(&extension12.RenegotiationInfo{}),
+			wantError:   true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateServerHelloResponse(test.offer, test.serverHello)
+			if !test.wantError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+			requireAlert(t, err, alert.UnsupportedExtension)
+		})
+	}
+}
+
+func serverHelloForTest(extensions ...extension.Value) *handshake.MessageServerHello {
+	return &handshake.MessageServerHello{Extensions: extensions}
+}
+
+func helloRetryRequestForTest(extensions ...extension.Value) *handshake.MessageServerHello {
+	serverHello := serverHelloForTest(extensions...)
+	var hrrRandom [handshake.RandomLength]byte
+	copy(hrrRandom[:], handshake.HelloRetryRequestRandom())
+	serverHello.Random.UnmarshalFixed(hrrRandom)
+
+	return serverHello
 }

--- a/pkg/protocol/extension/raw.go
+++ b/pkg/protocol/extension/raw.go
@@ -108,6 +108,10 @@ func MarshalList(values []Value) ([]byte, error) {
 	payloads := make([][]byte, len(values))
 	totalLen := 0
 	for i, value := range values {
+		if value == nil {
+			return nil, dtlserrors.ErrNilExtension
+		}
+
 		payload, err := value.MarshalData()
 		if err != nil {
 			return nil, err

--- a/pkg/protocol/extension/raw_test.go
+++ b/pkg/protocol/extension/raw_test.go
@@ -68,6 +68,11 @@ func TestMarshalListBounds(t *testing.T) {
 	assert.ErrorIs(t, err, dtlserrors.ErrInvalidExtensionsLength)
 }
 
+func TestMarshalListRejectsNilExtension(t *testing.T) {
+	_, err := MarshalList([]Value{nil})
+	assert.ErrorIs(t, err, dtlserrors.ErrNilExtension)
+}
+
 func FuzzParseList(f *testing.F) {
 	f.Add([]byte{0x00, 0x00})
 	f.Add([]byte{0x00, 0x04, 0xfa, 0xce, 0x00, 0x00})


### PR DESCRIPTION
#### Description
Enforces both the 1.2 and 1.3 specs and rejects unsolicited ServerHello extensions in responses  (currently only enforced in the dual mode #1005  ). does a cleanup after #1027 and removes some temporary code i added to get snapshots merged (e.g the use of stdlib "reflects" in the snapshot code, I moved the nil check to the new API before Type so we don't have to use reflects #1009 ). part of #1021 