### PR TITLE
Restore curves after daul-stack fallback

### DIFF
--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -323,6 +323,12 @@ func flight3Generate(
 		})
 	}
 
+	if state.NamedCurve == 0 {
+		if curves := supportedEllipticCurves(cfg.EllipticCurves); len(curves) > 0 {
+			state.NamedCurve = curves[0]
+		}
+	}
+
 	if state.NamedCurve != 0 {
 		ellipticCurves := supportedEllipticCurves(cfg.EllipticCurves)
 

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -8,7 +8,9 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,4 +53,24 @@ func TestFlight3GenerateReusesHookOnlyConnectionIDAfterVersionDowngrade(t *testi
 			assert.Equal(t, cid, connectionIDs[0])
 		})
 	}
+}
+
+func TestFlight3GenerateRestoresCurveExtensionsAfterVersionDowngrade(t *testing.T) {
+	state13 := dtlsstate.NewState13(true)
+	state := dtlsstate.Activate12(&state13)
+	cfg := &dtlsconfig.HandshakeConfig{EllipticCurves: []elliptic.Curve{elliptic.X25519}}
+
+	packets, dtlsAlert, err := generateForTest(t, Flight3, nil, state, nil, cfg)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, elliptic.X25519, state.NamedCurve)
+
+	handshakeMessage, ok := packets[0].Record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	clientHello, ok := handshakeMessage.Message.(*handshake.MessageClientHello)
+	require.True(t, ok)
+	assert.Contains(t, clientHello.Extensions, &extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}})
+	assert.Contains(t, clientHello.Extensions, &extension12.SupportedPointFormats{
+		PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
+	})
 }

--- a/internal/flight/flight12/flight_test_helpers_test.go
+++ b/internal/flight/flight12/flight_test_helpers_test.go
@@ -37,7 +37,7 @@ func generateForTest(
 	flight Flight,
 	conn dtlsflight.Conn,
 	state *dtlsstate.State12,
-	cache *dtlsflight.Cache,
+	cache *dtlsflight.Cache, //nolint:unparam
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {


### PR DESCRIPTION
#### Description
This was found thanks to #1029 because now we reject extensions offered in ServerHello, but not offered in ClientHello which exposed a bug where a dual-stack client falling back from DTLS 1.3 to DTLS 1.2 after a HelloVerifyRequest omitted supported_groups and ec_point_formats from the retry ClientHello.

part of #1005 