### PR TITLE
Validate ServerHello extensions against ClientHello

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -858,6 +858,7 @@ func testPionE2ESimpleServerHelloHook(t *testing.T, server, client func(*comm), 
 
 		clientOpts := []dtls.ClientOption{
 			dtls.WithCertificates(cert),
+			dtls.WithSupportedProtocols(apln),
 			dtls.WithVerifyConnection(func(s *dtls.State) error {
 				if s.NegotiatedProtocol != apln {
 					return errHookAPLNFailed

--- a/flight_test.go
+++ b/flight_test.go
@@ -876,6 +876,12 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	)
 
 	state := newTestState13(false)
+	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{
+		state: state,
+		cfg:   cfg,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
 	cache := dtlsflight.NewCache()
 	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
 
@@ -893,6 +899,35 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.Equal(t, selectedGroup, entries[0].Group)
 	assert.Empty(t, entries[0].KeyExchange)
+}
+
+func TestFlight13_1ParseRejectsUnsolicitedHelloRetryRequestExtension(t *testing.T) {
+	cfg := testHandshakeConfig13(t)
+	state := newTestState13(false)
+	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{
+		state: state,
+		cfg:   cfg,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+
+	rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Value{
+		&extension13.SelectedVersion{Version: protocol.Version1_3},
+		extension.Raw{Type: 0xfafa},
+	})
+	cache := dtlsflight.NewCache()
+	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
+
+	nextFlight, dtlsAlert, err := flight13ParseForTest(
+		t, dtlsflight13.Flight1, context.Background(), &handshakeTestContext13{
+			state: state,
+			cache: cache,
+			cfg:   cfg,
+		})
+
+	require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
+	assert.Zero(t, nextFlight)
 }
 
 func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *testing.T) {
@@ -2132,8 +2167,14 @@ func TestFlight13_3ParseRejectsMissingKeyShare(t *testing.T) {
 func TestFlight13_3ParseRejectsUnofferedKeyShareGroup(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := newTestState13(false)
+	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{
+		state: state,
+		cfg:   cfg,
+	})
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
 
-	group := cfg.EllipticCurves[0]
+	group := elliptic.X25519MLKEM768
 	serverKeypair, err := elliptic.GenerateKeypair(group)
 	require.NoError(t, err)
 
@@ -4040,7 +4081,7 @@ func TestFlight13_3ParseRejectsUnsolicitedConnectionID(t *testing.T) {
 				t, false, nil, [][]byte{cid},
 			)
 
-			require.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
+			require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
 			require.NotNil(t, dtlsAlert)
 			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
 			assert.Zero(t, nextFlight)

--- a/internal/flight/flight12/flight1handler_test.go
+++ b/internal/flight/flight12/flight1handler_test.go
@@ -12,6 +12,7 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
@@ -57,11 +58,15 @@ func TestFlight1_Process_RejectsInvalidLateServerFlight(t *testing.T) { //nolint
 	cache := dtlsflight.NewCache()
 	cfg := &dtlsconfig.HandshakeConfig{
 		LocalSRTPProtectionProfiles: []dtlsconfig.SRTPProtectionProfile{extension.SRTP_AEAD_AES_128_GCM},
+		EllipticCurves:              []elliptic.Curve{elliptic.X25519},
+		ExtendedMasterSecret:        dtlsconfig.RequestExtendedMasterSecret,
 	}
 	cfg.LocalCipherSuites = []dtlsconfig.CipherSuite{
 		ciphersuite.ForID(ciphersuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, nil),
 	}
 	cfg.Log = logging.NewDefaultLoggerFactory().NewLogger("dtls")
+	_, _, err := flight1Generate(mockConn, state, cache, cfg)
+	assert.NoError(t, err)
 
 	serverHello := []byte{
 		0x02, 0x00, 0x00, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -68,6 +68,12 @@ func flight3Parse(
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
+		if err := extensionnegotiation.ValidateServerHelloResponse(
+			state.LocalClientHelloSnapshots.Current(), serverHelloMsg,
+		); err != nil {
+			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
+				err
+		}
 		for _, v := range serverHelloMsg.Extensions {
 			switch ext := v.(type) {
 			case *extension.SRTPSelection:

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -4,11 +4,18 @@
 package flight12
 
 import (
+	"context"
 	"testing"
 
+	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
@@ -73,4 +80,35 @@ func TestFlight3GenerateRestoresCurveExtensionsAfterVersionDowngrade(t *testing.
 	assert.Contains(t, clientHello.Extensions, &extension12.SupportedPointFormats{
 		PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 	})
+}
+
+func TestFlight3RejectsUnsolicitedServerHelloExtension(t *testing.T) {
+	state := newTestState12()
+	clientHello := &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		CipherSuiteIDs:     []uint16{uint16(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)},
+		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+	}
+	_, offer, err := extensionnegotiation.FinalizeClientHello(clientHello, nil)
+	assert.NoError(t, err)
+	state.LocalClientHelloSnapshots.Record(offer)
+
+	cipherSuiteID := uint16(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+	raw, err := (&handshake.Handshake{Message: &handshake.MessageServerHello{
+		Version:           protocol.Version1_2,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		Extensions: []extension.Value{
+			extension.Raw{Type: 0xfafa},
+		},
+	}}).Marshal()
+	assert.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(raw, 0, 0, handshake.TypeServerHello, false)
+
+	_, dtlsAlert, err := parseForTest(
+		t, Flight3, context.Background(), nil, state, cache, &dtlsconfig.HandshakeConfig{},
+	)
+	assert.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
 }

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -228,9 +228,11 @@ func flight1Parse(
 
 		return 0, &alert.Alert{Level: alert.Fatal, Description: description}, err
 	}
-	if _, present, duplicate := connectionIDExtension(sh.Extensions); present || duplicate {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter},
-			dtlserrors.ErrInvalidHelloRetryRequest
+	if err := extensionnegotiation.ValidateServerHelloResponse(
+		state.LocalClientHelloSnapshots.Current(), sh,
+	); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
+			err
 	}
 	selectedCipherSuite, dtlsAlert, err := selectServerHelloCipherSuite(sh, cfg)
 	if err != nil {

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -129,12 +129,14 @@ func processFlight3ServerHello(
 	if failure != nil {
 		return failure
 	}
+	if err := extensionnegotiation.ValidateServerHelloResponse(
+		flightCtx.state.LocalClientHelloSnapshots.Current(), serverHello,
+	); err != nil {
+		return newFlightParseFailure(alert.UnsupportedExtension, err)
+	}
 	remoteCID, hasRemoteCID, duplicateCID := connectionIDExtension(serverHello.Extensions)
 	if duplicateCID {
 		return newFlightParseFailure(alert.IllegalParameter, dtlserrors.ErrInvalidServerHello)
-	}
-	if hasRemoteCID && !flightCtx.state.LocalCIDOffered {
-		return newFlightParseFailure(alert.UnsupportedExtension, dtlserrors.ErrInvalidServerHello)
 	}
 	flightCtx.state.RemoteVersions = versions
 	flightCtx.state.LocalVersion = protocol.Version1_3


### PR DESCRIPTION
#### Description
This applies the ServerHello extensions validations added in #1028 in single 1.2 and 1.3 modes, and updates the E2E test to reflect these changes (the client didn't negotiate ALPN and it accepted the server's ServerHello with ALPN).
Part of #1021 

The test are failing because we don't send curves extensions in ClientHello when we downgrade to 1.2 from dual state mode.... I made a PR to fix it https://github.com/pion/dtls/pull/1030