### PR TITLE
Make CID negotiations transactional

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1458,13 +1458,13 @@ func (c *Conn) unpackDatagram(buf []byte) ([][]byte, error) {
 	common := dtlsstate.CommonState(c.state)
 	if common.LocalVersion.Equal(protocol.Version1_3) ||
 		protocol.IsDTLS13Ciphertext(protocol.ContentType(buf[0])) {
-		cidLength := len(common.LocalConnectionID())
+		cidLength := len(common.LocalConnectionIDForInboundRecords())
 		state13, is13 := c.state.(*dtlsstate.State13)
 
 		return recordlayer.UnpackDatagram13(buf, cidLength, is13 && state13.CID.Negotiated, true)
 	}
 
-	return recordlayer.ContentAwareUnpackDatagram(buf, len(common.LocalConnectionID()))
+	return recordlayer.ContentAwareUnpackDatagram(buf, len(common.LocalConnectionIDForInboundRecords()))
 }
 
 func (c *Conn) queueableCiphertextEpoch(epochLow uint8, remoteEpoch uint16) bool {
@@ -1480,7 +1480,7 @@ func (c *Conn) queueableCiphertextEpoch(epochLow uint8, remoteEpoch uint16) bool
 func (c *Conn) unmarshalCiphertextRecord(buf []byte) (recordlayer.CiphertextRecord13, error) {
 	record := recordlayer.CiphertextRecord13{}
 	hasCID := buf[0]&recordlayer.UnifiedHeaderCIDBit != 0
-	localCID := dtlsstate.CommonState(c.state).LocalConnectionID()
+	localCID := dtlsstate.CommonState(c.state).LocalConnectionIDForInboundRecords()
 	cidExpected, cidAllowed, err := c.ciphertextCIDPolicy(localCID)
 	if err != nil {
 		return record, err
@@ -1873,7 +1873,7 @@ func (c *Conn) unmarshalLegacyHeader(buf []byte) (*recordlayer.Header, bool) {
 	header := &recordlayer.Header{}
 	// Set connection ID size so that records of content type tls12_cid will
 	// be parsed correctly.
-	localCID := dtlsstate.CommonState(c.state).LocalConnectionID()
+	localCID := dtlsstate.CommonState(c.state).LocalConnectionIDForInboundRecords()
 	if len(localCID) > 0 {
 		header.ConnectionID = make([]byte, len(localCID))
 	}
@@ -1971,7 +1971,7 @@ func (c *Conn) decryptLegacyPacket(
 
 func (c *Conn) validateLegacyCIDPresence(header *recordlayer.Header) bool {
 	common := dtlsstate.CommonState(c.state)
-	if len(common.LocalConnectionID()) == 0 || header.ContentType == protocol.ContentTypeConnectionID {
+	if len(common.LocalConnectionIDForInboundRecords()) == 0 || header.ContentType == protocol.ContentTypeConnectionID {
 		return true
 	}
 
@@ -1984,7 +1984,7 @@ func (c *Conn) decryptLegacyRecord(header *recordlayer.Header, buf []byte) ([]by
 	var decryptHeader recordlayer.Header
 	common := dtlsstate.CommonState(c.state)
 	if header.ContentType == protocol.ContentTypeConnectionID {
-		decryptHeader.ConnectionID = make([]byte, len(common.LocalConnectionID()))
+		decryptHeader.ConnectionID = make([]byte, len(common.LocalConnectionIDForInboundRecords()))
 	}
 	decrypted, err := common.CipherSuite.Decrypt(decryptHeader, buf)
 	if err != nil {
@@ -1997,7 +1997,7 @@ func (c *Conn) decryptLegacyRecord(header *recordlayer.Header, buf []byte) ([]by
 }
 
 func (c *Conn) validateLegacyCID(header *recordlayer.Header) bool {
-	if bytes.Equal(dtlsstate.CommonState(c.state).LocalConnectionID(), header.ConnectionID) {
+	if bytes.Equal(dtlsstate.CommonState(c.state).LocalConnectionIDForInboundRecords(), header.ConnectionID) {
 		return true
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -2401,7 +2401,7 @@ func TestPickVersionFromServerHelloRejectsUnsolicitedExtension(t *testing.T) {
 	cfg := testVersionNegotiationHandshakeConfig13(t)
 	cfg.MinVersion = protocol.Version1_2
 	common := &dtlsstate.Common{}
-	common.LocalClientHelloSnapshots.Record(offer)
+	require.NoError(t, common.LocalClientHelloSnapshots.Record(offer))
 	conn := &Conn{
 		handshakeConfig: cfg,
 		state:           &dtlsstate.State13{Common: common},
@@ -3197,6 +3197,8 @@ func TestSessionResume(t *testing.T) {
 		secret, _ := hex.DecodeString(
 			"2e942a37aca5241deb2295b5fcedac221c7078d2503d2b62aeb48c880d7da73c001238b708559686b9da6e829c05ead7",
 		)
+		clientCID := []byte{0xc1}
+		serverCID := []byte{0x51}
 
 		s := Session{ID: id, Secret: secret}
 
@@ -3210,6 +3212,7 @@ func TestSessionResume(t *testing.T) {
 				WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
 				WithServerName("example.com"),
 				WithSessionStore(ss),
+				WithConnectionIDGenerator(func() []byte { return clientCID }),
 				WithMTU(100),
 			}
 			c, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, false)
@@ -3220,6 +3223,7 @@ func TestSessionResume(t *testing.T) {
 			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
 			WithServerName("example.com"),
 			WithSessionStore(ss),
+			WithConnectionIDGenerator(func() []byte { return serverCID }),
 			WithMTU(100),
 		}
 		server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), opts, true)
@@ -3232,6 +3236,9 @@ func TestSessionResume(t *testing.T) {
 		actualMasterSecret := state.masterSecret
 		assert.Equal(t, actualSessionID, id, "TestSessionResumption SessionID mismatch")
 		assert.Equal(t, actualMasterSecret, secret, "TestSessionResumption masterSecret mismatch")
+		serverCommon := dtlsstate.CommonState(server.state)
+		assert.Equal(t, serverCID, serverCommon.LocalConnectionID())
+		assert.Equal(t, clientCID, serverCommon.RemoteConnectionID)
 
 		defer func() {
 			assert.NoError(t, server.Close())
@@ -3239,6 +3246,9 @@ func TestSessionResume(t *testing.T) {
 
 		res := <-clientRes
 		assert.NoError(t, res.err)
+		clientCommon := dtlsstate.CommonState(res.c.state)
+		assert.Equal(t, clientCID, clientCommon.LocalConnectionID())
+		assert.Equal(t, serverCID, clientCommon.RemoteConnectionID)
 		assert.NoError(t, res.c.Close())
 	})
 
@@ -4003,6 +4013,8 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	// Setup client
 	clientCert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
+	clientCID := []byte("client-cid")
+	serverCID := []byte("server-cid")
 
 	client, err := ClientWithOptions(
 		dtlsnet.PacketConnFromConn(ca),
@@ -4011,6 +4023,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 		WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3),
 		WithMaxVersion(protocol.Version1_3),
+		WithConnectionIDGenerator(func() []byte { return clientCID }),
 	)
 	assert.NoError(t, err)
 	defer func() {
@@ -4032,6 +4045,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 		WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3),
 		WithMaxVersion(protocol.Version1_3),
+		WithConnectionIDGenerator(func() []byte { return serverCID }),
 	)
 	assert.NoError(t, err)
 	defer func() {
@@ -4052,6 +4066,10 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	}()
 	require.NoError(t, <-errorChannel)
 	require.NoError(t, <-errorChannel)
+	assert.Equal(t, clientCID, dtlsstate.CommonState(client.state).LocalConnectionID())
+	assert.Equal(t, serverCID, dtlsstate.CommonState(client.state).RemoteConnectionID)
+	assert.Equal(t, serverCID, dtlsstate.CommonState(server.state).LocalConnectionID())
+	assert.Equal(t, clientCID, dtlsstate.CommonState(server.state).RemoteConnectionID)
 
 	_, ok = client.ConnectionState()
 	require.True(t, ok)
@@ -4919,8 +4937,7 @@ func TestSealRecordContentUsesNegotiatedConnectionID(t *testing.T) {
 		Secret:     secret,
 		Protection: protection,
 	}, nil)
-	state.SetLocalConnectionID([]byte("local-cid"))
-	state.NegotiateConnectionIDs([]byte("remote-cid"))
+	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
 
 	rawRecord, err := conn.sealRecordContent(
 		dtlsflight13.EpochApplication, 0, protocol.ContentTypeApplicationData, []byte("application"),
@@ -4947,8 +4964,7 @@ func TestOpenCiphertextRecordUsesNegotiatedConnectionID(t *testing.T) {
 		Protection: protection,
 	})
 	state.SetRemoteEpoch(dtlsflight13.EpochApplication)
-	state.SetLocalConnectionID([]byte("local-cid"))
-	state.NegotiateConnectionIDs([]byte("remote-cid"))
+	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
 
 	sealed, err := protection.Seal(
 		recordlayer.UnifiedHeader{

--- a/flight_test.go
+++ b/flight_test.go
@@ -4,6 +4,7 @@
 package dtls
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/hmac"
@@ -20,6 +21,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
@@ -62,6 +64,19 @@ type handshakeTestContext13 struct {
 
 func newTestState13(isClient bool) *dtlsstate.State13 {
 	state := dtlsstate.NewState13(isClient)
+	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		Extensions: []extension.Value{
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}},
+			&extension13.ClientKeyShare{},
+		},
+	}, nil)
+	if err != nil {
+		panic(err) //nolint:forbidigo // The fixed test fixture must remain valid.
+	}
+	_ = state.LocalClientHelloSnapshots.Record(snapshot)  // The first snapshot cannot conflict.
+	_ = state.RemoteClientHelloSnapshots.Record(snapshot) // The first snapshot cannot conflict.
 
 	return &state
 }
@@ -899,35 +914,6 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.Equal(t, selectedGroup, entries[0].Group)
 	assert.Empty(t, entries[0].KeyExchange)
-}
-
-func TestFlight13_1ParseRejectsUnsolicitedHelloRetryRequestExtension(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	state := newTestState13(false)
-	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeTestContext13{
-		state: state,
-		cfg:   cfg,
-	})
-	require.NoError(t, err)
-	require.Nil(t, dtlsAlert)
-
-	rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Value{
-		&extension13.SelectedVersion{Version: protocol.Version1_3},
-		extension.Raw{Type: 0xfafa},
-	})
-	cache := dtlsflight.NewCache()
-	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
-
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
-		t, dtlsflight13.Flight1, context.Background(), &handshakeTestContext13{
-			state: state,
-			cache: cache,
-			cfg:   cfg,
-		})
-
-	require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
-	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
-	assert.Zero(t, nextFlight)
 }
 
 func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *testing.T) {
@@ -3198,6 +3184,7 @@ func TestFlight13_2Parse(t *testing.T) {
 		assert.Empty(t, state.KeyAgreementSecret)
 		assert.Nil(t, state.LocalKeypair)
 		assert.Zero(t, state.SelectedGroup)
+		assert.False(t, state.RemoteClientHelloSnapshots.Current().Offered(extension.TypeCookie))
 	})
 
 	t.Run("KeepsWaitingWhenNoClientHelloCached", func(t *testing.T) {
@@ -3310,6 +3297,46 @@ func findConnectionID(exts []extension.Value) (*extension.ConnectionID, bool) {
 	return nil, false
 }
 
+func clientHello13SnapshotHistory(t *testing.T, extensions []extension.Value) (history extensionnegotiation.ClientHelloSnapshots) { //nolint:lll
+	t.Helper()
+	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	require.NoError(t, err)
+	require.NoError(t, history.Record(snapshot))
+
+	return history
+}
+
+func assertSnapshotConnectionID(t *testing.T, snapshot extensionnegotiation.ClientHelloSnapshot, expectedCID []byte, expectedPresent bool) { //nolint:lll
+	t.Helper()
+	cid, present := extensionnegotiation.ConnectionIDOffer(snapshot)
+	assert.Equal(t, expectedPresent, present)
+	assert.True(t, bytes.Equal(expectedCID, cid))
+}
+
+func assertConnectionIDValue(t *testing.T, expected, actual []byte) {
+	t.Helper()
+	assert.True(t, bytes.Equal(expected, actual))
+}
+
+func assertConnectionIDs(t *testing.T, state *dtlsstate.State13, localCID, remoteCID []byte, negotiated bool) {
+	t.Helper()
+	assert.Equal(t, [3]bool{negotiated, negotiated, negotiated},
+		[3]bool{state.LocalCIDOffered, state.RemoteCIDOffered, state.CID.Negotiated})
+	assertConnectionIDValue(t, localCID, state.LocalConnectionID())
+	assertConnectionIDValue(t, remoteCID, state.RemoteConnectionID)
+	if !negotiated {
+		assert.Zero(t, state.CID)
+
+		return
+	}
+	assertConnectionIDValue(t, localCID, state.LocalConnectionIDForInboundRecords())
+	assert.Equal(t, len(localCID), state.CID.Receive.Length)
+	assert.Equal(t, len(localCID) > 0, state.CID.Receive.Expected)
+	assert.Equal(t, len(localCID) > 0, state.CID.Receive.CanSendNewConnectionID)
+	assert.Equal(t, len(remoteCID) > 0, state.CID.Send.UseCID)
+	assertConnectionIDValue(t, remoteCID, state.CID.Send.Active)
+}
+
 func clientHelloFromFlight13Packet(t *testing.T, packet *dtlsflight.Packet) *handshake.MessageClientHello {
 	t.Helper()
 
@@ -3326,284 +3353,144 @@ func clientHelloFromFlight13Packet(t *testing.T, packet *dtlsflight.Packet) *han
 	return clientHello
 }
 
+func setConnectionIDs(clientHello *handshake.MessageClientHello, cids ...[]byte) {
+	extensions := clientHello.Extensions[:0]
+	for _, ext := range clientHello.Extensions {
+		if _, ok := ext.(*extension.ConnectionID); !ok {
+			extensions = append(extensions, ext)
+		}
+	}
+	for _, cid := range cids {
+		extensions = append(extensions, &extension.ConnectionID{CID: cid})
+	}
+	clientHello.Extensions = extensions
+}
+
+type connectionIDNegotiationCase struct {
+	clientCID    []byte
+	serverCIDs   [][]byte
+	clientOffers bool
+	expectedErr  error
+	description  alert.Description
+}
+
+func connectionIDNegotiationCases() map[string]connectionIDNegotiationCase {
+	return map[string]connectionIDNegotiationCase{
+		"ServerDeclinesEmpty":    {clientOffers: true},
+		"ServerDeclinesNonEmpty": {clientOffers: true, clientCID: []byte{1}},
+		"BothEmpty":              {clientOffers: true, serverCIDs: [][]byte{{}}},
+		"OnlyClientSendsCID":     {clientOffers: true, serverCIDs: [][]byte{{0x10, 0x11}}},
+		"OnlyServerSendsCID":     {clientOffers: true, clientCID: []byte{1, 2}, serverCIDs: [][]byte{{}}},
+		"Bidirectional":          {clientOffers: true, clientCID: []byte{1, 2}, serverCIDs: [][]byte{{0x10, 0x11}}},
+	}
+}
+
 func TestFlight13_1GenerateConnectionIDOffer(t *testing.T) {
 	tests := map[string]struct {
-		enabled bool
-		cid     []byte
+		generated, expected []byte
+		hooked              [][]byte
+		generator, hook     bool
+		invalid             bool
 	}{
-		"Disabled": {},
-		"Empty": {
-			enabled: true,
-		},
-		"NonEmpty": {
-			enabled: true,
-			cid:     []byte{0x01, 0x02, 0x03, 0x04},
-		},
+		"Disabled":      {},
+		"Empty":         {generator: true},
+		"NonEmpty":      {generated: []byte{1, 2, 3, 4}, expected: []byte{1, 2, 3, 4}, generator: true},
+		"HookRemove":    {generated: []byte{1, 2}, generator: true, hook: true},
+		"HookReplace":   {generated: []byte{1, 2}, expected: []byte{0xaa, 0xbb}, hooked: [][]byte{{0xaa, 0xbb}}, generator: true, hook: true}, //nolint:lll
+		"HookAdd":       {expected: []byte{0xcc}, hooked: [][]byte{{0xcc}}, hook: true},
+		"HookDuplicate": {generated: []byte{1}, hooked: [][]byte{{1}, {2}}, generator: true, hook: true, invalid: true},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cfg := testHandshakeConfig13(t)
-			calls := 0
-			if test.enabled {
+			cfg, calls := testHandshakeConfig13(t), 0
+			if test.generator {
 				cfg.ConnectionIDGenerator = func() []byte {
 					calls++
 
-					return test.cid
+					return test.generated
+				}
+			}
+			if test.hook {
+				cfg.ClientHelloMessageHook = func(ch handshake.MessageClientHello) handshake.Message {
+					setConnectionIDs(&ch, test.hooked...)
+
+					return &ch
 				}
 			}
 			state := newTestState13(true)
-
+			if test.invalid {
+				state.LocalClientHelloSnapshots.Reset()
+			}
 			packets, dtlsAlert, err := flight13GenerateForTest(
 				t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
 			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			require.Len(t, packets, 1)
-
-			connectionID, present := findConnectionID(clientHelloFromFlight13Packet(t, packets[0]).Extensions)
-			assert.Equal(t, test.enabled, present)
-			assert.Equal(t, test.enabled, state.LocalCIDOffered)
-			if test.enabled {
-				require.NotNil(t, connectionID)
-				if len(test.cid) == 0 {
-					assert.Empty(t, connectionID.CID)
-				} else {
-					assert.Equal(t, test.cid, connectionID.CID)
-				}
-				assert.Equal(t, test.cid, state.LocalConnectionID())
-				assert.Equal(t, 1, calls)
+			if test.invalid {
+				require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+				assert.Nil(t, dtlsAlert)
+				assert.Nil(t, packets)
+				assert.False(t, state.LocalClientHelloSnapshots.Current().Valid())
 			} else {
-				assert.Nil(t, state.LocalConnectionID())
-				assert.Zero(t, calls)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+				require.Len(t, packets, 1)
+				cid, present := findConnectionID(clientHelloFromFlight13Packet(t, packets[0]).Extensions)
+				expectedPresent := test.generator
+				if test.hook {
+					expectedPresent = len(test.hooked) == 1
+				}
+				assert.Equal(t, expectedPresent, present)
+				assertSnapshotConnectionID(t, state.LocalClientHelloSnapshots.Current(), test.expected, present)
+				assertConnectionIDValue(t, test.expected, state.LocalConnectionIDForInboundRecords())
+				if present {
+					require.NotNil(t, cid)
+					assertConnectionIDValue(t, test.expected, cid.CID)
+				}
 			}
-			assert.Nil(t, state.RemoteConnectionID)
-			assert.False(t, state.RemoteCIDOffered)
-			assert.False(t, state.CID.Negotiated)
-			assert.False(t, state.CID.Receive.Expected)
-			assert.False(t, state.CID.Send.UseCID)
+			assert.Equal(t, test.generator, calls == 1)
+			assertConnectionIDs(t, state, nil, nil, false)
 		})
 	}
 }
 
-func TestFlight13_1GenerateCapturesHookedConnectionIDOffer(t *testing.T) {
+func TestFlight13_3GenerateConnectionIDOffer(t *testing.T) { //nolint:cyclop // Compact scenario table.
 	tests := map[string]struct {
-		generatorEnabled bool
-		mutate           func(*handshake.MessageClientHello)
-		expectedCID      []byte
-		expectedPresent  bool
+		generated, expected  []byte
+		retryCIDs            [][]byte
+		generator, hookAll   bool
+		mutateRetry, invalid bool
 	}{
-		"Remove": {
-			generatorEnabled: true,
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				extensions := clientHello.Extensions[:0]
-				for _, ext := range clientHello.Extensions {
-					if _, ok := ext.(*extension.ConnectionID); !ok {
-						extensions = append(extensions, ext)
-					}
-				}
-				clientHello.Extensions = extensions
-			},
-		},
-		"Replace": {
-			generatorEnabled: true,
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				connectionID, present := findConnectionID(clientHello.Extensions)
-				if present {
-					connectionID.CID = []byte{0xaa, 0xbb}
-				}
-			},
-			expectedCID:     []byte{0xaa, 0xbb},
-			expectedPresent: true,
-		},
-		"Add": {
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				clientHello.Extensions = append(clientHello.Extensions, &extension.ConnectionID{
-					CID: []byte{0xcc},
-				})
-			},
-			expectedCID:     []byte{0xcc},
-			expectedPresent: true,
-		},
+		"ReuseEmpty":      {generator: true},
+		"ReuseNonEmpty":   {generated: []byte{1, 2, 3, 4}, expected: []byte{1, 2, 3, 4}, generator: true},
+		"ReuseHookOnly":   {expected: []byte{0xcc}, retryCIDs: [][]byte{{0xcc}}, hookAll: true},
+		"RejectRemove":    {generated: []byte{1}, generator: true, mutateRetry: true, invalid: true},
+		"RejectReplace":   {generated: []byte{1}, retryCIDs: [][]byte{{0xff}}, generator: true, mutateRetry: true, invalid: true}, //nolint:lll
+		"RejectAdd":       {retryCIDs: [][]byte{{0xff}}, mutateRetry: true, invalid: true},
+		"RejectDuplicate": {generated: []byte{1}, retryCIDs: [][]byte{{1}, {1}}, generator: true, mutateRetry: true, invalid: true}, //nolint:lll
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cfg := testHandshakeConfig13(t)
-			generatorCalls := 0
-			if test.generatorEnabled {
+			cfg, generatorCalls, hookCalls := testHandshakeConfig13(t), 0, 0
+			if test.generator {
 				cfg.ConnectionIDGenerator = func() []byte {
 					generatorCalls++
-
-					return []byte{0x01, 0x02}
-				}
-			}
-			cfg.ClientHelloMessageHook = func(clientHello handshake.MessageClientHello) handshake.Message {
-				test.mutate(&clientHello)
-
-				return &clientHello
-			}
-			state := newTestState13(true)
-
-			packets, dtlsAlert, err := flight13GenerateForTest(
-				t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
-			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			require.Len(t, packets, 1)
-
-			connectionID, present := findConnectionID(clientHelloFromFlight13Packet(t, packets[0]).Extensions)
-			assert.Equal(t, test.expectedPresent, present)
-			assert.Equal(t, test.expectedPresent, state.LocalCIDOffered)
-			if test.expectedPresent {
-				require.NotNil(t, connectionID)
-				assert.Equal(t, test.expectedCID, connectionID.CID)
-				assert.Equal(t, test.expectedCID, state.LocalConnectionID())
-			} else {
-				assert.Nil(t, state.LocalConnectionID())
-			}
-			if test.generatorEnabled {
-				assert.Equal(t, 1, generatorCalls)
-			} else {
-				assert.Zero(t, generatorCalls)
-			}
-		})
-	}
-}
-
-func TestFlight13_1GenerateRejectsDuplicateHookedConnectionIDOffer(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	cfg.ConnectionIDGenerator = func() []byte { return []byte{0x01} }
-	cfg.ClientHelloMessageHook = func(clientHello handshake.MessageClientHello) handshake.Message {
-		clientHello.Extensions = append(clientHello.Extensions, &extension.ConnectionID{CID: []byte{0x02}})
-
-		return &clientHello
-	}
-	state := newTestState13(true)
-
-	packets, dtlsAlert, err := flight13GenerateForTest(
-		t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
-	)
-
-	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
-	assert.Nil(t, dtlsAlert)
-	assert.Nil(t, packets)
-	assert.Nil(t, state.LocalConnectionID())
-	assert.False(t, state.LocalCIDOffered)
-}
-
-func TestFlight13_3GenerateReusesConnectionIDOffer(t *testing.T) {
-	tests := map[string][]byte{
-		"Empty":    nil,
-		"NonEmpty": {0x01, 0x02, 0x03, 0x04},
-	}
-
-	for name, cid := range tests {
-		t.Run(name, func(t *testing.T) {
-			cfg := testHandshakeConfig13(t)
-			calls := 0
-			cfg.ConnectionIDGenerator = func() []byte {
-				calls++
-				if calls == 1 {
-					return cid
-				}
-
-				return []byte{0xff}
-			}
-			state := newTestState13(true)
-
-			firstFlight, dtlsAlert, err := flight13GenerateForTest(
-				t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
-			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-			state.Cookie = []byte{0xaa, 0xbb}
-
-			secondFlight, dtlsAlert, err := flight13GenerateForTest(
-				t, dtlsflight13.Flight3, &handshakeTestContext13{state: state, cfg: cfg},
-			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			assert.Equal(t, 1, calls)
-
-			firstCID, firstPresent := findConnectionID(
-				clientHelloFromFlight13Packet(t, firstFlight[0]).Extensions,
-			)
-			secondCID, secondPresent := findConnectionID(
-				clientHelloFromFlight13Packet(t, secondFlight[0]).Extensions,
-			)
-			require.True(t, firstPresent)
-			require.True(t, secondPresent)
-			assert.Equal(t, firstCID.CID, secondCID.CID)
-			if cid == nil {
-				assert.Empty(t, secondCID.CID)
-			} else {
-				assert.Equal(t, cid, secondCID.CID)
-			}
-			assert.True(t, state.LocalCIDOffered)
-		})
-	}
-}
-
-func TestFlight13_3GenerateRejectsHookedConnectionIDChange(t *testing.T) {
-	tests := map[string]struct {
-		offer  bool
-		mutate func(*handshake.MessageClientHello)
-	}{
-		"Remove": {
-			offer: true,
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				extensions := clientHello.Extensions[:0]
-				for _, ext := range clientHello.Extensions {
-					if _, ok := ext.(*extension.ConnectionID); !ok {
-						extensions = append(extensions, ext)
+					if generatorCalls == 1 {
+						return test.generated
 					}
-				}
-				clientHello.Extensions = extensions
-			},
-		},
-		"Replace": {
-			offer: true,
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				connectionID, present := findConnectionID(clientHello.Extensions)
-				if present {
-					connectionID.CID = []byte{0xff}
-				}
-			},
-		},
-		"Add": {
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				clientHello.Extensions = append(clientHello.Extensions, &extension.ConnectionID{CID: []byte{0xff}})
-			},
-		},
-		"Duplicate": {
-			offer: true,
-			mutate: func(clientHello *handshake.MessageClientHello) {
-				clientHello.Extensions = append(clientHello.Extensions, &extension.ConnectionID{CID: []byte{0x01}})
-			},
-		},
-	}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			cfg := testHandshakeConfig13(t)
-			generatorCalls := 0
-			if test.offer {
-				cfg.ConnectionIDGenerator = func() []byte {
-					generatorCalls++
-
-					return []byte{0x01}
+					return []byte{0xff}
 				}
 			}
-			hookCalls := 0
-			cfg.ClientHelloMessageHook = func(clientHello handshake.MessageClientHello) handshake.Message {
-				hookCalls++
-				if hookCalls == 2 {
-					test.mutate(&clientHello)
-				}
+			if test.hookAll || test.mutateRetry {
+				cfg.ClientHelloMessageHook = func(ch handshake.MessageClientHello) handshake.Message {
+					hookCalls++
+					if test.hookAll || hookCalls == 2 {
+						setConnectionIDs(&ch, test.retryCIDs...)
+					}
 
-				return &clientHello
+					return &ch
+				}
 			}
 			state := newTestState13(true)
 			firstFlight, dtlsAlert, err := flight13GenerateForTest(
@@ -3612,63 +3499,40 @@ func TestFlight13_3GenerateRejectsHookedConnectionIDChange(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, dtlsAlert)
 			require.Len(t, firstFlight, 1)
-			state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-			state.Cookie = []byte{0xaa}
+			initialSnapshot := state.LocalClientHelloSnapshots.Current()
+			state.RemoteVersions, state.Cookie = []protocol.Version{protocol.Version1_3}, []byte{0xaa}
 
-			packets, dtlsAlert, err := flight13GenerateForTest(
+			secondFlight, dtlsAlert, err := flight13GenerateForTest(
 				t, dtlsflight13.Flight3, &handshakeTestContext13{state: state, cfg: cfg},
 			)
-			require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
-			assert.Nil(t, dtlsAlert)
-			assert.Nil(t, packets)
-			assert.Equal(t, 2, hookCalls)
-			if test.offer {
-				assert.Equal(t, 1, generatorCalls)
-			} else {
-				assert.Zero(t, generatorCalls)
+			assert.Equal(t, test.generator, generatorCalls == 1)
+			if test.hookAll || test.mutateRetry {
+				assert.Equal(t, 2, hookCalls)
 			}
+			if test.invalid {
+				require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+				assert.Nil(t, dtlsAlert)
+				assert.Nil(t, secondFlight)
+				assertSnapshotConnectionID(t, initialSnapshot, test.generated, test.generator)
+				assertSnapshotConnectionID(t, state.LocalClientHelloSnapshots.Current(), test.generated, test.generator)
+			} else {
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+				require.Len(t, secondFlight, 1)
+				firstCID, firstPresent := findConnectionID(clientHelloFromFlight13Packet(t, firstFlight[0]).Extensions)
+				secondCID, secondPresent := findConnectionID(clientHelloFromFlight13Packet(t, secondFlight[0]).Extensions)
+				require.True(t, firstPresent)
+				require.True(t, secondPresent)
+				assert.Equal(t, firstCID.CID, secondCID.CID)
+				assertConnectionIDValue(t, test.expected, secondCID.CID)
+				assertSnapshotConnectionID(t, state.LocalClientHelloSnapshots.Current(), test.expected, true)
+			}
+			assertConnectionIDs(t, state, nil, nil, false)
 		})
 	}
 }
 
-func TestFlight13_3GenerateReusesHookOnlyConnectionIDOffer(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	hookCalls := 0
-	cfg.ClientHelloMessageHook = func(clientHello handshake.MessageClientHello) handshake.Message {
-		hookCalls++
-		clientHello.Extensions = append(clientHello.Extensions, &extension.ConnectionID{CID: []byte{0xcc}})
-
-		return &clientHello
-	}
-	state := newTestState13(true)
-
-	firstFlight, dtlsAlert, err := flight13GenerateForTest(
-		t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
-	)
-	require.NoError(t, err)
-	require.Nil(t, dtlsAlert)
-	require.Len(t, firstFlight, 1)
-	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	state.Cookie = []byte{0xaa}
-
-	secondFlight, dtlsAlert, err := flight13GenerateForTest(
-		t, dtlsflight13.Flight3, &handshakeTestContext13{state: state, cfg: cfg},
-	)
-	require.NoError(t, err)
-	require.Nil(t, dtlsAlert)
-	require.Len(t, secondFlight, 1)
-	assert.Equal(t, 2, hookCalls)
-
-	firstCID, firstPresent := findConnectionID(clientHelloFromFlight13Packet(t, firstFlight[0]).Extensions)
-	secondCID, secondPresent := findConnectionID(clientHelloFromFlight13Packet(t, secondFlight[0]).Extensions)
-	require.True(t, firstPresent)
-	require.True(t, secondPresent)
-	assert.Equal(t, firstCID.CID, secondCID.CID)
-	assert.Equal(t, []byte{0xcc}, state.LocalConnectionID())
-	assert.True(t, state.LocalCIDOffered)
-}
-
-func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
+func TestFlight13_2ParseConnectionIDOffer(t *testing.T) {
 	cookie := []byte{0xde, 0xad, 0xbe, 0xef}
 	tests := map[string]struct {
 		firstPresent bool
@@ -3676,24 +3540,12 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 		secondCIDs   [][]byte
 		expectedErr  error
 	}{
-		"RemovedEmptyOffer": {
-			firstPresent: true,
-			firstCID:     []byte{},
-		},
-		"AddedEmptyOffer": {
-			secondCIDs: [][]byte{{}},
-		},
-		"ChangedValue": {
-			firstPresent: true,
-			firstCID:     []byte{0x01},
-			secondCIDs:   [][]byte{{0x02}},
-		},
-		"DuplicateOffer": {
-			firstPresent: true,
-			firstCID:     []byte{0x01},
-			secondCIDs:   [][]byte{{0x01}, {0x01}},
-			expectedErr:  dtlserrors.ErrDuplicateExtension,
-		},
+		"RejectRemovedEmpty": {firstPresent: true, firstCID: []byte{}, expectedErr: dtlserrors.ErrInvalidClientHello},
+		"RejectAddedEmpty":   {secondCIDs: [][]byte{{}}, expectedErr: dtlserrors.ErrInvalidClientHello},
+		"RejectChangedValue": {firstPresent: true, firstCID: []byte{1}, secondCIDs: [][]byte{{2}}, expectedErr: dtlserrors.ErrInvalidClientHello},      //nolint:lll
+		"RejectDuplicate":    {firstPresent: true, firstCID: []byte{1}, secondCIDs: [][]byte{{1}, {1}}, expectedErr: dtlserrors.ErrDuplicateExtension}, //nolint:lll
+		"RepeatEmpty":        {firstPresent: true, firstCID: []byte{}, secondCIDs: [][]byte{{}}},
+		"RepeatNonEmpty":     {firstPresent: true, firstCID: []byte{1, 2}, secondCIDs: [][]byte{{1, 2}}},
 	}
 
 	for name, test := range tests {
@@ -3701,10 +3553,11 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 			cfg := testHandshakeConfig13(t)
 			state := newTestState13(false)
 			state.Cookie = cookie
+			initialExtensions := requiredClientHello13Extensions(t, cfg)
 			if test.firstPresent {
-				state.RemoteConnectionID = test.firstCID
-				state.RemoteCIDOffered = true
+				initialExtensions = append(initialExtensions, &extension.ConnectionID{CID: test.firstCID})
 			}
+			state.RemoteClientHelloSnapshots = clientHello13SnapshotHistory(t, initialExtensions)
 			cache := dtlsflight.NewCache()
 			exts := requiredClientHello13Extensions(t, cfg)
 			for _, cid := range test.secondCIDs {
@@ -3717,105 +3570,44 @@ func TestFlight13_2ParseRejectsChangedConnectionIDOffer(t *testing.T) {
 				t, dtlsflight13.Flight2, context.Background(), flight13_2Context(state, cache, cfg),
 			)
 
-			expectedErr := test.expectedErr
-			if expectedErr == nil {
-				expectedErr = dtlserrors.ErrInvalidClientHello
-			}
-			require.ErrorIs(t, err, expectedErr)
-			require.NotNil(t, dtlsAlert)
-			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
-			assert.Zero(t, nextFlight)
-			assert.Nil(t, state.LocalKeypair)
-		})
-	}
-}
-
-func TestFlight13_2ParseAcceptsRepeatedConnectionIDOffer(t *testing.T) {
-	cookie := []byte{0xde, 0xad, 0xbe, 0xef}
-	for name, cid := range map[string][]byte{
-		"Empty":    {},
-		"NonEmpty": {0x01, 0x02},
-	} {
-		t.Run(name, func(t *testing.T) {
-			cfg := testHandshakeConfig13(t)
-			state := newTestState13(false)
-			state.Cookie = cookie
-			state.RemoteConnectionID = cid
-			state.RemoteCIDOffered = true
-			cache := dtlsflight.NewCache()
-			exts := append(requiredClientHello13Extensions(t, cfg),
-				&extension.ConnectionID{CID: cid},
-				&extension13.Cookie{Cookie: cookie},
-			)
-			pushClientHello13(t, cache, protocol.Version1_2, exts)
-
-			nextFlight, dtlsAlert, err := flight13ParseForTest(
-				t, dtlsflight13.Flight2, context.Background(), flight13_2Context(state, cache, cfg),
-			)
-
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			assert.Equal(t, dtlsflight13.Flight4, nextFlight)
-			assert.True(t, state.RemoteCIDOffered)
-			if len(cid) > 0 {
-				assert.Equal(t, cid, state.RemoteConnectionID)
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+				assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
+				assert.Zero(t, nextFlight)
+				assert.Nil(t, state.LocalKeypair)
 			} else {
-				assert.Nil(t, state.RemoteConnectionID)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+				assert.Equal(t, dtlsflight13.Flight4, nextFlight)
 			}
-			assert.False(t, state.CID.Negotiated)
+			assertSnapshotConnectionID(
+				t, state.RemoteClientHelloSnapshots.Current(), test.firstCID, test.firstPresent,
+			)
+			assertConnectionIDs(t, state, nil, nil, false)
 		})
 	}
 }
 
-func TestFlight13_4GenerateNegotiatesConnectionIDs(t *testing.T) {
-	tests := map[string]struct {
-		clientOffered bool
-		serverEnabled bool
-		clientCID     []byte
-		serverCID     []byte
-	}{
-		"NoClientOffer": {
-			serverEnabled: true,
-			serverCID:     []byte{0x10},
-		},
-		"ServerDeclines": {
-			clientOffered: true,
-			clientCID:     []byte{0x01},
-		},
-		"BothEmpty": {
-			clientOffered: true,
-			serverEnabled: true,
-		},
-		"OnlyClientSendsCID": {
-			clientOffered: true,
-			serverEnabled: true,
-			serverCID:     []byte{0x10, 0x11},
-		},
-		"OnlyServerSendsCID": {
-			clientOffered: true,
-			serverEnabled: true,
-			clientCID:     []byte{0x01, 0x02},
-		},
-		"Bidirectional": {
-			clientOffered: true,
-			serverEnabled: true,
-			clientCID:     []byte{0x01, 0x02},
-			serverCID:     []byte{0x10, 0x11},
-		},
-	}
-
+func TestFlight13_4GenerateNegotiatesConnectionIDs(t *testing.T) { //nolint:cyclop // Compact scenario matrix.
+	tests := connectionIDNegotiationCases()
+	tests["NoClientOffer"] = connectionIDNegotiationCase{serverCIDs: [][]byte{{0x10}}}
+	tests["InvalidServerCID"] = connectionIDNegotiationCase{clientOffers: true, serverCIDs: [][]byte{make([]byte, 256)}} //nolint:lll
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			var serverCID []byte
+			if len(test.serverCIDs) > 0 {
+				serverCID = test.serverCIDs[0]
+			}
 			cfg := testHandshakeConfig13(t)
 			certificate, err := selfsign.GenerateSelfSigned()
 			require.NoError(t, err)
 			cfg.LocalCertificates = []tls.Certificate{certificate}
 			generatorCalls := 0
-			if test.serverEnabled {
+			if len(test.serverCIDs) > 0 {
 				cfg.ConnectionIDGenerator = func() []byte {
 					generatorCalls++
 
-					return test.serverCID
+					return serverCID
 				}
 			}
 			keypair, err := elliptic.GenerateKeypair(cfg.EllipticCurves[0])
@@ -3824,67 +3616,75 @@ func TestFlight13_4GenerateNegotiatesConnectionIDs(t *testing.T) {
 			state.CipherSuite = cfg.LocalCipherSuites[0]
 			state.LocalKeypair = keypair
 			state.RemoteSignatureSchemes = append([]signaturehash.Algorithm(nil), cfg.LocalSignatureSchemes...)
-			if test.clientOffered {
-				state.RemoteConnectionID = test.clientCID
-				state.RemoteCIDOffered = true
+			offerExtensions := requiredClientHello13Extensions(t, cfg)
+			if test.clientOffers {
+				offerExtensions = append(offerExtensions, &extension.ConnectionID{CID: test.clientCID})
 			}
+			state.RemoteClientHelloSnapshots = clientHello13SnapshotHistory(t, offerExtensions)
 
-			packets, dtlsAlert, err := flight13GenerateForTest(
-				t, dtlsflight13.Flight4, &handshakeTestContext13{state: state, cfg: cfg},
-			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			require.NotEmpty(t, packets)
-			serverHelloHandshake, ok := packets[0].Record.Content.(*handshake.Handshake)
-			require.True(t, ok)
-			serverHello, ok := serverHelloHandshake.Message.(*handshake.MessageServerHello)
-			require.True(t, ok)
-
-			expectedNegotiated := test.clientOffered && test.serverEnabled
-			connectionID, present := findConnectionID(serverHello.Extensions)
-			assert.Equal(t, expectedNegotiated, present)
-			assert.Equal(t, expectedNegotiated, state.CID.Negotiated)
-			if !expectedNegotiated {
-				assert.Zero(t, generatorCalls)
-				assert.Nil(t, state.LocalConnectionID())
-				assert.Nil(t, state.RemoteConnectionID)
-				assert.False(t, state.LocalCIDOffered)
-				assert.False(t, state.RemoteCIDOffered)
-				assert.Equal(t, dtlsstate.CIDState{}, state.CID)
+			if len(serverCID) > 255 {
+				packets, dtlsAlert, err := flight13GenerateForTest(
+					t, dtlsflight13.Flight4, &handshakeTestContext13{state: state, cfg: cfg},
+				)
+				require.ErrorIs(t, err, dtlserrors.ErrInvalidCIDFormat)
+				assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, dtlsAlert)
+				assert.Nil(t, packets)
+				assert.Equal(t, 1, generatorCalls)
+				assertConnectionIDs(t, state, nil, nil, false)
 
 				return
 			}
 
-			require.NotNil(t, connectionID)
+			expectedNegotiated := test.clientOffers && len(test.serverCIDs) > 0
+			for range 2 {
+				packets, dtlsAlert, err := flight13GenerateForTest(
+					t, dtlsflight13.Flight4, &handshakeTestContext13{state: state, cfg: cfg},
+				)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+				require.NotEmpty(t, packets)
+				serverHelloHandshake, ok := packets[0].Record.Content.(*handshake.Handshake)
+				require.True(t, ok)
+				serverHello, ok := serverHelloHandshake.Message.(*handshake.MessageServerHello)
+				require.True(t, ok)
+				connectionID, present := findConnectionID(serverHello.Extensions)
+				assert.Equal(t, expectedNegotiated, present)
+				assert.Equal(t, expectedNegotiated, state.CID.Negotiated)
+				if expectedNegotiated {
+					require.NotNil(t, connectionID)
+					if len(serverCID) == 0 {
+						assert.Empty(t, connectionID.CID)
+					} else {
+						assert.Equal(t, serverCID, connectionID.CID)
+					}
+				}
+			}
+			assertSnapshotConnectionID(
+				t, state.RemoteClientHelloSnapshots.Current(), test.clientCID, test.clientOffers,
+			)
+			if !expectedNegotiated {
+				assert.Zero(t, generatorCalls)
+				assertConnectionIDs(t, state, nil, nil, false)
+
+				return
+			}
+
 			assert.Equal(t, 1, generatorCalls)
-			assert.True(t, state.LocalCIDOffered)
-			assert.True(t, state.RemoteCIDOffered)
-			assert.Equal(t, test.serverCID, state.LocalConnectionID())
-			assert.Equal(t, test.serverCID, connectionID.CID)
-			assert.Equal(t, test.clientCID, state.RemoteConnectionID)
-			assert.Equal(t, len(test.serverCID), state.CID.Receive.Length)
-			assert.Equal(t, len(test.serverCID) > 0, state.CID.Receive.Expected)
-			assert.Equal(t, len(test.serverCID) > 0, state.CID.Receive.CanSendNewConnectionID)
-			assert.Equal(t, len(test.clientCID) > 0, state.CID.Send.UseCID)
-			assert.Equal(t, test.clientCID, state.CID.Send.Active)
+			assertConnectionIDs(t, state, serverCID, test.clientCID, true)
 		})
 	}
 }
 
-func TestFlight13_0ParseCapturesConnectionIDOffer(t *testing.T) {
+func TestFlight13_0ParseConnectionIDOffer(t *testing.T) {
 	tests := map[string]struct {
-		present bool
-		cid     []byte
+		cids     [][]byte
+		expected []byte
+		invalid  bool
 	}{
-		"Absent": {},
-		"Empty": {
-			present: true,
-			cid:     []byte{},
-		},
-		"NonEmpty": {
-			present: true,
-			cid:     []byte{0x01, 0x02, 0x03, 0x04},
-		},
+		"Absent":    {},
+		"Empty":     {cids: [][]byte{{}}},
+		"NonEmpty":  {cids: [][]byte{{1, 2, 3, 4}}, expected: []byte{1, 2, 3, 4}},
+		"Duplicate": {cids: [][]byte{{1}, {2}}, invalid: true},
 	}
 
 	for name, test := range tests {
@@ -3897,10 +3697,13 @@ func TestFlight13_0ParseCapturesConnectionIDOffer(t *testing.T) {
 				return []byte{0xaa}
 			}
 			state := newTestState13(false)
+			if test.invalid {
+				state.RemoteClientHelloSnapshots.Reset()
+			}
 			cache := dtlsflight.NewCache()
 			exts := requiredClientHello13Extensions(t, cfg)
-			if test.present {
-				exts = append(exts, &extension.ConnectionID{CID: test.cid})
+			for _, cid := range test.cids {
+				exts = append(exts, &extension.ConnectionID{CID: cid})
 			}
 			pushFlight13_0ClientHello(t, cache, cfg, exts)
 
@@ -3911,47 +3714,22 @@ func TestFlight13_0ParseCapturesConnectionIDOffer(t *testing.T) {
 					cfg:   cfg,
 				},
 			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
-			assert.Equal(t, dtlsflight13.Flight2, nextFlight)
-			assert.Zero(t, generatorCalls, "server CID generation is deferred until the final ServerHello")
-			assert.Equal(t, test.present, state.RemoteCIDOffered)
-			if test.present && len(test.cid) > 0 {
-				assert.Equal(t, test.cid, state.RemoteConnectionID)
+			if test.invalid {
+				require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
+				assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
+				assert.Zero(t, nextFlight)
+				assert.False(t, state.RemoteClientHelloSnapshots.Current().Valid())
 			} else {
-				assert.Nil(t, state.RemoteConnectionID)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+				assert.Equal(t, dtlsflight13.Flight2, nextFlight)
+				present := len(test.cids) == 1
+				assertSnapshotConnectionID(t, state.RemoteClientHelloSnapshots.Current(), test.expected, present)
 			}
-			assert.Nil(t, state.LocalConnectionID())
-			assert.False(t, state.LocalCIDOffered)
-			assert.False(t, state.CID.Negotiated)
+			assert.Zero(t, generatorCalls, "server CID generation is deferred until the final ServerHello")
+			assertConnectionIDs(t, state, nil, nil, false)
 		})
 	}
-}
-
-func TestFlight13_0ParseRejectsDuplicateConnectionID(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	state := newTestState13(false)
-	cache := dtlsflight.NewCache()
-	exts := append(requiredClientHello13Extensions(t, cfg),
-		&extension.ConnectionID{CID: []byte{0x01}},
-		&extension.ConnectionID{CID: []byte{0x02}},
-	)
-	pushFlight13_0ClientHello(t, cache, cfg, exts)
-
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
-		t, dtlsflight13.Flight0, context.Background(), &handshakeTestContext13{
-			state: state,
-			cache: cache,
-			cfg:   cfg,
-		},
-	)
-
-	require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
-	require.NotNil(t, dtlsAlert)
-	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
-	assert.Zero(t, nextFlight)
-	assert.Nil(t, state.RemoteConnectionID)
-	assert.False(t, state.RemoteCIDOffered)
 }
 
 func parseFlight13ServerHelloConnectionID(
@@ -4009,128 +3787,77 @@ func parseFlight13ServerHelloConnectionID(
 	return state, nextFlight, dtlsAlert, err
 }
 
-func TestFlight13_3ParseNegotiatesConnectionIDs(t *testing.T) {
-	tests := map[string]struct {
-		clientCID   []byte
-		serverCID   []byte
-		serverSends bool
-	}{
-		"ServerDeclines": {},
-		"BothEmpty": {
-			serverSends: true,
-		},
-		"OnlyClientSendsCID": {
-			serverCID:   []byte{0x10, 0x11},
-			serverSends: true,
-		},
-		"OnlyServerSendsCID": {
-			clientCID:   []byte{0x01, 0x02},
-			serverSends: true,
-		},
-		"Bidirectional": {
-			clientCID:   []byte{0x01, 0x02},
-			serverCID:   []byte{0x10, 0x11},
-			serverSends: true,
-		},
-	}
+func TestFlight13_3ParseConnectionID(t *testing.T) {
+	tests := connectionIDNegotiationCases()
+	tests["UnsolicitedEmpty"] = connectionIDNegotiationCase{serverCIDs: [][]byte{{}}, expectedErr: dtlserrors.ErrUnsolicitedExtension, description: alert.UnsupportedExtension}                                          //nolint:lll
+	tests["UnsolicitedNonEmpty"] = connectionIDNegotiationCase{serverCIDs: [][]byte{{0x10, 0x11}}, expectedErr: dtlserrors.ErrUnsolicitedExtension, description: alert.UnsupportedExtension}                             //nolint:lll
+	tests["Duplicate"] = connectionIDNegotiationCase{clientOffers: true, clientCID: []byte{1}, serverCIDs: [][]byte{{0x10}, {0x11}}, expectedErr: dtlserrors.ErrDuplicateExtension, description: alert.IllegalParameter} //nolint:lll
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			var serverCIDs [][]byte
-			if test.serverSends {
-				serverCIDs = [][]byte{test.serverCID}
-			}
 			state, nextFlight, dtlsAlert, err := parseFlight13ServerHelloConnectionID(
-				t, true, test.clientCID, serverCIDs,
+				t, test.clientOffers, test.clientCID, test.serverCIDs,
 			)
-			require.NoError(t, err)
-			require.Nil(t, dtlsAlert)
 			assert.Zero(t, nextFlight, "the parser should wait for the protected remainder of Flight 3")
-
-			assert.Equal(t, test.serverSends, state.CID.Negotiated)
-			if !test.serverSends {
-				assert.Nil(t, state.LocalConnectionID())
-				assert.Nil(t, state.RemoteConnectionID)
-				assert.False(t, state.LocalCIDOffered)
-				assert.False(t, state.RemoteCIDOffered)
-				assert.Equal(t, dtlsstate.CIDState{}, state.CID)
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+				assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: test.description}, dtlsAlert)
+				assertConnectionIDs(t, state, nil, nil, false)
 
 				return
 			}
-
-			assert.True(t, state.LocalCIDOffered)
-			assert.True(t, state.RemoteCIDOffered)
-			assert.Equal(t, test.clientCID, state.LocalConnectionID())
-			assert.Equal(t, test.serverCID, state.RemoteConnectionID)
-			assert.Equal(t, len(test.clientCID), state.CID.Receive.Length)
-			assert.Equal(t, len(test.clientCID) > 0, state.CID.Receive.Expected)
-			assert.Equal(t, len(test.clientCID) > 0, state.CID.Receive.CanSendNewConnectionID)
-			assert.Equal(t, len(test.serverCID) > 0, state.CID.Send.UseCID)
-			assert.Equal(t, test.serverCID, state.CID.Send.Active)
+			require.NoError(t, err)
+			require.Nil(t, dtlsAlert)
+			if len(test.serverCIDs) == 0 {
+				assertConnectionIDs(t, state, nil, nil, false)
+			} else {
+				assertConnectionIDs(t, state, test.clientCID, test.serverCIDs[0], true)
+			}
 		})
 	}
 }
 
-func TestFlight13_3ParseRejectsUnsolicitedConnectionID(t *testing.T) {
-	for name, cid := range map[string][]byte{
-		"Empty":    {},
-		"NonEmpty": {0x10, 0x11},
+func TestFlight13_1ParseRejectsHelloRetryRequestExtension(t *testing.T) {
+	for name, test := range map[string]struct {
+		extension   extension.Value
+		expectedErr error
+		description alert.Description
+		isClient    bool
+		generate    bool
+	}{
+		"ConnectionID": {
+			extension: &extension.ConnectionID{}, expectedErr: dtlserrors.ErrExtensionNotAllowed,
+			description: alert.IllegalParameter, isClient: true,
+		},
+		"Unsolicited": {
+			extension: extension.Raw{Type: 0xfafa}, expectedErr: dtlserrors.ErrUnsolicitedExtension,
+			description: alert.UnsupportedExtension, generate: true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			state, nextFlight, dtlsAlert, err := parseFlight13ServerHelloConnectionID(
-				t, false, nil, [][]byte{cid},
-			)
+			cfg, state := testHandshakeConfig13(t), newTestState13(test.isClient)
+			if test.generate {
+				_, dtlsAlert, err := flight13GenerateForTest(
+					t, dtlsflight13.Flight1, &handshakeTestContext13{state: state, cfg: cfg},
+				)
+				require.NoError(t, err)
+				require.Nil(t, dtlsAlert)
+			}
+			rawServerHello := marshalHelloRetryRequestServerHello(t, cfg, []extension.Value{
+				&extension13.SelectedVersion{Version: protocol.Version1_3}, test.extension,
+			})
+			cache := dtlsflight.NewCache()
+			cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
 
-			require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+			nextFlight, dtlsAlert, err := flight13ParseForTest(
+				t, dtlsflight13.Flight1, context.Background(), &handshakeTestContext13{
+					state: state, cache: cache, cfg: cfg,
+				},
+			)
+			require.ErrorIs(t, err, test.expectedErr)
 			require.NotNil(t, dtlsAlert)
-			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
+			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: test.description}, dtlsAlert)
 			assert.Zero(t, nextFlight)
-			assert.Nil(t, state.LocalConnectionID())
-			assert.False(t, state.LocalCIDOffered)
-			assert.Nil(t, state.RemoteConnectionID)
-			assert.False(t, state.RemoteCIDOffered)
-			assert.Equal(t, dtlsstate.CIDState{}, state.CID)
 		})
 	}
-}
-
-func TestFlight13_3ParseRejectsDuplicateConnectionID(t *testing.T) {
-	state, nextFlight, dtlsAlert, err := parseFlight13ServerHelloConnectionID(
-		t, true, []byte{0x01}, [][]byte{{0x10}, {0x11}},
-	)
-
-	require.ErrorIs(t, err, dtlserrors.ErrDuplicateExtension)
-	require.NotNil(t, dtlsAlert)
-	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
-	assert.Zero(t, nextFlight)
-	assert.False(t, state.CID.Negotiated)
-}
-
-func TestFlight13_1ParseRejectsConnectionIDInHelloRetryRequest(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	rawServerHello := marshalHelloRetryRequestServerHello(
-		t,
-		cfg,
-		[]extension.Value{
-			&extension13.SelectedVersion{Version: protocol.Version1_3},
-			&extension.ConnectionID{CID: []byte{}},
-		},
-	)
-	state := newTestState13(true)
-	cache := dtlsflight.NewCache()
-	cache.Push(rawServerHello, cfg.InitialEpoch, 0, handshake.TypeServerHello, false)
-
-	nextFlight, dtlsAlert, err := flight13ParseForTest(
-		t, dtlsflight13.Flight1, context.Background(), &handshakeTestContext13{
-			state: state,
-			cache: cache,
-			cfg:   cfg,
-		},
-	)
-
-	require.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
-	require.NotNil(t, dtlsAlert)
-	assert.Equal(t, alert.Fatal, dtlsAlert.Level)
-	assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
-	assert.Zero(t, nextFlight)
 }

--- a/internal/extensionnegotiation/negotiation.go
+++ b/internal/extensionnegotiation/negotiation.go
@@ -38,6 +38,11 @@ func (s ClientHelloSnapshot) Extension(typ extension.Type) (extension.Raw, bool)
 	return extension.Raw{}, false
 }
 
+// Offered reports whether the ClientHello contained typ.
+func (s ClientHelloSnapshot) Offered(typ extension.Type) bool {
+	return slices.ContainsFunc(s.extensions, func(raw extension.Raw) bool { return raw.Type == typ })
+}
+
 // ClientHelloSnapshots retains the initial and most recent offers.
 // Its snapshots are immutable.
 type ClientHelloSnapshots struct {
@@ -54,15 +59,25 @@ func (s ClientHelloSnapshots) Current() ClientHelloSnapshot { return s.current }
 // Reset removes all retained offers.
 func (s *ClientHelloSnapshots) Reset() { *s = ClientHelloSnapshots{} }
 
-// Record retains snapshot as the current offer.
-func (s *ClientHelloSnapshots) Record(snapshot ClientHelloSnapshot) {
+// Record retains snapshot as the current offer, rejecting a changed CID on retry.
+func (s *ClientHelloSnapshots) Record(snapshot ClientHelloSnapshot) error {
 	if !snapshot.Valid() {
-		return
+		return nil
 	}
-	if !s.initial.Valid() {
+	if s.initial.Valid() {
+		first, firstPresent := s.initial.Extension(extension.TypeConnectionID)
+		second, secondPresent := snapshot.Extension(extension.TypeConnectionID)
+		if firstPresent != secondPresent || !bytes.Equal(first.Data, second.Data) {
+			return negotiationError(dtlserrors.ErrInvalidClientHello,
+				fmt.Errorf("connection_id changed after retry: %w", dtlserrors.ErrInvalidClientHello),
+				alert.IllegalParameter)
+		}
+	} else {
 		s.initial = snapshot
 	}
 	s.current = snapshot
+
+	return nil
 }
 
 // RecordWire retains the exact ClientHello body from an unfragmented DTLS
@@ -70,35 +85,22 @@ func (s *ClientHelloSnapshots) Record(snapshot ClientHelloSnapshot) {
 func (s *ClientHelloSnapshots) RecordWire(rawHandshake []byte) error {
 	var header handshake.Header
 	if err := header.Unmarshal(rawHandshake); err != nil {
-		return fmt.Errorf(
-			"%w: header: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
-		)
+		return negotiationError(dtlserrors.ErrInvalidClientHello, fmt.Errorf("header: %w", err), alert.DecodeError)
 	}
 	if header.Type != handshake.TypeClientHello ||
 		header.FragmentOffset != 0 || header.FragmentLength != header.Length ||
 		int(header.Length) != len(rawHandshake)-handshake.HeaderLength {
-		return fmt.Errorf(
-			"%w: invalid wire handshake: %w",
-			dtlserrors.ErrInvalidClientHello,
-			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
-		)
+		return negotiationError(dtlserrors.ErrInvalidClientHello,
+			fmt.Errorf("invalid wire handshake: %w", dtlserrors.ErrInvalidClientHello), alert.DecodeError)
 	}
 
 	snapshot, err := snapshotClientHello(rawHandshake[handshake.HeaderLength:])
 	if err != nil {
-		return fmt.Errorf(
-			"%w: wire handshake: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.DecodeError},
-		)
+		return negotiationError(dtlserrors.ErrInvalidClientHello,
+			fmt.Errorf("wire handshake: %w", err), alert.DecodeError)
 	}
-	s.Record(snapshot)
 
-	return nil
+	return s.Record(snapshot)
 }
 
 // FinalizeClientHello clones and validates a ClientHello before and after the
@@ -108,39 +110,22 @@ func FinalizeClientHello(
 	hook func(handshake.MessageClientHello) handshake.Message,
 ) (*handshake.MessageClientHello, ClientHelloSnapshot, error) {
 	clientHello, err := validatedClientHello(base)
-	if err != nil {
-		return nil, ClientHelloSnapshot{}, err
+	if err == nil && hook != nil {
+		clientHello, err = validatedClientHello(hook(*clientHello))
 	}
-
-	message := handshake.Message(clientHello)
-	if hook != nil {
-		message = hook(*clientHello)
-	}
-	clientHello, err = validatedClientHello(message)
 	if err != nil {
 		return nil, ClientHelloSnapshot{}, err
 	}
 
 	body, err := clientHello.Marshal()
-	if err != nil {
-		return nil, ClientHelloSnapshot{}, fmt.Errorf(
-			"%w: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
-	}
-	snapshot, err := snapshotClientHello(body)
-	if err != nil {
-		return nil, ClientHelloSnapshot{}, fmt.Errorf(
-			"%w: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
+	if err == nil {
+		var snapshot ClientHelloSnapshot
+		if snapshot, err = snapshotClientHello(body); err == nil {
+			return clientHello, snapshot, nil
+		}
 	}
 
-	return clientHello, snapshot, nil
+	return nil, ClientHelloSnapshot{}, negotiationError(dtlserrors.ErrInvalidClientHello, err, alert.InternalError)
 }
 
 func snapshotClientHello(body []byte) (ClientHelloSnapshot, error) {
@@ -205,27 +190,100 @@ func ValidateServerHelloResponse(
 ) error {
 	random := serverHello.Random.MarshalFixed()
 	isHelloRetryRequest := bytes.Equal(random[:], handshake.HelloRetryRequestRandom())
-	offeredTypes := make(map[extension.Type]struct{}, len(offer.extensions))
-	for _, value := range offer.extensions {
-		offeredTypes[value.Type] = struct{}{}
+
+	err := ValidateResponseExtensions(offer, serverHello.Extensions, func(typ extension.Type) bool {
+		return (isHelloRetryRequest && typ == extension.TypeCookie) ||
+			(!isHelloRetryRequest && typ == extension.TypeRenegotiationInfo &&
+				clientHelloHasCipherSuite(offer, 0x00ff))
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", dtlserrors.ErrInvalidServerHello, err)
 	}
 
-	for _, value := range serverHello.Extensions {
-		typ := value.ExtensionType()
-		_, offered := offeredTypes[typ]
-		if offered ||
-			(isHelloRetryRequest && typ == extension.TypeCookie) ||
-			(!isHelloRetryRequest && typ == extension.TypeRenegotiationInfo &&
-				clientHelloHasCipherSuite(offer, 0x00ff)) {
-			continue
-		}
+	return nil
+}
 
-		return fmt.Errorf(
-			"extension %d: %w: %w",
-			typ,
-			dtlserrors.ErrUnsolicitedExtension,
-			&alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
-		)
+// ValidateServerHello12Context rejects responses that the wire codec
+// classified as HelloRetryRequest or DTLS 1.3 ServerHello.
+func ValidateServerHello12Context(serverHello *handshake.MessageServerHello) error {
+	random := serverHello.Random.MarshalFixed()
+	is13 := slices.ContainsFunc(serverHello.Extensions, func(value extension.Value) bool {
+		typ := value.ExtensionType()
+
+		return typ == extension.TypeSupportedVersions || typ == extension.TypeKeyShare || typ == extension.TypePreSharedKey
+	})
+	if !bytes.Equal(random[:], handshake.HelloRetryRequestRandom()) && !is13 {
+		return nil
+	}
+
+	return negotiationError(dtlserrors.ErrInvalidServerHello,
+		fmt.Errorf("response is not a DTLS 1.2 ServerHello: %w", dtlserrors.ErrExtensionNotAllowed), alert.IllegalParameter)
+}
+
+func ValidateResponseExtensions(
+	offer ClientHelloSnapshot,
+	values []extension.Value,
+	allowed func(extension.Type) bool,
+) error {
+	for _, value := range values {
+		typ := value.ExtensionType()
+		if !offer.Offered(typ) && (allowed == nil || !allowed(typ)) {
+			return fmt.Errorf("extension %d: %w: %w", typ, dtlserrors.ErrUnsolicitedExtension,
+				&alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension})
+		}
+	}
+
+	return nil
+}
+
+// FinalizeServerHello clones and validates a ServerHello before and after its
+// hook.
+func FinalizeServerHello(
+	base *handshake.MessageServerHello,
+	hook func(handshake.MessageServerHello) handshake.Message,
+	offer ClientHelloSnapshot,
+) (*handshake.MessageServerHello, error) {
+	serverHello, err := validatedServerHello(base)
+	if err == nil && hook != nil {
+		serverHello, err = validatedServerHello(hook(*serverHello))
+	}
+	if err != nil {
+		return nil, err
+	}
+	if ValidateServerHello12Context(serverHello) != nil {
+		return nil, invalidHook(dtlserrors.ErrInvalidServerHello, serverHello, dtlserrors.ErrInvalidServerHello)
+	}
+	if err := ValidateServerHelloResponse(offer, serverHello); err != nil {
+		return nil, err
+	}
+
+	return serverHello, nil
+}
+
+// ConnectionIDOffer returns the offered connection ID and its presence.
+func ConnectionIDOffer(snapshot ClientHelloSnapshot) ([]byte, bool) {
+	raw, ok := snapshot.Extension(extension.TypeConnectionID)
+	if !ok || len(raw.Data) == 0 || len(raw.Data) != int(raw.Data[0])+1 {
+		return nil, false
+	}
+
+	return raw.Data[1:], true
+}
+
+// ConnectionID is the session-wide CID negotiation decision.
+type ConnectionID struct {
+	ClientCID, ServerCID []byte
+}
+
+// DecideConnectionID derives a CID decision from an offer and final response.
+func DecideConnectionID(offer ClientHelloSnapshot, responses []extension.Value) *ConnectionID {
+	clientCID, offered := ConnectionIDOffer(offer)
+	if offered {
+		for _, value := range responses {
+			if response, ok := value.(*extension.ConnectionID); ok && response != nil {
+				return &ConnectionID{ClientCID: clientCID, ServerCID: bytes.Clone(response.CID)}
+			}
+		}
 	}
 
 	return nil
@@ -240,39 +298,55 @@ func clientHelloHasCipherSuite(offer ClientHelloSnapshot, id uint16) bool {
 func validatedClientHello(message handshake.Message) (*handshake.MessageClientHello, error) {
 	clientHello, ok := message.(*handshake.MessageClientHello)
 	if !ok || clientHello == nil {
-		return nil, fmt.Errorf(
-			"%w: hook returned %T: %w",
-			dtlserrors.ErrInvalidClientHello,
-			message,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
+		return nil, invalidHook(dtlserrors.ErrInvalidClientHello, message, nil)
 	}
 	if slices.Contains(clientHello.CompressionMethods, nil) {
-		return nil, fmt.Errorf(
-			"%w: hook returned a nil ClientHello value: %w",
-			dtlserrors.ErrInvalidClientHello,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
+		err := fmt.Errorf("hook returned a nil ClientHello value: %w", dtlserrors.ErrInvalidCompressionMethod)
+
+		return nil, invalidHook(dtlserrors.ErrInvalidClientHello, message, err)
 	}
 
-	raw, err := clientHello.Marshal()
-	if err != nil {
-		return nil, fmt.Errorf(
-			"%w: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
-	}
 	canonical := &handshake.MessageClientHello{}
-	if err := canonical.Unmarshal(raw); err != nil {
-		return nil, fmt.Errorf(
-			"%w: %w: %w",
-			dtlserrors.ErrInvalidClientHello,
-			err,
-			&alert.Alert{Level: alert.Fatal, Description: alert.InternalError},
-		)
+	if err := canonicalize(clientHello, canonical, dtlserrors.ErrInvalidClientHello); err != nil {
+		return nil, err
 	}
 
 	return canonical, nil
+}
+
+func validatedServerHello(message handshake.Message) (*handshake.MessageServerHello, error) {
+	serverHello, ok := message.(*handshake.MessageServerHello)
+	if !ok || serverHello == nil {
+		return nil, invalidHook(dtlserrors.ErrInvalidServerHello, message, nil)
+	}
+	canonical := &handshake.MessageServerHello{}
+	if err := canonicalize(serverHello, canonical, dtlserrors.ErrInvalidServerHello); err != nil {
+		return nil, err
+	}
+
+	return canonical, nil
+}
+
+func canonicalize(message, canonical handshake.Message, kind error) error {
+	raw, err := message.Marshal()
+	if err == nil {
+		err = canonical.Unmarshal(raw)
+	}
+	if err != nil {
+		return invalidHook(kind, message, err)
+	}
+
+	return nil
+}
+
+func invalidHook(kind error, message handshake.Message, err error) error {
+	if err == nil {
+		err = fmt.Errorf("hook returned %T: %w", message, kind)
+	}
+
+	return negotiationError(kind, err, alert.InternalError)
+}
+
+func negotiationError(kind, err error, description alert.Description) error {
+	return fmt.Errorf("%w: %w: %w", kind, err, &alert.Alert{Level: alert.Fatal, Description: description})
 }

--- a/internal/extensionnegotiation/negotiation_test.go
+++ b/internal/extensionnegotiation/negotiation_test.go
@@ -180,7 +180,7 @@ func TestClientHelloSnapshotsRetainInitialAndCurrentOffers(t *testing.T) {
 			clientHelloForTest(extension.Raw{Type: unknownExtensionType, Data: []byte{value}}), nil,
 		)
 		require.NoError(t, err)
-		history.Record(snapshot)
+		require.NoError(t, history.Record(snapshot))
 	}
 
 	initial, ok := history.Initial().Extension(unknownExtensionType)
@@ -250,6 +250,21 @@ func TestValidateServerHelloResponse(t *testing.T) {
 			require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
 			requireAlert(t, err, alert.UnsupportedExtension)
 		})
+	}
+}
+
+func TestValidateServerHello12Context(t *testing.T) {
+	check := func(serverHello *handshake.MessageServerHello) {
+		err := ValidateServerHello12Context(serverHello)
+		require.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
+		require.ErrorIs(t, err, dtlserrors.ErrExtensionNotAllowed)
+		requireAlert(t, err, alert.IllegalParameter)
+	}
+	check(helloRetryRequestForTest())
+	for _, typ := range []extension.Type{
+		extension.TypeSupportedVersions, extension.TypeKeyShare, extension.TypePreSharedKey,
+	} {
+		check(serverHelloForTest(extension.Raw{Type: typ}))
 	}
 }
 

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -47,10 +47,7 @@ func flight0Parse(
 
 	// Connection Identifiers must be negotiated afresh on session resumption.
 	// https://datatracker.ietf.org/doc/html/rfc9146#name-the-connection_id-extension
-	state.SetLocalConnectionID(nil)
-	state.LocalCIDOffered = false
-	state.RemoteConnectionID = nil
-	state.RemoteCIDOffered = false
+	state.ResetConnectionIDs()
 
 	state.HandshakeRecvSequence = pull.NextSequence
 
@@ -119,24 +116,10 @@ func flight0Parse(
 			state.RemoteSupportsRenegotiation = true
 		case *extension.ALPNOffer:
 			state.PeerSupportedProtocols = slices.Clone(ext.Protocols)
-		case *extension.ConnectionID:
-			// Only set connection ID to be sent if server supports connection
-			// IDs.
-			if cfg.ConnectionIDGenerator != nil {
-				state.RemoteConnectionID = bytes.Clone(ext.CID)
-				state.RemoteCIDOffered = true
-			}
 		case *extension.CertificateSignatureAlgorithms:
 			// Store the client's certificate signature schemes for later validation
 			state.RemoteCertSignatureSchemes = dtlsflight.SignatureSchemes(ext.Schemes)
 		}
-	}
-
-	// If the client doesn't support connection IDs, the server should not
-	// expect one to be sent.
-	if !state.RemoteCIDOffered {
-		state.SetLocalConnectionID(nil)
-		state.LocalCIDOffered = false
 	}
 
 	if cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret && !state.ExtendedMasterSecret {

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -71,6 +71,7 @@ func flight1Generate(
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
+	state.ResetConnectionIDs()
 	state.LocalClientHelloSnapshots.Reset()
 
 	var zeroEpoch uint16
@@ -161,9 +162,7 @@ func flight1Generate(
 	// in which case we are just requesting that the server send us a CID to
 	// use.
 	if cfg.ConnectionIDGenerator != nil {
-		state.SetLocalConnectionID(cfg.ConnectionIDGenerator())
-		state.LocalCIDOffered = true
-		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
+		extensions = append(extensions, &extension.ConnectionID{CID: cfg.ConnectionIDGenerator()})
 	}
 
 	clientHello := &handshake.MessageClientHello{
@@ -180,7 +179,9 @@ func flight1Generate(
 	if err != nil {
 		return nil, nil, err
 	}
-	state.LocalClientHelloSnapshots.Record(snapshot)
+	if err := state.RecordLocalClientHello(snapshot); err != nil {
+		return nil, nil, err
+	}
 	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{

--- a/internal/flight/flight12/flight2handler.go
+++ b/internal/flight/flight12/flight2handler.go
@@ -56,7 +56,7 @@ func flight2Parse(
 	}
 
 	if err := state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
-		return 0, nil, err
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
 
 	return Flight4, nil, nil

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -32,7 +32,7 @@ func flight3Parse(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) (Flight, *alert.Alert, error) {
+) (next Flight, dtlsAlert *alert.Alert, err error) {
 	// Clients may receive multiple HelloVerifyRequest messages with different cookies.
 	// Clients SHOULD handle this by sending a new ClientHello with a cookie in response
 	// to the new HelloVerifyRequest. RFC 6347 Section 4.2.1
@@ -63,17 +63,29 @@ func flight3Parse(
 
 	serverResponse = serverResponsePull.Messages[handshake.TypeServerHello]
 	serverHelloMsg, hasServerHello := serverResponse.(*handshake.MessageServerHello)
+	var decision *extensionnegotiation.ConnectionID
 	if hasServerHello { //nolint:nestif
 		if !serverHelloMsg.Version.Equal(protocol.Version1_2) {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
-		if err := extensionnegotiation.ValidateServerHelloResponse(
-			state.LocalClientHelloSnapshots.Current(), serverHelloMsg,
-		); err != nil {
-			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
-				err
+		offer := state.LocalClientHelloSnapshots.Current()
+		if validationErr := extensionnegotiation.ValidateServerHello12Context(serverHelloMsg); validationErr != nil {
+			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, validationErr
 		}
+		if validationErr := extensionnegotiation.ValidateServerHelloResponse(offer, serverHelloMsg); validationErr != nil {
+			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, validationErr
+		}
+		decision = extensionnegotiation.DecideConnectionID(offer, serverHelloMsg.Extensions)
+		if decision == nil {
+			state.CommitNegotiatedExtensions(nil)
+		}
+		defer func() {
+			if err != nil || dtlsAlert != nil {
+				state.ResetConnectionIDs()
+			}
+		}()
+
 		for _, v := range serverHelloMsg.Extensions {
 			switch ext := v.(type) {
 			case *extension.SRTPSelection:
@@ -91,20 +103,7 @@ func flight3Parse(
 				}
 			case *extension.ALPNSelection:
 				state.NegotiatedProtocol = ext.Protocol
-			case *extension.ConnectionID:
-				// Only set connection ID to be sent if client supports connection
-				// IDs.
-				if state.LocalCIDOffered {
-					state.RemoteConnectionID = bytes.Clone(ext.CID)
-					state.RemoteCIDOffered = true
-				}
 			}
-		}
-		// If the server doesn't support connection IDs, the client should not
-		// expect one to be sent.
-		if !state.RemoteCIDOffered {
-			state.SetLocalConnectionID(nil)
-			state.LocalCIDOffered = false
 		}
 
 		if cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret && !state.ExtendedMasterSecret {
@@ -134,7 +133,12 @@ func flight3Parse(
 		cfg.Log.Tracef("[handshake] use cipher suite: %s", selectedCipherSuite.String())
 
 		if len(serverHelloMsg.SessionID) > 0 && bytes.Equal(state.SessionID, serverHelloMsg.SessionID) {
-			return handleResumption(ctx, conn, state, cache, cfg)
+			next, dtlsAlert, err := handleResumption(ctx, conn, state, cache, cfg)
+			if next != 0 && err == nil {
+				state.CommitNegotiatedExtensions(decision)
+			}
+
+			return next, dtlsAlert, err
 		}
 
 		if cfg.HasSessionStore && len(state.SessionID) > 0 {
@@ -196,6 +200,7 @@ func flight3Parse(
 		state.RemoteCertRequestAlgs = slices.Clone(creq.SignatureHashAlgorithms)
 		state.RemoteRequestedCertificate = true
 	}
+	state.CommitNegotiatedExtensions(decision)
 
 	return Flight5, nil, nil
 }
@@ -367,10 +372,11 @@ func flight3Generate(
 		extensions = append(extensions, &extension.ALPNOffer{Protocols: cfg.SupportedProtocols})
 	}
 
-	// If we sent a connection ID on the first ClientHello, send it on the
-	// second.
-	if cfg.ConnectionIDGenerator != nil && state.LocalCIDOffered {
-		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
+	// If the generated first ClientHello offered a connection ID, use the
+	// exact post-hook value as the default in the second ClientHello.
+	cid, cidOffered := extensionnegotiation.ConnectionIDOffer(state.LocalClientHelloSnapshots.Initial())
+	if cfg.ConnectionIDGenerator != nil && cidOffered {
+		extensions = append(extensions, &extension.ConnectionID{CID: cid})
 	}
 
 	clientHello := &handshake.MessageClientHello{
@@ -387,7 +393,9 @@ func flight3Generate(
 	if err != nil {
 		return nil, nil, err
 	}
-	state.LocalClientHelloSnapshots.Record(snapshot)
+	if err := state.RecordLocalClientHello(snapshot); err != nil {
+		return nil, nil, err
+	}
 	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,8 +31,7 @@ func TestFlight3GenerateReusesHookOnlyConnectionIDAfterVersionDowngrade(t *testi
 	} {
 		t.Run(name, func(t *testing.T) {
 			state13 := dtlsstate.NewState13(true)
-			state13.SetLocalConnectionID(cid)
-			state13.LocalCIDOffered = true
+			recordCH12(t, &state13.LocalClientHelloSnapshots, &extension.ConnectionID{CID: cid})
 			state := dtlsstate.Activate12(&state13)
 			cfg := &dtlsconfig.HandshakeConfig{
 				ClientHelloMessageHook: func(clientHello handshake.MessageClientHello) handshake.Message {
@@ -64,6 +64,7 @@ func TestFlight3GenerateReusesHookOnlyConnectionIDAfterVersionDowngrade(t *testi
 
 func TestFlight3GenerateRestoresCurveExtensionsAfterVersionDowngrade(t *testing.T) {
 	state13 := dtlsstate.NewState13(true)
+	recordCH12(t, &state13.LocalClientHelloSnapshots)
 	state := dtlsstate.Activate12(&state13)
 	cfg := &dtlsconfig.HandshakeConfig{EllipticCurves: []elliptic.Curve{elliptic.X25519}}
 
@@ -90,25 +91,159 @@ func TestFlight3RejectsUnsolicitedServerHelloExtension(t *testing.T) {
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 	}
 	_, offer, err := extensionnegotiation.FinalizeClientHello(clientHello, nil)
-	assert.NoError(t, err)
-	state.LocalClientHelloSnapshots.Record(offer)
+	require.NoError(t, err)
+	require.NoError(t, state.LocalClientHelloSnapshots.Record(offer))
 
 	cipherSuiteID := uint16(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
 	raw, err := (&handshake.Handshake{Message: &handshake.MessageServerHello{
 		Version:           protocol.Version1_2,
 		CipherSuiteID:     &cipherSuiteID,
 		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-		Extensions: []extension.Value{
-			extension.Raw{Type: 0xfafa},
-		},
+		Extensions:        []extension.Value{extension.Raw{Type: 0xfafa}},
 	}}).Marshal()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cache := dtlsflight.NewCache()
 	cache.Push(raw, 0, 0, handshake.TypeServerHello, false)
 
 	_, dtlsAlert, err := parseForTest(
 		t, Flight3, context.Background(), nil, state, cache, &dtlsconfig.HandshakeConfig{},
 	)
+	assert.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
 	assert.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
 	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
+}
+
+func TestFlight3DoesNotCommitConnectionIDBeforeSuccess(t *testing.T) {
+	state := newTestState12()
+	state.IsClient, state.SessionID = true, []byte{1}
+	recordCH12(t, &state.LocalClientHelloSnapshots, &extension.ConnectionID{CID: []byte{0xc1}})
+	suite := ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalCipherSuites: []dtlsconfig.CipherSuite{suite}, HasSessionStore: true,
+		DelSession: func([]byte) error { return dtlserrors.ErrInvalidPacket },
+		Log:        logging.NewDefaultLoggerFactory().NewLogger("dtls"),
+	}
+	cipherSuiteID := uint16(suite.ID())
+	raw, err := (&handshake.Handshake{Message: &handshake.MessageServerHello{
+		Version: protocol.Version1_2, SessionID: []byte{2}, CipherSuiteID: &cipherSuiteID,
+		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		Extensions:        []extension.Value{&extension.ConnectionID{CID: []byte{0x51}}},
+	}}).Marshal()
+	require.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(raw, 0, 0, handshake.TypeServerHello, false)
+
+	_, dtlsAlert, err := parseForTest(t, Flight3, t.Context(), nil, state, cache, cfg)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidPacket)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, dtlsAlert)
+	assert.False(t, state.LocalCIDOffered || state.RemoteCIDOffered)
+	assert.Nil(t, state.LocalConnectionID())
+	assert.Nil(t, state.RemoteConnectionID)
+}
+
+func TestFlight2RejectsChangedConnectionID(t *testing.T) {
+	state := newTestState12()
+	state.Cookie, state.HandshakeRecvSequence = []byte{0xc0}, 1
+	recordCH12(t, &state.RemoteClientHelloSnapshots, &extension.ConnectionID{CID: []byte{1}})
+	raw, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageClientHello{
+			Version: protocol.Version1_2, Cookie: state.Cookie,
+			CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+			Extensions:         []extension.Value{&extension.ConnectionID{CID: []byte{2}}},
+		},
+	}).Marshal()
+	require.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(raw, 0, 1, handshake.TypeClientHello, true)
+
+	_, dtlsAlert, err := parseForTest(t, Flight2, t.Context(), nil, state, cache, &dtlsconfig.HandshakeConfig{})
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
+	cid, present := extensionnegotiation.ConnectionIDOffer(state.RemoteClientHelloSnapshots.Current())
+	assert.Equal(t, []byte{1}, cid)
+	assert.True(t, present)
+}
+
+func TestFlight4bGenerateCommitsConnectionIDOnce(t *testing.T) {
+	for name, test := range map[string]struct {
+		clientCID, serverCID []byte
+	}{
+		"bidirectional":       {[]byte{0xc1}, []byte{0x51}},
+		"empty client CID":    {nil, []byte{0x51}},
+		"empty server CID":    {[]byte{0xc1}, nil},
+		"both CIDs are empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := newTestState12()
+			state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
+			state.LocalVerifyData = []byte{1}
+			recordCH12(t, &state.RemoteClientHelloSnapshots, &extension.ConnectionID{CID: test.clientCID})
+			calls := 0
+			cfg := &dtlsconfig.HandshakeConfig{ConnectionIDGenerator: func() []byte {
+				calls++
+
+				return test.serverCID
+			}}
+			for range 2 {
+				packets, _, err := generateForTest(t, Flight4b, nil, state, dtlsflight.NewCache(), cfg)
+				require.NoError(t, err)
+				require.Len(t, packets, 3)
+				assert.Equal(t, len(test.clientCID) > 0, packets[2].ShouldWrapCID)
+			}
+			assert.Equal(t, 1, calls)
+			assert.True(t, state.LocalCIDOffered && state.RemoteCIDOffered)
+			assert.Equal(t, string(test.serverCID), string(state.LocalConnectionID()))
+			assert.Equal(t, string(test.clientCID), string(state.RemoteConnectionID))
+		})
+	}
+}
+
+func TestFlight4bGenerateDoesNotCommitConnectionIDAfterLateResponseError(t *testing.T) {
+	state := newTestState12()
+	state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
+	state.LocalVerifyData = []byte{1}
+	recordCH12(t, &state.RemoteClientHelloSnapshots, &extension.ConnectionID{CID: []byte{0xc1}})
+	cfg := &dtlsconfig.HandshakeConfig{
+		ConnectionIDGenerator: func() []byte { return []byte{0x51} },
+		ServerHelloMessageHook: func(serverHello handshake.MessageServerHello) handshake.Message {
+			serverHello.Extensions = append(serverHello.Extensions, extension.Raw{Type: 0xfafa})
+
+			return &serverHello
+		},
+	}
+
+	_, _, err := generateForTest(t, Flight4b, nil, state, nil, cfg)
+	require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+	var dtlsAlert *alert.Alert
+	require.ErrorAs(t, err, &dtlsAlert)
+	assert.Equal(t, alert.UnsupportedExtension, dtlsAlert.Description)
+	assert.False(t, state.LocalCIDOffered || state.RemoteCIDOffered)
+	assert.Nil(t, state.LocalConnectionID())
+	assert.Nil(t, state.RemoteConnectionID)
+}
+
+func TestFlight5bFinishedUsesCommittedServerConnectionID(t *testing.T) {
+	for name, decision := range map[string]*extensionnegotiation.ConnectionID{
+		"not negotiated":   nil,
+		"bidirectional":    {ClientCID: []byte{0xc1}, ServerCID: []byte{0x51}},
+		"empty server CID": {ClientCID: []byte{0xc1}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := newTestState12()
+			state.IsClient, state.LocalVerifyData = true, []byte{1}
+			state.CommitNegotiatedExtensions(decision)
+			packets, _, err := generateForTest(t, Flight5b, nil, state, nil, &dtlsconfig.HandshakeConfig{})
+			require.NoError(t, err)
+			require.Len(t, packets, 2)
+			assert.Equal(t, decision != nil && len(decision.ServerCID) > 0, packets[1].ShouldWrapCID)
+		})
+	}
+}
+
+func recordCH12(t *testing.T, snapshots *extensionnegotiation.ClientHelloSnapshots, extensions ...extension.Value) {
+	t.Helper()
+	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	require.NoError(t, err)
+	require.NoError(t, snapshots.Record(snapshot))
 }

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -9,6 +9,7 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
@@ -69,10 +70,14 @@ func flight4bGenerate(
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	var pkts []*dtlsflight.Packet
+	offer := state.RemoteClientHelloSnapshots.Current()
 
-	extensions := []extension.Value{&extension12.RenegotiationInfo{
-		RenegotiatedConnection: 0,
-	}}
+	extensions := []extension.Value{}
+	if state.RemoteSupportsRenegotiation {
+		extensions = append(extensions, &extension12.RenegotiationInfo{
+			RenegotiatedConnection: 0,
+		})
+	}
 	if (cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret) && state.ExtendedMasterSecret {
 		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
@@ -92,10 +97,11 @@ func flight4bGenerate(
 		extensions = append(extensions, &extension.ALPNSelection{Protocol: selectedProto})
 		state.NegotiatedProtocol = selectedProto
 	}
+	if cid := serverCIDExtension(state, cfg, offer); cid != nil {
+		extensions = append(extensions, cid)
+	}
 
 	cipherSuiteID := uint16(state.CipherSuite.ID())
-	var serverHello handshake.Handshake
-
 	serverHelloMessage := &handshake.MessageServerHello{
 		Version:           protocol.Version1_2,
 		Random:            state.LocalRandom,
@@ -105,11 +111,12 @@ func flight4bGenerate(
 		Extensions:        extensions,
 	}
 
-	if cfg.ServerHelloMessageHook != nil {
-		serverHello = handshake.Handshake{Message: cfg.ServerHelloMessageHook(*serverHelloMessage)}
-	} else {
-		serverHello = handshake.Handshake{Message: serverHelloMessage}
+	serverHelloMessage, err = extensionnegotiation.FinalizeServerHello(serverHelloMessage, cfg.ServerHelloMessageHook, offer) //nolint:lll
+	if err != nil {
+		return nil, nil, err
 	}
+	decision := extensionnegotiation.DecideConnectionID(offer, serverHelloMessage.Extensions)
+	serverHello := handshake.Handshake{Message: serverHelloMessage}
 
 	serverHello.Header.MessageSequence = uint16(state.HandshakeSendSequence) //nolint:gosec // G115
 
@@ -159,9 +166,11 @@ func flight4bGenerate(
 				},
 			},
 			ShouldEncrypt:            true,
+			ShouldWrapCID:            decision != nil && len(decision.ClientCID) > 0,
 			ResetLocalSequenceNumber: true,
 		},
 	)
+	state.CommitNegotiatedExtensions(decision)
 
 	return pkts, nil, nil
 }

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
@@ -262,6 +263,7 @@ func flight4Generate(
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
+	offer := state.RemoteClientHelloSnapshots.Current()
 	extensions := []extension.Value{}
 
 	if (cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
@@ -279,7 +281,8 @@ func flight4Generate(
 			RenegotiatedConnection: 0,
 		})
 	}
-	if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypeCertificate {
+	if state.CipherSuite.AuthenticationType() == ciphersuite.AuthenticationTypeCertificate &&
+		offer.Offered(extension.TypeSupportedPointFormats) {
 		extensions = append(extensions, &extension12.SupportedPointFormats{
 			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
 		})
@@ -294,14 +297,8 @@ func flight4Generate(
 		state.NegotiatedProtocol = selectedProto
 	}
 
-	// If we have a connection ID generator, we are willing to use connection
-	// IDs. We already know whether the client supports connection IDs from
-	// parsing the ClientHello, so avoid setting local connection ID if the
-	// client won't send it.
-	if cfg.ConnectionIDGenerator != nil && state.RemoteCIDOffered {
-		state.SetLocalConnectionID(cfg.ConnectionIDGenerator())
-		state.LocalCIDOffered = true
-		extensions = append(extensions, &extension.ConnectionID{CID: state.LocalConnectionID()})
+	if cid := serverCIDExtension(state, cfg, offer); cid != nil {
+		extensions = append(extensions, cid)
 	}
 
 	var pkts []*dtlsflight.Packet
@@ -309,7 +306,7 @@ func flight4Generate(
 
 	if cfg.HasSessionStore {
 		state.SessionID = make([]byte, sessionLength)
-		if _, err := rand.Read(state.SessionID); err != nil {
+		if _, err = rand.Read(state.SessionID); err != nil {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 		}
 	}
@@ -323,13 +320,12 @@ func flight4Generate(
 		Extensions:        extensions,
 	}
 
-	var content handshake.Handshake
-
-	if cfg.ServerHelloMessageHook != nil {
-		content = handshake.Handshake{Message: cfg.ServerHelloMessageHook(*serverHello)}
-	} else {
-		content = handshake.Handshake{Message: serverHello}
+	serverHello, err = extensionnegotiation.FinalizeServerHello(serverHello, cfg.ServerHelloMessageHook, offer)
+	if err != nil {
+		return nil, nil, err
 	}
+	decision := extensionnegotiation.DecideConnectionID(offer, serverHello.Extensions)
+	content := handshake.Handshake{Message: serverHello}
 
 	pkts = append(pkts, &dtlsflight.Packet{
 		Record: &recordlayer.RecordLayer{
@@ -485,6 +481,19 @@ func flight4Generate(
 			},
 		},
 	})
+	state.CommitNegotiatedExtensions(decision)
 
 	return pkts, nil, nil
+}
+
+func serverCIDExtension(state *dtlsstate.State12, cfg *dtlsconfig.HandshakeConfig, offer extensionnegotiation.ClientHelloSnapshot) *extension.ConnectionID { //nolint:lll
+	if cfg.ConnectionIDGenerator == nil || !offer.Offered(extension.TypeConnectionID) {
+		return nil
+	}
+	cid := state.LocalConnectionID()
+	if !state.LocalCIDOffered {
+		cid = cfg.ConnectionIDGenerator()
+	}
+
+	return &extension.ConnectionID{CID: cid}
 }

--- a/internal/flight/flight12/flight5bhandler.go
+++ b/internal/flight/flight12/flight5bhandler.go
@@ -88,6 +88,7 @@ func flight5bGenerate(
 				},
 			},
 			ShouldEncrypt:            true,
+			ShouldWrapCID:            state.ShouldWrapConnectionID(),
 			ResetLocalSequenceNumber: true,
 		})
 

--- a/internal/flight/flight13/extensions.go
+++ b/internal/flight/flight13/extensions.go
@@ -5,7 +5,6 @@ package flight13
 
 import (
 	"bytes"
-	"fmt"
 	"slices"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
@@ -45,10 +44,6 @@ func processClientHelloExtensions(
 	clientHello *handshake.MessageClientHello,
 ) *clientHelloExtensionFailure {
 	var seen clientHelloExtensionSet
-	remoteCID, hasRemoteCID, duplicateCID := connectionIDExtension(clientHello.Extensions)
-	if duplicateCID {
-		return newClientHelloExtensionFailure(alert.IllegalParameter, dtlserrors.ErrInvalidClientHello)
-	}
 
 	for _, val := range clientHello.Extensions {
 		if failure := processClientHelloSecurityExtension(state, cfg, &seen, val); failure != nil {
@@ -60,12 +55,6 @@ func processClientHelloExtensions(
 	if !seen.hasPreSharedKey && (!seen.hasSignatureAlgorithms || !seen.hasSupportedGroups) {
 		return newClientHelloExtensionFailure(alert.MissingExtension, dtlserrors.ErrMissingClientHelloExtension)
 	}
-	if hasRemoteCID {
-		state.RemoteConnectionID = remoteCID
-	} else {
-		state.RemoteConnectionID = nil
-	}
-	state.RemoteCIDOffered = hasRemoteCID
 
 	return nil
 }
@@ -128,47 +117,4 @@ func cloneKeyShareEntries(entries []extension13.KeyShareEntry) []extension13.Key
 	}
 
 	return cloned
-}
-
-// connectionIDExtension extracts a connection_id extension while preserving
-// the distinction between an absent extension and a present, zero-length CID.
-func connectionIDExtension(extensions []extension.Value) ([]byte, bool, bool) {
-	var cid []byte
-	found := false
-	for _, val := range extensions {
-		ext, ok := val.(*extension.ConnectionID)
-		if !ok {
-			continue
-		}
-		if found {
-			return nil, false, true
-		}
-		if len(ext.CID) > 0 {
-			cid = bytes.Clone(ext.CID)
-		}
-		found = true
-	}
-
-	return cid, found, false
-}
-
-func captureClientHelloConnectionIDOffer(
-	state *dtlsstate.State13,
-	clientHello *handshake.MessageClientHello,
-) {
-	localCID, present, _ := connectionIDExtension(clientHello.Extensions)
-	state.SetLocalConnectionID(localCID)
-	state.LocalCIDOffered = present
-}
-
-func validateRepeatedClientHelloConnectionIDOffer(
-	state *dtlsstate.State13,
-	clientHello *handshake.MessageClientHello,
-) error {
-	localCID, present, _ := connectionIDExtension(clientHello.Extensions)
-	if present != state.LocalCIDOffered || !bytes.Equal(localCID, state.LocalConnectionID()) {
-		return fmt.Errorf("%w: connection_id changed", dtlserrors.ErrInvalidClientHello)
-	}
-
-	return nil
 }

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -130,10 +130,8 @@ func flight1Generate(
 	}
 
 	if cfg.ConnectionIDGenerator != nil {
-		state.SetLocalConnectionID(bytes.Clone(cfg.ConnectionIDGenerator()))
-		state.LocalCIDOffered = true
 		extensions = append(extensions, &extension.ConnectionID{
-			CID: bytes.Clone(state.LocalConnectionID()),
+			CID: bytes.Clone(cfg.ConnectionIDGenerator()),
 		})
 	}
 
@@ -152,12 +150,11 @@ func flight1Generate(
 
 	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
 	if err != nil {
-		state.ResetConnectionIDs()
-
 		return nil, nil, err
 	}
-	captureClientHelloConnectionIDOffer(state, clientHello)
-	state.LocalClientHelloSnapshots.Record(snapshot)
+	if err := state.RecordLocalClientHello(snapshot); err != nil {
+		return nil, nil, err
+	}
 	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{
@@ -231,8 +228,7 @@ func flight1Parse(
 	if err := extensionnegotiation.ValidateServerHelloResponse(
 		state.LocalClientHelloSnapshots.Current(), sh,
 	); err != nil {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension},
-			err
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, err
 	}
 	selectedCipherSuite, dtlsAlert, err := selectServerHelloCipherSuite(sh, cfg)
 	if err != nil {

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -9,7 +9,6 @@ import (
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
-	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
@@ -51,8 +50,9 @@ func flight2Parse( //nolint:cyclop
 	if !bytes.Equal(flightCtx.state.Cookie, cookie) {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlserrors.ErrCookieMismatch
 	}
-	if failure := validateRepeatedClientHelloConnectionID(flightCtx.state, clientHello); failure != nil {
-		return 0, failure.alert, failure.err
+	snapshots := flightCtx.state.RemoteClientHelloSnapshots
+	if err := snapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
 
 	if failure := processClientHelloExtensions(flightCtx.state, flightCtx.cfg, clientHello); failure != nil {
@@ -64,25 +64,10 @@ func flight2Parse( //nolint:cyclop
 	if failure := flightCtx.handleInboundHandshake(pull.Items); failure != nil {
 		return 0, failure.alert, failure.err
 	}
-	if err := flightCtx.state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
-		return 0, nil, err
-	}
+	flightCtx.state.RemoteClientHelloSnapshots = snapshots
 	flightCtx.state.HandshakeRecvSequence = pull.NextSequence
 
 	return Flight4, nil, nil
-}
-
-func validateRepeatedClientHelloConnectionID(
-	state *dtlsstate.State13,
-	clientHello *handshake.MessageClientHello,
-) *clientHelloExtensionFailure {
-	remoteCID, present, duplicate := connectionIDExtension(clientHello.Extensions)
-	expectedPresent := state.RemoteCIDOffered
-	if duplicate || present != expectedPresent || (present && !bytes.Equal(remoteCID, state.RemoteConnectionID)) {
-		return newClientHelloExtensionFailure(alert.IllegalParameter, dtlserrors.ErrInvalidClientHello)
-	}
-
-	return nil
 }
 
 func flight2Generate(

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -51,7 +51,7 @@ func flight3Parse(
 			pull.items,
 		)
 		if failure != nil {
-			return 0, failure.alert, failure.err
+			return abortFlight3(flightCtx, failure)
 		}
 		nextHandshakeSequence = pull.nextHandshakeSequence
 	}
@@ -77,15 +77,21 @@ func flight3Parse(
 		return 0, nil, nil
 	}
 	if protectedFlight.failure != nil {
-		return 0, protectedFlight.failure.alert, protectedFlight.failure.err
+		return abortFlight3(flightCtx, protectedFlight.failure)
 	}
 	failure := handleFlight3ProtectedHandshake(flightCtx, protectedFlight.items)
 	if failure != nil {
-		return 0, failure.alert, failure.err
+		return abortFlight3(flightCtx, failure)
 	}
 	flightCtx.state.HandshakeRecvSequence = protectedFlight.nextHandshakeSequence
 
 	return Flight5, nil, nil
+}
+
+func abortFlight3(flightCtx *handshakeContext, failure *flightParseFailure) (Flight, *alert.Alert, error) {
+	flightCtx.state.ResetConnectionIDs()
+
+	return 0, failure.alert, failure.err
 }
 
 func flight3PullServerHello(
@@ -129,15 +135,11 @@ func processFlight3ServerHello(
 	if failure != nil {
 		return failure
 	}
-	if err := extensionnegotiation.ValidateServerHelloResponse(
-		flightCtx.state.LocalClientHelloSnapshots.Current(), serverHello,
-	); err != nil {
+	offer := flightCtx.state.LocalClientHelloSnapshots.Current()
+	if err := extensionnegotiation.ValidateServerHelloResponse(offer, serverHello); err != nil {
 		return newFlightParseFailure(alert.UnsupportedExtension, err)
 	}
-	remoteCID, hasRemoteCID, duplicateCID := connectionIDExtension(serverHello.Extensions)
-	if duplicateCID {
-		return newFlightParseFailure(alert.IllegalParameter, dtlserrors.ErrInvalidServerHello)
-	}
+	decision := extensionnegotiation.DecideConnectionID(offer, serverHello.Extensions)
 	flightCtx.state.RemoteVersions = versions
 	flightCtx.state.LocalVersion = protocol.Version1_3
 
@@ -157,11 +159,7 @@ func processFlight3ServerHello(
 	if failure := applyFlight3ServerKeyShare(flightCtx, serverShare); failure != nil {
 		return failure
 	}
-	if hasRemoteCID {
-		flightCtx.state.NegotiateConnectionIDs(remoteCID)
-	} else {
-		flightCtx.state.ResetConnectionIDs()
-	}
+	flightCtx.state.CommitNegotiatedExtensions(decision)
 
 	return nil
 }
@@ -256,22 +254,26 @@ func handleFlight3ProtectedHandshake(
 	flightCtx *handshakeContext,
 	items []dtlsflight.DecodedHandshakeCacheItem,
 ) *flightParseFailure {
+	flightCtx.state.RemoteCertificateRequest = nil
+	offer := flightCtx.state.LocalClientHelloSnapshots.Current()
+	for _, item := range items {
+		if item.Parsed == nil {
+			continue
+		}
+		switch message := item.Parsed.Message.(type) {
+		case *handshake.MessageEncryptedExtensions:
+			if err := extensionnegotiation.ValidateResponseExtensions(offer, message.Extensions, nil); err != nil {
+				return newFlightParseFailure(alert.UnsupportedExtension, err)
+			}
+		case *handshake.MessageCertificateRequest13:
+			flightCtx.state.RemoteCertificateRequest = message
+		}
+	}
 	if flightCtx.protectedHandshakeHandler == nil {
 		return newFlightParseFailure(alert.InternalError, dtlserrors.ErrHandshakeTranscriptHashNotSelected)
 	}
 	if err := flightCtx.protectedHandshakeHandler(flightCtx.state.CipherSuite, items); err != nil {
 		return protectedFlightParseFailure(err)
-	}
-	flightCtx.state.RemoteCertificateRequest = nil
-	for _, item := range items {
-		if item.Parsed == nil {
-			continue
-		}
-		if request, ok := item.Parsed.Message.(*handshake.MessageCertificateRequest13); ok {
-			flightCtx.state.RemoteCertificateRequest = request
-
-			break
-		}
 	}
 
 	return nil
@@ -370,11 +372,9 @@ func flight3Generate(
 		})
 	}
 
-	localCID := flightCtx.state.LocalConnectionID()
-	if flightCtx.cfg.ConnectionIDGenerator != nil && flightCtx.state.LocalCIDOffered {
-		extensions = append(extensions, &extension.ConnectionID{
-			CID: bytes.Clone(localCID),
-		})
+	localCID, localCIDOffered := extensionnegotiation.ConnectionIDOffer(flightCtx.state.LocalClientHelloSnapshots.Current()) //nolint:lll
+	if flightCtx.cfg.ConnectionIDGenerator != nil && localCIDOffered {
+		extensions = append(extensions, &extension.ConnectionID{CID: bytes.Clone(localCID)})
 	}
 
 	if len(flightCtx.state.Cookie) > 0 {
@@ -391,17 +391,13 @@ func flight3Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(
-		clientHello,
-		flightCtx.cfg.ClientHelloMessageHook,
-	)
+	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook) //nolint:lll
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := validateRepeatedClientHelloConnectionIDOffer(flightCtx.state, clientHello); err != nil {
+	if err := flightCtx.state.RecordLocalClientHello(snapshot); err != nil {
 		return nil, nil, err
 	}
-	flightCtx.state.LocalClientHelloSnapshots.Record(snapshot)
 	content := handshake.Handshake{Message: clientHello}
 
 	return []*dtlsflight.Packet{

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
@@ -235,33 +236,30 @@ func flight4Generate( //nolint:cyclop
 			KeyExchange: state.LocalKeypair.PublicKey,
 		},
 	})
-	if state.RemoteCIDOffered && cfg.ConnectionIDGenerator != nil {
-		if !state.LocalCIDOffered {
-			state.SetLocalConnectionID(bytes.Clone(cfg.ConnectionIDGenerator()))
-			state.LocalCIDOffered = true
+	offer := state.RemoteClientHelloSnapshots.Current()
+	if cfg.ConnectionIDGenerator != nil && offer.Offered(extension.TypeConnectionID) {
+		localCID := state.LocalConnectionID()
+		if !state.CID.Negotiated {
+			localCID = bytes.Clone(cfg.ConnectionIDGenerator())
 		}
-		state.NegotiateConnectionIDs(state.RemoteConnectionID)
-		serverHelloExtensions = append(serverHelloExtensions, &extension.ConnectionID{
-			CID: bytes.Clone(state.LocalConnectionID()),
-		})
-	} else {
-		state.ResetConnectionIDs()
+		serverHelloExtensions = append(serverHelloExtensions, &extension.ConnectionID{CID: bytes.Clone(localCID)})
 	}
+	serverHelloMessage := &handshake.MessageServerHello{
+		Version:           protocol.Version1_2,
+		Random:            state.LocalRandom,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		Extensions:        serverHelloExtensions,
+	}
+	if _, err = serverHelloMessage.Marshal(); err != nil {
+		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
+	}
+	decision := extensionnegotiation.DecideConnectionID(offer, serverHelloExtensions)
 
 	serverHello := &dtlsflight.Packet{
 		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &handshake.Handshake{
-				Message: &handshake.MessageServerHello{
-					Version:           protocol.Version1_2,
-					Random:            state.LocalRandom,
-					CipherSuiteID:     &cipherSuiteID,
-					CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-					Extensions:        serverHelloExtensions,
-				},
-			},
+			Header:  recordlayer.Header{Version: protocol.Version1_2},
+			Content: &handshake.Handshake{Message: serverHelloMessage},
 		},
 	}
 
@@ -306,6 +304,7 @@ func flight4Generate( //nolint:cyclop
 		),
 		HandshakePacket(&handshake.MessageFinished{}),
 	)
+	state.CommitNegotiatedExtensions(decision)
 
 	return pkts, nil, nil
 }

--- a/internal/flight/flight13/flighthandler_test.go
+++ b/internal/flight/flight13/flighthandler_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
@@ -170,6 +172,26 @@ func TestHandleFlight3ProtectedHandshakeRetainsCertificateRequest(t *testing.T) 
 	assert.Same(t, request, flightCtx.state.RemoteCertificateRequest)
 }
 
+func TestFlight3ParseClearsConnectionIDAfterInvalidEncryptedExtensions(t *testing.T) {
+	state := dtlsstate.NewState13(true)
+	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte{1}, ServerCID: []byte{2}})
+	state.SetRemoteEpoch(EpochHandshake)
+
+	cache := dtlsflight.NewCache()
+	cache.Push(marshalProtectedTestHandshake(t, 0, &handshake.MessageEncryptedExtensions{
+		Extensions: []extension.Value{extension.Raw{Type: 0xfafa}},
+	}), EpochHandshake, 0, handshake.TypeEncryptedExtensions, false)
+	cache.Push(marshalProtectedTestHandshake(t, 1, &handshake.MessageFinished{}), EpochHandshake, 1, handshake.TypeFinished, false) //nolint:lll
+	next, dtlsAlert, err := flight3Parse(t.Context(), nil, &handshakeContext{state: &state, cache: cache})
+
+	require.ErrorIs(t, err, dtlserrors.ErrUnsolicitedExtension)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, dtlsAlert)
+	assert.Zero(t, next)
+	assert.Nil(t, state.LocalConnectionIDForInboundRecords())
+	assert.Nil(t, state.RemoteConnectionID)
+	assert.Equal(t, dtlsstate.CIDState{}, state.CID)
+}
+
 func TestFlight5ClientCertificateClonesCertificateAuthorities(t *testing.T) {
 	authority := []byte{0x01, 0x02}
 	request := &handshake.MessageCertificateRequest13{Extensions: []extension.Value{
@@ -284,11 +306,23 @@ func flight4TestContext(t *testing.T) (*handshakeContext, tls.Certificate) {
 	keypair, err := elliptic.GenerateKeypair(elliptic.X25519)
 	require.NoError(t, err)
 	signatureSchemes := signaturehash.Algorithms13()
+	_, offer, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		Extensions: []extension.Value{
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(signaturehash.Algorithms13())},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}},
+			&extension13.ClientKeyShare{},
+		},
+	}, nil)
+	require.NoError(t, err)
+	var remoteOffers extensionnegotiation.ClientHelloSnapshots
+	require.NoError(t, remoteOffers.Record(offer))
 
 	return &handshakeContext{
 		state: &dtlsstate.State13{
 			Common: &dtlsstate.Common{
-				CipherSuite: ciphersuite.NewTLSAes128GcmSha256(),
+				CipherSuite:                ciphersuite.NewTLSAes128GcmSha256(),
+				RemoteClientHelloSnapshots: remoteOffers,
 			},
 			LocalKeypair:           keypair,
 			RemoteSignatureSchemes: append([]signaturehash.Algorithm(nil), signatureSchemes...),

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
@@ -102,8 +103,20 @@ func (c *flightTestConn) SessionKey() []byte {
 	return nil
 }
 
-func newTestState13(isClient bool) *dtlsstate.State13 {
+func newTestState13(t *testing.T, isClient bool) *dtlsstate.State13 {
+	t.Helper()
 	state := dtlsstate.NewState13(isClient)
+	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		Extensions: []extension.Value{
+			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
+			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(signaturehash.Algorithms13())},
+			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}},
+			&extension13.ClientKeyShare{},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_ = state.LocalClientHelloSnapshots.Record(snapshot)  // The first snapshot cannot conflict.
+	_ = state.RemoteClientHelloSnapshots.Record(snapshot) // The first snapshot cannot conflict.
 
 	return &state
 }
@@ -170,7 +183,7 @@ func TestHandshakeFSMWaitCancellationResetsRetransmitInterval(t *testing.T) {
 }
 
 func TestHandshakeFSM13OwnsTranscriptAndPropagatesContext(t *testing.T) {
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
 
@@ -186,7 +199,7 @@ func TestHandshakeFSM13OwnsTranscriptAndPropagatesContext(t *testing.T) {
 }
 
 func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	state.SetLocalEpoch(dtlsflight13.EpochApplication)
 	conn := &flightTestConn{}
 	fsm := &fsm13{handshakeContext: handshakeContext{state: state}}
@@ -203,7 +216,7 @@ func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
 
 func TestHandshakeFSM13DoesNotSendEmptyACK(t *testing.T) {
 	conn := &flightTestConn{}
-	fsm := &fsm13{handshakeContext: handshakeContext{state: newTestState13(false)}}
+	fsm := &fsm13{handshakeContext: handshakeContext{state: newTestState13(t, false)}}
 
 	require.NoError(t, sendACK(context.Background(), conn, fsm.state.LocalEpoch(), nil))
 	assert.Empty(t, conn.writtenPackets)
@@ -237,7 +250,7 @@ func TestHandshakeFSM13ACKProgress(t *testing.T) {
 }
 
 func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
 	cfg.ClientHelloMessageHook = func(ch handshake.MessageClientHello) handshake.Message {
@@ -278,7 +291,7 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 }
 
 func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testing.T) {
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
 
@@ -312,7 +325,7 @@ func TestHandshakeFSM13TranscriptSurvivesStateChangesAndRetransmitSeed(t *testin
 }
 
 func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	cache := dtlsflight.NewCache()
 	cfg := testHandshakeConfig13(t)
 
@@ -325,7 +338,7 @@ func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
 
 func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.CipherSuite = cfg.LocalCipherSuites[0]
 	cache := dtlsflight.NewCache()
 
@@ -343,7 +356,7 @@ func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testi
 
 func TestHandshakeFSM13PrepareCommitsOutboundClientHello(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	cache := dtlsflight.NewCache()
 
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, nil, nil)
@@ -364,7 +377,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundClientHello(t *testing.T) {
 
 func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscript(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.CipherSuite = cfg.LocalCipherSuites[0]
 	cache := dtlsflight.NewCache()
 	transcript := NewTranscript()
@@ -397,7 +410,7 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 	keypair, err := elliptic.GenerateKeypair(group)
 	require.NoError(t, err)
 
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.CipherSuite = cfg.LocalCipherSuites[0]
 	state.LocalKeypair = keypair
 	state.RemoteSignatureSchemes = append([]signaturehash.Algorithm(nil), cfg.LocalSignatureSchemes...)
@@ -544,7 +557,7 @@ func TestHandshakeFSM13ServerFlight4KeepsReaderPausedThroughQueueDrain(t *testin
 	cfg := testHandshakeConfig13(t)
 	cfg.InsecureSkipHelloVerify = true
 	_, clientHello, _ := newFlight13ClientHelloFixture(t, cfg)
-	serverState := newTestState13(false)
+	serverState := newTestState13(t, false)
 	cache := dtlsflight.NewCache()
 	fsm, err := newFSM13(serverState, cache, cfg, dtlsflight13.Flight0, nil, nil)
 	require.NoError(t, err)
@@ -601,7 +614,7 @@ func TestHandshakeFSM13NonDrainingTransitionReleasesReaderAfterWait(t *testing.T
 	cfg := testHandshakeConfig13(t)
 	cfg.InsecureSkipHelloVerify = false
 	_, clientHello, _ := newFlight13ClientHelloFixture(t, cfg)
-	serverState := newTestState13(false)
+	serverState := newTestState13(t, false)
 	cache := dtlsflight.NewCache()
 	fsm, err := newFSM13(serverState, cache, cfg, dtlsflight13.Flight0, nil, nil)
 	require.NoError(t, err)
@@ -660,7 +673,7 @@ func TestHandshakeFSM13ReaderPauseRequiredOnlyForQueueDrainingTransitions(t *tes
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			state := newTestState13(test.isClient)
+			state := newTestState13(t, test.isClient)
 			state.SetRemoteEpoch(test.remoteEpoch)
 			flightContext := handshakeContext{state: state}
 			assert.Equal(t, test.expected, flightContext.transitionRequiresReaderPause(test.nextFlight))
@@ -1468,7 +1481,7 @@ func newNoHRRFlight13Fixture(t *testing.T) noHRRFlight13Fixture {
 	cfg.InsecureSkipHelloVerify = true
 
 	clientState, clientHello, transcript := newFlight13ClientHelloFixture(t, cfg)
-	serverState := newTestState13(false)
+	serverState := newTestState13(t, false)
 	serverCache := dtlsflight.NewCache()
 
 	_, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight0, &handshakeContext{
@@ -1524,7 +1537,7 @@ func newFlight13ClientHelloFixture(
 ) (*dtlsstate.State13, []*dtlsflight.Packet, *Transcript) {
 	t.Helper()
 
-	clientState := newTestState13(true)
+	clientState := newTestState13(t, true)
 	clientHello, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight1, &handshakeContext{
 		state: clientState,
 		cache: dtlsflight.NewCache(),

--- a/internal/handshake/transcript_test.go
+++ b/internal/handshake/transcript_test.go
@@ -632,7 +632,7 @@ func TestDeriveTrafficSecrets13KeySchedule(t *testing.T) {
 
 func TestDeriveAndStoreHandshakeTrafficSecrets13FromTranscript(t *testing.T) {
 	cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.CipherSuite = cipherSuite
 	state.KeyAgreementSecret = bytes.Repeat([]byte{0x11}, sha256.Size)
 
@@ -666,7 +666,7 @@ func TestInitHandshakeRecordProtection13InstallsDirectionalKeys(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 			secretLen := cipherSuite.HashFunc()().Size()
-			state := newTestState13(testCase.isClient)
+			state := newTestState13(t, testCase.isClient)
 			state.CipherSuite = cipherSuite
 			state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 				Client: bytes.Repeat([]byte{0x11}, secretLen),
@@ -699,7 +699,7 @@ func TestInitApplicationRecordProtection13Rekeys(t *testing.T) {
 		Client: bytes.Repeat([]byte{0x33}, secretLen),
 		Server: bytes.Repeat([]byte{0x44}, secretLen),
 	}
-	state := newTestState13(true)
+	state := newTestState13(t, true)
 	state.CipherSuite = cipherSuite
 	state.KeySchedule.HandshakeTraffic = handshakeSecrets
 	state.KeySchedule.ClientApplicationTrafficSecret0 = applicationSecrets.Client
@@ -763,13 +763,13 @@ func TestInitApplicationRecordProtection13RejectsInvalidState(t *testing.T) {
 		},
 		{
 			name:  "missing cipher suite",
-			state: newTestState13(false),
+			state: newTestState13(t, false),
 			err:   dtlserrors.ErrCipherSuiteNotSet,
 		},
 		{
 			name: "not tls 13",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.ClientApplicationTrafficSecret0 = applicationSecrets.Client
 				state.KeySchedule.ServerApplicationTrafficSecret0 = applicationSecrets.Server
@@ -781,7 +781,7 @@ func TestInitApplicationRecordProtection13RejectsInvalidState(t *testing.T) {
 		{
 			name: "missing client application secret",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.ServerApplicationTrafficSecret0 = applicationSecrets.Server
 
@@ -792,7 +792,7 @@ func TestInitApplicationRecordProtection13RejectsInvalidState(t *testing.T) {
 		{
 			name: "missing server application secret",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.ClientApplicationTrafficSecret0 = applicationSecrets.Client
 
@@ -803,7 +803,7 @@ func TestInitApplicationRecordProtection13RejectsInvalidState(t *testing.T) {
 		{
 			name: "handshake protection initialized without application secrets",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 					Client: bytes.Repeat([]byte{0x11}, sha256.Size),
@@ -837,13 +837,13 @@ func TestInitHandshakeRecordProtection13RejectsInvalidState(t *testing.T) {
 		},
 		{
 			name:  "missing cipher suite",
-			state: newTestState13(false),
+			state: newTestState13(t, false),
 			err:   dtlserrors.ErrCipherSuiteNotSet,
 		},
 		{
 			name: "not tls 13",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 					Client: []byte{0x11},
@@ -857,7 +857,7 @@ func TestInitHandshakeRecordProtection13RejectsInvalidState(t *testing.T) {
 		{
 			name: "missing client secret",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 					Server: []byte{0x22},
@@ -870,7 +870,7 @@ func TestInitHandshakeRecordProtection13RejectsInvalidState(t *testing.T) {
 		{
 			name: "missing server secret",
 			state: func() *dtlsstate.State13 {
-				state := newTestState13(false)
+				state := newTestState13(t, false)
 				state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
 				state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 					Client: []byte{0x11},
@@ -917,7 +917,7 @@ func TestCertificateVerifyInput13ServerAndClient(t *testing.T) {
 func TestHandshakeFinishedBaseKeys13(t *testing.T) {
 	clientSecret := bytes.Repeat([]byte{0x11}, sha256.Size)
 	serverSecret := bytes.Repeat([]byte{0x22}, sha256.Size)
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.KeySchedule.HandshakeTraffic = dtlsstate.TrafficSecrets{
 		Client: clientSecret,
 		Server: serverSecret,
@@ -931,9 +931,9 @@ func TestHandshakeFinishedBaseKeys13(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, serverSecret, serverBaseKey)
 
-	_, err = ClientHandshakeFinishedBaseKey(newTestState13(false))
+	_, err = ClientHandshakeFinishedBaseKey(newTestState13(t, false))
 	assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
-	_, err = ServerHandshakeFinishedBaseKey(newTestState13(false))
+	_, err = ServerHandshakeFinishedBaseKey(newTestState13(t, false))
 	assert.ErrorIs(t, err, dtlserrors.ErrLengthMismatch)
 }
 
@@ -1074,7 +1074,7 @@ func TestFinishedFailureDoesNotPoisonTranscript13(t *testing.T) {
 
 func TestDTLS13TranscriptAuthenticatedHandshakeInputs(t *testing.T) {
 	cipherSuite := ciphersuite.ForID(ciphersuite.TLS_AES_128_GCM_SHA256, nil)
-	state := newTestState13(false)
+	state := newTestState13(t, false)
 	state.CipherSuite = cipherSuite
 	state.KeyAgreementSecret = bytes.Repeat([]byte{0x77}, sha256.Size)
 	transcript := NewTranscript()

--- a/internal/state/common.go
+++ b/internal/state/common.go
@@ -6,6 +6,7 @@
 package state
 
 import (
+	"bytes"
 	"sync/atomic"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
@@ -51,6 +52,8 @@ type Common struct {
 	// RemoteCIDOffered reports whether the peer sent a connection_id
 	// extension.
 	RemoteCIDOffered bool
+	// pendingLocalConnectionID is the uncommitted CID offered by this client.
+	pendingLocalConnectionID atomic.Pointer[[]byte]
 
 	IsClient bool
 
@@ -105,6 +108,55 @@ func (s *Common) LocalConnectionID() []byte {
 
 func (s *Common) SetLocalConnectionID(v []byte) {
 	s.localConnectionID.Store(v)
+}
+
+// RecordLocalClientHello retains an offer and publishes its pending CID.
+func (s *Common) RecordLocalClientHello(snapshot extensionnegotiation.ClientHelloSnapshot) error {
+	if err := s.LocalClientHelloSnapshots.Record(snapshot); err != nil {
+		return err
+	}
+	if cid, offered := extensionnegotiation.ConnectionIDOffer(snapshot); offered {
+		s.pendingLocalConnectionID.Store(&cid)
+	} else {
+		s.pendingLocalConnectionID.Store(nil)
+	}
+
+	return nil
+}
+
+// ResetConnectionIDs clears committed CID state and starts a new decision.
+func (s *Common) ResetConnectionIDs() {
+	s.SetLocalConnectionID(nil)
+	s.RemoteConnectionID, s.LocalCIDOffered, s.RemoteCIDOffered = nil, false, false
+	s.pendingLocalConnectionID.Store(nil)
+}
+
+// CommitNegotiatedExtensions applies a fully validated extension decision.
+func (s *Common) CommitNegotiatedExtensions(decision *extensionnegotiation.ConnectionID) {
+	if decision == nil {
+		s.ResetConnectionIDs()
+
+		return
+	}
+
+	localCID, remoteCID := decision.ServerCID, decision.ClientCID
+	if s.IsClient {
+		localCID, remoteCID = remoteCID, localCID
+	}
+	s.SetLocalConnectionID(bytes.Clone(localCID))
+	s.RemoteConnectionID = bytes.Clone(remoteCID)
+	s.LocalCIDOffered, s.RemoteCIDOffered = true, true
+	s.pendingLocalConnectionID.Store(nil)
+}
+
+// LocalConnectionIDForInboundRecords returns the negotiated CID, or the
+// pending wire offer while a client is still waiting for ServerHello.
+func (s *Common) LocalConnectionIDForInboundRecords() []byte {
+	if cid := s.pendingLocalConnectionID.Load(); s.IsClient && cid != nil {
+		return *cid
+	}
+
+	return s.LocalConnectionID()
 }
 
 // State is retained as the DTLS 1.2 state alias for callers that still only

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -6,6 +6,7 @@ package state
 import (
 	"bytes"
 
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
@@ -134,32 +135,22 @@ func (*State13) ShouldWrapConnectionID() bool {
 }
 
 // ResetConnectionIDs clears the connection IDs and CID state.
-func (s *State13) ResetConnectionIDs() {
-	s.SetLocalConnectionID(nil)
-	s.LocalCIDOffered = false
-	s.RemoteConnectionID = nil
-	s.RemoteCIDOffered = false
-	s.CID = CIDState{}
-}
+func (s *State13) ResetConnectionIDs() { s.CommitNegotiatedExtensions(nil) }
 
-// NegotiateConnectionIDs records the connection IDs negotiated.
-func (s *State13) NegotiateConnectionIDs(remoteCID []byte) {
-	localCID := bytes.Clone(s.LocalConnectionID())
+// CommitNegotiatedExtensions applies a fully validated extension decision.
+func (s *State13) CommitNegotiatedExtensions(decision *extensionnegotiation.ConnectionID) {
+	s.Common.CommitNegotiatedExtensions(decision)
+	if decision == nil {
+		s.CID = CIDState{}
 
-	s.SetLocalConnectionID(localCID)
-	s.LocalCIDOffered = true
-	s.RemoteConnectionID = bytes.Clone(remoteCID)
-	s.RemoteCIDOffered = true
+		return
+	}
+	localCID, remoteCID := s.LocalConnectionID(), s.RemoteConnectionID
 	s.CID = CIDState{
 		Negotiated: true,
 		Receive: CIDReceiveState{
-			Expected:               len(localCID) > 0,
-			Length:                 len(localCID),
-			CanSendNewConnectionID: len(localCID) > 0,
+			Expected: len(localCID) > 0, Length: len(localCID), CanSendNewConnectionID: len(localCID) > 0,
 		},
-		Send: CIDSendState{
-			UseCID: len(remoteCID) > 0,
-			Active: bytes.Clone(remoteCID),
-		},
+		Send: CIDSendState{UseCID: len(remoteCID) > 0, Active: bytes.Clone(remoteCID)},
 	}
 }

--- a/internal/state/state13_test.go
+++ b/internal/state/state13_test.go
@@ -4,44 +4,112 @@
 package state
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestState13NegotiateConnectionIDsPreservesNilValues(t *testing.T) {
-	state := NewState13(true)
-	state.SetLocalConnectionID(nil)
-	state.LocalCIDOffered = true
-
-	state.NegotiateConnectionIDs(nil)
-
-	assert.True(t, state.LocalCIDOffered)
-	assert.True(t, state.RemoteCIDOffered)
-	assert.Nil(t, state.LocalConnectionID())
-	assert.Nil(t, state.RemoteConnectionID)
-	assert.True(t, state.CID.Negotiated)
-	assert.False(t, state.CID.Receive.Expected)
-	assert.Zero(t, state.CID.Receive.Length)
-	assert.False(t, state.CID.Send.UseCID)
-	assert.Nil(t, state.CID.Send.Active)
+func assertConnectionIDs(t *testing.T, state *Common, local, remote []byte, negotiated bool) {
+	t.Helper()
+	assert.Equal(t, local, state.LocalConnectionID())
+	assert.Equal(t, remote, state.RemoteConnectionID)
+	assert.Equal(t, [2]bool{negotiated, negotiated}, [2]bool{state.LocalCIDOffered, state.RemoteCIDOffered})
 }
 
-func TestState13NegotiateConnectionIDsClonesValues(t *testing.T) {
-	localCID := []byte{0x01, 0x02}
-	remoteCID := []byte{0x10, 0x11}
-	state := NewState13(true)
-	state.SetLocalConnectionID(localCID)
-	state.LocalCIDOffered = true
+func assertConnectionIDs13(t *testing.T, state *State13, local, remote []byte, negotiated bool) {
+	t.Helper()
+	assertConnectionIDs(t, state.Common, local, remote, negotiated)
+	if !negotiated {
+		assert.Zero(t, state.CID)
 
-	state.NegotiateConnectionIDs(remoteCID)
-	localCID[0] = 0xff
-	remoteCID[0] = 0xff
+		return
+	}
+	hasLocal := len(local) > 0
+	assert.Equal(t, [3]bool{true, hasLocal, hasLocal},
+		[3]bool{state.CID.Negotiated, state.CID.Receive.Expected, state.CID.Receive.CanSendNewConnectionID})
+	assert.Equal(t, len(local), state.CID.Receive.Length)
+	assert.Equal(t, len(remote) > 0, state.CID.Send.UseCID)
+	assert.Equal(t, remote, state.CID.Send.Active)
+}
 
-	assert.Equal(t, []byte{0x01, 0x02}, state.LocalConnectionID())
-	assert.Equal(t, []byte{0x10, 0x11}, state.RemoteConnectionID)
-	assert.Equal(t, []byte{0x10, 0x11}, state.CID.Send.Active)
+func TestCommitNegotiatedExtensions(t *testing.T) {
+	clientCID := []byte{0x01, 0x02}
+	serverCID := []byte{0x10, 0x11, 0x12}
+	empty := []byte{}
+	tests := []struct {
+		name           string
+		isClient       bool
+		client, server []byte
+		negotiated     bool
+	}{
+		{"client", true, clientCID, serverCID, true},
+		{"server", false, clientCID, serverCID, true},
+		{"client empty CID", true, nil, empty, true},
+		{"server empty CID", false, nil, empty, true},
+		{"both nil", true, nil, nil, true},
+		{"declined", true, nil, nil, false},
+	}
 
-	state.RemoteConnectionID[0] = 0xee
-	assert.Equal(t, []byte{0x10, 0x11}, state.CID.Send.Active)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			local, remote := test.server, test.client
+			if test.isClient {
+				local, remote = remote, local
+			}
+			var decision *extensionnegotiation.ConnectionID
+			if test.negotiated {
+				decision = &extensionnegotiation.ConnectionID{
+					ClientCID: bytes.Clone(test.client), ServerCID: bytes.Clone(test.server),
+				}
+			}
+			state12, state13 := NewState12(test.isClient), NewState13(test.isClient)
+			state12.SetLocalConnectionID([]byte{0xff})
+			state12.LocalCIDOffered, state12.RemoteCIDOffered = true, true
+			state12.RemoteConnectionID = []byte{0xff}
+			state13.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte{0xff}, ServerCID: []byte{0xff}}) //nolint:lll
+
+			state12.CommitNegotiatedExtensions(decision)
+			state13.CommitNegotiatedExtensions(decision)
+			assertConnectionIDs(t, state12.Common, local, remote, test.negotiated)
+			assertConnectionIDs13(t, &state13, local, remote, test.negotiated)
+
+			if decision != nil {
+				clone := Clone13ForVerification(&state13, nil)
+				if len(decision.ClientCID) > 0 {
+					decision.ClientCID[0] = 0xff
+				}
+				if len(decision.ServerCID) > 0 {
+					decision.ServerCID[0] = 0xff
+				}
+				assertConnectionIDs(t, state12.Common, local, remote, true)
+				assertConnectionIDs13(t, &state13, local, remote, true)
+				if len(local) > 0 {
+					state13.LocalConnectionID()[0] = 0xee
+				}
+				if len(remote) > 0 {
+					state13.RemoteConnectionID[0] = 0xee
+					assert.Equal(t, remote, state13.CID.Send.Active)
+					state13.CID.Send.Active[0] = 0xee
+				}
+				assertConnectionIDs13(t, clone, local, remote, true)
+			}
+		})
+	}
+}
+
+func TestRecordLocalClientHelloTracksCIDPresence(t *testing.T) {
+	for _, extensions := range [][]extension.Value{nil, {&extension.ConnectionID{}}} {
+		_, snapshot, err := extensionnegotiation.FinalizeClientHello(
+			&handshake.MessageClientHello{Extensions: extensions}, nil,
+		)
+		require.NoError(t, err)
+		state := NewState12(true)
+		require.NoError(t, state.RecordLocalClientHello(snapshot))
+		assert.Equal(t, len(extensions) > 0, state.pendingLocalConnectionID.Load() != nil)
+	}
 }


### PR DESCRIPTION
#### Description
This fixes a similar issues to #1029 but with CID negotiations.
By deriving CID state from the finalized ClientHello and ServerHello, and commit
it only after the handshake flight succeeds. Preserve pending inbound CID state handling.

and by extension this rejects changed CID offers after helloRetryRequest and unsolicited CID
responses for both DTLS 1.2 and DTLS 1.3.
this fixes many issues with 1.3 cid handling but also 1.2:

1. CID state was committed when an extension was generated or received, before the handshake flight succeeded.
2. clientHello or serverHello hooks could add, remove, or replace a CID while internal state retained value. 
3. CID generator ran again on ServerHello retransmission, advertising a different CID (kinda an xd).
4. he second ClientHello after HelloVerifyRequest could change, add, or remove its CID instead of repeating the original offer.
5. Session resumption did not renegotiate CID correctly.

and with the dual state, A DTLS 1.2 client could accept a ServerHello with HelloRetryRequest-only extensions.

part of #775 and #1021