### PR TITLE
Negotiate 1.2 SRTP / MKI from final offers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -312,6 +312,8 @@ func (c *Conn) Handshake() error {
 //
 // Most uses of this package need not call HandshakeContext explicitly: the
 // first [Conn.Read] or [Conn.Write] will call it automatically.
+//
+//nolint:cyclop
 func (c *Conn) HandshakeContext(ctx context.Context) error {
 	c.handshakeMutex.Lock()
 	defer c.handshakeMutex.Unlock()
@@ -356,6 +358,10 @@ func (c *Conn) HandshakeContext(ctx context.Context) error {
 	}
 
 	if err := c.handshake(ctx, start); err != nil {
+		if common.LocalVersion.Equal(protocol.Version1_2) && !c.isHandshakeCompletedSuccessfully() {
+			common.SetSRTPProtectionProfile(0)
+		}
+
 		return err
 	}
 
@@ -739,7 +745,7 @@ func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
 		return nil, false
 	}
 
-	return common.RemoteSRTPMasterKeyIdentifier, true
+	return bytes.Clone(common.RemoteSRTPMasterKeyIdentifier), true
 }
 
 func (c *Conn) writePackets(ctx context.Context, pkts []*dtlsflight.Packet) error {

--- a/conn_test.go
+++ b/conn_test.go
@@ -995,27 +995,33 @@ func TestSRTPConfiguration(t *testing.T) {
 		ServerSRTP                    []SRTPProtectionProfile
 		ClientSRTPMasterKeyIdentifier []byte
 		ServerSRTPMasterKeyIdentifier []byte
+		ExpectedClientMKI             []byte
+		ExpectedServerMKI             []byte
 		ExpectedProfile               SRTPProtectionProfile
 		WantClientError               error
 		WantServerError               error
 	}{
 		{
-			Name:            "No SRTP in use",
-			ClientSRTP:      nil,
-			ServerSRTP:      nil,
-			ExpectedProfile: 0,
-			WantClientError: nil,
-			WantServerError: nil,
+			Name: "No SRTP in use",
 		},
 		{
-			Name:                          "SRTP both ends",
+			Name:                          "SRTP with echoed MKI",
 			ClientSRTP:                    []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
 			ServerSRTP:                    []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
-			ExpectedProfile:               SRTP_AES128_CM_HMAC_SHA1_80,
 			ClientSRTPMasterKeyIdentifier: []byte("ClientSRTPMKI"),
-			ServerSRTPMasterKeyIdentifier: []byte("ServerSRTPMKI"),
-			WantClientError:               nil,
-			WantServerError:               nil,
+			ServerSRTPMasterKeyIdentifier: []byte("ClientSRTPMKI"),
+			ExpectedClientMKI:             []byte("ClientSRTPMKI"),
+			ExpectedServerMKI:             []byte("ClientSRTPMKI"),
+			ExpectedProfile:               SRTP_AES128_CM_HMAC_SHA1_80,
+		},
+		{
+			Name:                          "SRTP with declined MKI",
+			ClientSRTP:                    []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
+			ServerSRTP:                    []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
+			ClientSRTPMasterKeyIdentifier: []byte("ClientSRTPMKI"),
+			ServerSRTPMasterKeyIdentifier: []byte("OtherMKI"),
+			ExpectedServerMKI:             []byte("ClientSRTPMKI"),
+			ExpectedProfile:               SRTP_AES128_CM_HMAC_SHA1_80,
 		},
 		{
 			Name:            "SRTP client only",
@@ -1061,7 +1067,11 @@ func TestSRTPConfiguration(t *testing.T) {
 		resultCh := make(chan result)
 
 		go func() {
-			opts := []ClientOption{WithSRTPMasterKeyIdentifier(test.ServerSRTPMasterKeyIdentifier)}
+			opts := []ClientOption{
+				WithMinVersion(protocol.Version1_2),
+				WithMaxVersion(protocol.Version1_2),
+				WithSRTPMasterKeyIdentifier(test.ClientSRTPMasterKeyIdentifier),
+			}
 			if len(test.ClientSRTP) > 0 {
 				opts = append(opts, WithSRTPProtectionProfiles(test.ClientSRTP...))
 			}
@@ -1069,7 +1079,11 @@ func TestSRTPConfiguration(t *testing.T) {
 			resultCh <- result{client, err}
 		}()
 
-		opts := []ServerOption{WithSRTPMasterKeyIdentifier(test.ClientSRTPMasterKeyIdentifier)}
+		opts := []ServerOption{
+			WithMinVersion(protocol.Version1_2),
+			WithMaxVersion(protocol.Version1_2),
+			WithSRTPMasterKeyIdentifier(test.ServerSRTPMasterKeyIdentifier),
+		}
 		if len(test.ServerSRTP) > 0 {
 			opts = append(opts, WithSRTPProtectionProfiles(test.ServerSRTP...))
 		}
@@ -1102,12 +1116,14 @@ func TestSRTPConfiguration(t *testing.T) {
 			"TestSRTPConfiguration: Server SRTPProtectionProfile Mismatch '%s'", test.Name)
 
 		actualServerMKI, _ := server.RemoteSRTPMasterKeyIdentifier()
-		assert.Truef(t, bytes.Equal(test.ServerSRTPMasterKeyIdentifier, actualServerMKI),
-			"TestSRTPConfiguration: Server SRTPMKI Mismatch '%s'", test.Name)
-
+		assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI), test.Name)
+		if len(actualServerMKI) > 0 {
+			actualServerMKI[0] ^= 0xff
+			actualServerMKI, _ = server.RemoteSRTPMasterKeyIdentifier()
+			assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI), test.Name)
+		}
 		actualClientMKI, _ := res.c.RemoteSRTPMasterKeyIdentifier()
-		assert.Truef(t, bytes.Equal(test.ClientSRTPMasterKeyIdentifier, actualClientMKI),
-			"TestSRTPConfiguration: Client SRTPMKI Mismatch '%s'", test.Name)
+		assert.True(t, bytes.Equal(test.ExpectedClientMKI, actualClientMKI), test.Name)
 	}
 }
 

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -4,7 +4,6 @@
 package flight12
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"slices"
@@ -99,13 +98,6 @@ func flight0Parse(
 				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrNoSupportedEllipticCurves //nolint:lll
 			}
 			state.NamedCurve = namedCurve
-		case *extension.SRTPOffer:
-			profile, ok := dtlsflight.FindMatchingSRTPProfile(cfg.LocalSRTPProtectionProfiles, ext.ProtectionProfiles)
-			if !ok {
-				return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrServerNoMatchingSRTPProfile //nolint:lll
-			}
-			state.SetSRTPProtectionProfile(profile)
-			state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(ext.MasterKeyIdentifier)
 		case *extension12.ExtendedMasterSecret:
 			if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 				state.ExtendedMasterSecret = true
@@ -184,6 +176,7 @@ func flight0Generate(
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	// Initialize
+	state.SetSRTPProtectionProfile(0)
 	if !cfg.InsecureSkipHelloVerify {
 		state.Cookie = make([]byte, cookieLength)
 		if _, err := rand.Read(state.Cookie); err != nil {

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -72,6 +72,7 @@ func flight1Generate(
 	cfg *dtlsconfig.HandshakeConfig,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	state.ResetConnectionIDs()
+	state.SetSRTPProtectionProfile(0)
 	state.LocalClientHelloSnapshots.Reset()
 
 	var zeroEpoch uint16

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -64,6 +64,7 @@ func flight3Parse(
 	serverResponse = serverResponsePull.Messages[handshake.TypeServerHello]
 	serverHelloMsg, hasServerHello := serverResponse.(*handshake.MessageServerHello)
 	var decision *extensionnegotiation.ConnectionID
+	var srtpDecision srtpDecision
 	if hasServerHello { //nolint:nestif
 		if !serverHelloMsg.Version.Equal(protocol.Version1_2) {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
@@ -75,6 +76,13 @@ func flight3Parse(
 		}
 		if validationErr := extensionnegotiation.ValidateServerHelloResponse(offer, serverHelloMsg); validationErr != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, validationErr
+		}
+		if srtpDecision, err = validateSRTPSelection(
+			offer,
+			serverHelloMsg.Extensions,
+			cfg.LocalSRTPProtectionProfiles,
+		); err != nil {
+			return 0, nil, err
 		}
 		decision = extensionnegotiation.DecideConnectionID(offer, serverHelloMsg.Extensions)
 		if decision == nil {
@@ -88,15 +96,6 @@ func flight3Parse(
 
 		for _, v := range serverHelloMsg.Extensions {
 			switch ext := v.(type) {
-			case *extension.SRTPSelection:
-				profile, found := dtlsflight.FindMatchingSRTPProfile(
-					[]extension.SRTPProtectionProfile{ext.ProtectionProfile}, cfg.LocalSRTPProtectionProfiles,
-				)
-				if !found {
-					return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlserrors.ErrClientNoMatchingSRTPProfile //nolint:lll
-				}
-				state.SetSRTPProtectionProfile(profile)
-				state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(ext.MasterKeyIdentifier)
 			case *extension12.ExtendedMasterSecret:
 				if cfg.ExtendedMasterSecret != dtlsconfig.DisableExtendedMasterSecret {
 					state.ExtendedMasterSecret = true
@@ -108,9 +107,6 @@ func flight3Parse(
 
 		if cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret && !state.ExtendedMasterSecret {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrClientRequiredButNoServerEMS //nolint:lll
-		}
-		if len(cfg.LocalSRTPProtectionProfiles) > 0 && state.SRTPProtectionProfile() == 0 {
-			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, dtlserrors.ErrRequestedButNoSRTPExtension //nolint:lll
 		}
 
 		remoteCipherSuite := ciphersuite.ForID(ciphersuite.ID(*serverHelloMsg.CipherSuiteID), cfg.CustomCipherSuites)
@@ -136,6 +132,7 @@ func flight3Parse(
 			next, dtlsAlert, err := handleResumption(ctx, conn, state, cache, cfg)
 			if next != 0 && err == nil {
 				state.CommitNegotiatedExtensions(decision)
+				commitSRTP(state, srtpDecision.profile, srtpDecision.peerMKI)
 			}
 
 			return next, dtlsAlert, err
@@ -201,6 +198,7 @@ func flight3Parse(
 		state.RemoteRequestedCertificate = true
 	}
 	state.CommitNegotiatedExtensions(decision)
+	commitSRTP(state, srtpDecision.profile, srtpDecision.peerMKI)
 
 	return Flight5, nil, nil
 }

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -71,6 +71,10 @@ func flight4bGenerate(
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	var pkts []*dtlsflight.Packet
 	offer := state.RemoteClientHelloSnapshots.Current()
+	srtpSelection, err := negotiateServerSRTP(offer, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	extensions := []extension.Value{}
 	if state.RemoteSupportsRenegotiation {
@@ -82,12 +86,7 @@ func flight4bGenerate(
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret) && state.ExtendedMasterSecret {
 		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
-	if state.SRTPProtectionProfile() != 0 {
-		extensions = append(extensions, &extension.SRTPSelection{
-			ProtectionProfile:   state.SRTPProtectionProfile(),
-			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
-		})
-	}
+	extensions = appendSRTPSelection(extensions, srtpSelection)
 
 	selectedProto, err := extension.ALPNProtocolSelection(cfg.SupportedProtocols, state.PeerSupportedProtocols)
 	if err != nil {
@@ -113,6 +112,11 @@ func flight4bGenerate(
 
 	serverHelloMessage, err = extensionnegotiation.FinalizeServerHello(serverHelloMessage, cfg.ServerHelloMessageHook, offer) //nolint:lll
 	if err != nil {
+		return nil, nil, err
+	}
+	if err = validateServerSRTP(
+		offer, serverHelloMessage.Extensions, cfg.LocalSRTPProtectionProfiles, srtpSelection,
+	); err != nil {
 		return nil, nil, err
 	}
 	decision := extensionnegotiation.DecideConnectionID(offer, serverHelloMessage.Extensions)
@@ -171,6 +175,7 @@ func flight4bGenerate(
 		},
 	)
 	state.CommitNegotiatedExtensions(decision)
+	commitSRTP(state, srtpSelection.profile, srtpSelection.peerMKI)
 
 	return pkts, nil, nil
 }

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -265,17 +265,16 @@ func flight4Generate(
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	offer := state.RemoteClientHelloSnapshots.Current()
 	extensions := []extension.Value{}
+	srtpSelection, err := negotiateServerSRTP(offer, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if (cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
 		cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret) && state.ExtendedMasterSecret {
 		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
 	}
-	if state.SRTPProtectionProfile() != 0 {
-		extensions = append(extensions, &extension.SRTPSelection{
-			ProtectionProfile:   state.SRTPProtectionProfile(),
-			MasterKeyIdentifier: cfg.LocalSRTPMasterKeyIdentifier,
-		})
-	}
+	extensions = appendSRTPSelection(extensions, srtpSelection)
 	if state.RemoteSupportsRenegotiation {
 		extensions = append(extensions, &extension12.RenegotiationInfo{
 			RenegotiatedConnection: 0,
@@ -322,6 +321,11 @@ func flight4Generate(
 
 	serverHello, err = extensionnegotiation.FinalizeServerHello(serverHello, cfg.ServerHelloMessageHook, offer)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err = validateServerSRTP(
+		offer, serverHello.Extensions, cfg.LocalSRTPProtectionProfiles, srtpSelection,
+	); err != nil {
 		return nil, nil, err
 	}
 	decision := extensionnegotiation.DecideConnectionID(offer, serverHello.Extensions)
@@ -482,6 +486,7 @@ func flight4Generate(
 		},
 	})
 	state.CommitNegotiatedExtensions(decision)
+	commitSRTP(state, srtpSelection.profile, srtpSelection.peerMKI)
 
 	return pkts, nil, nil
 }

--- a/internal/flight/flight12/srtp.go
+++ b/internal/flight/flight12/srtp.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flight12
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+)
+
+type srtpDecision struct {
+	profile extension.SRTPProtectionProfile
+	mki     []byte
+	peerMKI []byte
+}
+
+func readSRTPOffer(snapshot extensionnegotiation.ClientHelloSnapshot) (extension.SRTPOffer, bool, error) {
+	raw, ok := snapshot.Extension(extension.TypeUseSRTP)
+	if !ok {
+		return extension.SRTPOffer{}, false, nil
+	}
+
+	var offer extension.SRTPOffer
+	if err := offer.UnmarshalData(raw.Data); err != nil {
+		return extension.SRTPOffer{}, true, fmt.Errorf("%w: %w",
+			srtpAlert(dtlserrors.ErrInvalidClientHello, alert.DecodeError), err)
+	}
+
+	return offer, true, nil
+}
+
+func negotiateServerSRTP(
+	snapshot extensionnegotiation.ClientHelloSnapshot,
+	cfg *dtlsconfig.HandshakeConfig,
+) (srtpDecision, error) {
+	offer, offered, err := readSRTPOffer(snapshot)
+	if err != nil || !offered {
+		return srtpDecision{}, err
+	}
+
+	profile, ok := dtlsflight.FindMatchingSRTPProfile(cfg.LocalSRTPProtectionProfiles, offer.ProtectionProfiles)
+	if !ok {
+		return srtpDecision{}, srtpAlert(dtlserrors.ErrServerNoMatchingSRTPProfile, alert.InsufficientSecurity)
+	}
+
+	decision := srtpDecision{profile: profile, peerMKI: bytes.Clone(offer.MasterKeyIdentifier)}
+	if len(offer.MasterKeyIdentifier) > 0 && bytes.Equal(offer.MasterKeyIdentifier, cfg.LocalSRTPMasterKeyIdentifier) {
+		decision.mki = bytes.Clone(offer.MasterKeyIdentifier)
+	}
+
+	return decision, nil
+}
+
+func validateSRTPSelection(
+	snapshot extensionnegotiation.ClientHelloSnapshot,
+	responses []extension.Value,
+	localProfiles []extension.SRTPProtectionProfile,
+) (srtpDecision, error) {
+	offer, offered, err := readSRTPOffer(snapshot)
+	if err != nil {
+		return srtpDecision{}, err
+	}
+
+	if !offered {
+		return srtpDecision{}, nil
+	}
+	var selection *extension.SRTPSelection
+	for _, response := range responses {
+		if value, ok := response.(*extension.SRTPSelection); ok {
+			selection = value
+
+			break
+		}
+	}
+	if selection == nil {
+		return srtpDecision{}, srtpAlert(dtlserrors.ErrRequestedButNoSRTPExtension, alert.InsufficientSecurity)
+	}
+	if !slices.Contains(offer.ProtectionProfiles, selection.ProtectionProfile) ||
+		!slices.Contains(localProfiles, selection.ProtectionProfile) {
+		return srtpDecision{}, srtpAlert(dtlserrors.ErrClientNoMatchingSRTPProfile, alert.IllegalParameter)
+	}
+	if len(selection.MasterKeyIdentifier) > 0 &&
+		!bytes.Equal(selection.MasterKeyIdentifier, offer.MasterKeyIdentifier) {
+		return srtpDecision{}, srtpAlert(dtlserrors.ErrClientNoMatchingSRTPProfile, alert.IllegalParameter)
+	}
+
+	return srtpDecision{
+		profile: selection.ProtectionProfile,
+		mki:     bytes.Clone(selection.MasterKeyIdentifier),
+		peerMKI: bytes.Clone(selection.MasterKeyIdentifier),
+	}, nil
+}
+
+func validateServerSRTP(
+	snapshot extensionnegotiation.ClientHelloSnapshot,
+	responses []extension.Value,
+	localProfiles []extension.SRTPProtectionProfile,
+	want srtpDecision,
+) error {
+	got, err := validateSRTPSelection(snapshot, responses, localProfiles)
+	if err != nil {
+		return err
+	}
+	if got.profile != want.profile || !bytes.Equal(got.mki, want.mki) {
+		return srtpAlert(dtlserrors.ErrInvalidServerHello, alert.InternalError)
+	}
+
+	return nil
+}
+
+func appendSRTPSelection(extensions []extension.Value, decision srtpDecision) []extension.Value {
+	if decision.profile == 0 {
+		return extensions
+	}
+
+	return append(extensions, &extension.SRTPSelection{
+		ProtectionProfile:   decision.profile,
+		MasterKeyIdentifier: bytes.Clone(decision.mki),
+	})
+}
+
+func commitSRTP(state *dtlsstate.State12, profile extension.SRTPProtectionProfile, peerMKI []byte) {
+	if profile != 0 {
+		state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(peerMKI)
+	}
+	state.SetSRTPProtectionProfile(profile)
+}
+
+func srtpAlert(kind error, description alert.Description) error {
+	return fmt.Errorf("%w: %w", kind, &alert.Alert{Level: alert.Fatal, Description: description})
+}

--- a/internal/flight/flight12/srtp_test.go
+++ b/internal/flight/flight12/srtp_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flight12
+
+import (
+	"testing"
+
+	"github.com/pion/dtls/v3/internal/ciphersuite"
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	profile80  extension.SRTPProtectionProfile = extension.SRTP_AES128_CM_HMAC_SHA1_80
+	profile32  extension.SRTPProtectionProfile = extension.SRTP_AES128_CM_HMAC_SHA1_32
+	initialMKI                                 = "initial"
+	finalMKI                                   = "final"
+)
+
+func TestFlight12ServerHelloUsesFinalSRTPOffer(t *testing.T) {
+	for _, test := range []struct {
+		name, serverMKI, hookMKI, wantMKI string
+		flight                            Flight
+		wantError                         bool
+	}{
+		{name: "echo", flight: Flight4, serverMKI: finalMKI, wantMKI: finalMKI},
+		{name: "decline", flight: Flight4, serverMKI: "other"},
+		{name: "hook cannot override decline", flight: Flight4, serverMKI: "other", hookMKI: finalMKI, wantError: true},
+		{name: "resumption", flight: Flight4b, serverMKI: finalMKI, wantMKI: finalMKI},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state := newSRTPServerState12()
+			if test.flight == Flight4b {
+				state.LocalVerifyData = []byte{1}
+			}
+			recordCH12(t, &state.RemoteClientHelloSnapshots, srtpOffer12(profile80, initialMKI))
+			recordCH12(t, &state.RemoteClientHelloSnapshots, srtpOffer12(profile32, finalMKI))
+
+			cfg := &dtlsconfig.HandshakeConfig{
+				LocalSRTPProtectionProfiles:  []extension.SRTPProtectionProfile{profile80, profile32},
+				LocalSRTPMasterKeyIdentifier: []byte(test.serverMKI),
+			}
+			if test.hookMKI != "" {
+				cfg.ServerHelloMessageHook = func(serverHello handshake.MessageServerHello) handshake.Message {
+					serverHello.Extensions = []extension.Value{&extension.SRTPSelection{
+						ProtectionProfile: profile32, MasterKeyIdentifier: []byte(test.hookMKI),
+					}}
+
+					return &serverHello
+				}
+			}
+
+			packets, _, err := generateForTest(t, test.flight, nil, state, dtlsflight.NewCache(), cfg)
+			if test.wantError {
+				require.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
+				assert.Zero(t, state.SRTPProtectionProfile())
+
+				return
+			}
+			require.NoError(t, err)
+			selection := serverHelloSRTPSelection12(t, packets)
+			require.NotNil(t, selection)
+			assert.Equal(t, profile32, selection.ProtectionProfile)
+			assert.Equal(t, test.wantMKI, string(selection.MasterKeyIdentifier))
+			assert.Equal(t, profile32, state.SRTPProtectionProfile())
+			assert.Equal(t, finalMKI, string(state.RemoteSRTPMasterKeyIdentifier))
+		})
+	}
+}
+
+func TestFlight12ResumptionClearsStaleSRTPWithoutFinalOffer(t *testing.T) {
+	state := newSRTPServerState12()
+	state.LocalVerifyData = []byte{1}
+	state.SetSRTPProtectionProfile(profile80)
+	state.RemoteSRTPMasterKeyIdentifier = []byte("stale")
+	recordCH12(t, &state.RemoteClientHelloSnapshots, srtpOffer12(profile80, initialMKI))
+	recordCH12(t, &state.RemoteClientHelloSnapshots)
+
+	packets, _, err := generateForTest(t, Flight4b, nil, state, dtlsflight.NewCache(), &dtlsconfig.HandshakeConfig{
+		LocalSRTPProtectionProfiles: []extension.SRTPProtectionProfile{profile80},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, serverHelloSRTPSelection12(t, packets))
+	assert.Zero(t, state.SRTPProtectionProfile())
+}
+
+func TestFlight12ClientValidatesFinalSRTPOfferBeforeCommit(t *testing.T) {
+	for _, test := range []struct {
+		name, mki string
+		profile   extension.SRTPProtectionProfile
+		complete  bool
+	}{
+		{name: "profile not in final offer", profile: profile80, mki: finalMKI},
+		{name: "mismatched MKI", profile: profile32, mki: "other"},
+		{name: "valid but incomplete flight", profile: profile32, mki: finalMKI},
+		{name: "valid complete flight commits", profile: profile32, mki: finalMKI, complete: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state, cache, cfg := newSRTPClientFlight3Test(t, test.profile, test.mki)
+			if test.complete {
+				pushHandshake12(t, cache, 1, &handshake.MessageServerHelloDone{})
+			}
+
+			_, _, err := parseForTest(t, Flight3, t.Context(), nil, state, cache, cfg)
+			if test.profile != profile32 || test.mki != finalMKI {
+				require.ErrorIs(t, err, dtlserrors.ErrClientNoMatchingSRTPProfile)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.complete {
+				assert.Equal(t, test.profile, state.SRTPProtectionProfile())
+				assert.Equal(t, test.mki, string(state.RemoteSRTPMasterKeyIdentifier))
+			} else {
+				assert.Zero(t, state.SRTPProtectionProfile())
+			}
+		})
+	}
+}
+
+func newSRTPServerState12() *dtlsstate.State12 {
+	state := newTestState12()
+	state.CipherSuite = ciphersuite.ForID(ciphersuite.TLS_PSK_WITH_AES_128_GCM_SHA256, nil)
+
+	return state
+}
+
+func newSRTPClientFlight3Test(
+	t *testing.T,
+	profile extension.SRTPProtectionProfile,
+	mki string,
+) (*dtlsstate.State12, *dtlsflight.Cache, *dtlsconfig.HandshakeConfig) {
+	t.Helper()
+	state := newTestState12()
+	state.IsClient = true
+	suite := ciphersuite.ForID(ciphersuite.TLS_PSK_WITH_AES_128_GCM_SHA256, nil)
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalCipherSuites:    []dtlsconfig.CipherSuite{suite},
+		LocalPSKIdentityHint: []byte("client"),
+		LocalPSKCallback:     func([]byte) ([]byte, error) { return []byte("psk"), nil },
+		LocalSRTPProtectionProfiles: []extension.SRTPProtectionProfile{
+			profile80, profile32,
+		},
+		Log: logging.NewDefaultLoggerFactory().NewLogger("dtls"),
+	}
+	recordCH12(t, &state.LocalClientHelloSnapshots, srtpOffer12(profile80, initialMKI))
+	recordCH12(t, &state.LocalClientHelloSnapshots, srtpOffer12(profile32, finalMKI))
+	cipherSuiteID := uint16(suite.ID())
+	cache := dtlsflight.NewCache()
+	pushHandshake12(t, cache, 0, &handshake.MessageServerHello{
+		Version: protocol.Version1_2, CipherSuiteID: &cipherSuiteID,
+		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		Extensions: []extension.Value{&extension.SRTPSelection{
+			ProtectionProfile: profile, MasterKeyIdentifier: []byte(mki),
+		}},
+	})
+
+	return state, cache, cfg
+}
+
+func srtpOffer12(profile extension.SRTPProtectionProfile, mki string) *extension.SRTPOffer {
+	return &extension.SRTPOffer{
+		ProtectionProfiles:  []extension.SRTPProtectionProfile{profile},
+		MasterKeyIdentifier: []byte(mki),
+	}
+}
+
+func pushHandshake12(t *testing.T, cache *dtlsflight.Cache, sequence uint16, message handshake.Message) {
+	t.Helper()
+	raw, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: sequence}, Message: message,
+	}).Marshal()
+	require.NoError(t, err)
+	cache.Push(raw, 0, sequence, message.Type(), false)
+}
+
+func serverHelloSRTPSelection12(t *testing.T, packets []*dtlsflight.Packet) *extension.SRTPSelection {
+	t.Helper()
+	require.NotEmpty(t, packets)
+	handshakePacket, ok := packets[0].Record.Content.(*handshake.Handshake)
+	require.True(t, ok)
+	serverHello, ok := handshakePacket.Message.(*handshake.MessageServerHello)
+	require.True(t, ok)
+	for _, value := range serverHello.Extensions {
+		if selection, ok := value.(*extension.SRTPSelection); ok {
+			return selection
+		}
+	}
+
+	return nil
+}

--- a/state.go
+++ b/state.go
@@ -25,6 +25,7 @@ type State struct {
 	masterSecret              []byte
 	sequenceNumber            uint64
 	srtpProtectionProfile     SRTPProtectionProfile
+	peerSRTPMKI               []byte
 	localConnectionID         []byte
 	remoteConnectionID        []byte
 	isClient                  bool
@@ -47,6 +48,7 @@ type serializedState struct {
 	MasterSecret          []byte
 	SequenceNumber        uint64
 	SRTPProtectionProfile uint16
+	PeerSRTPMKI           []byte
 	PeerCertificates      [][]byte
 	IdentityHint          []byte
 	SessionID             []byte
@@ -65,6 +67,11 @@ func generateState(internalState *dtlsstate.State) (*State, error) {
 	}
 
 	epoch := internalState.LocalEpoch()
+	profile := internalState.SRTPProtectionProfile()
+	var peerMKI []byte
+	if profile != 0 {
+		peerMKI = bytes.Clone(internalState.RemoteSRTPMasterKeyIdentifier)
+	}
 
 	return &State{
 		localEpoch:            internalState.LocalEpoch(),
@@ -73,7 +80,8 @@ func generateState(internalState *dtlsstate.State) (*State, error) {
 		remoteRandom:          internalState.RemoteRandom,
 		masterSecret:          internalState.MasterSecret,
 		sequenceNumber:        atomic.LoadUint64(&internalState.LocalSequenceNumber[epoch]),
-		srtpProtectionProfile: internalState.SRTPProtectionProfile(),
+		srtpProtectionProfile: profile,
+		peerSRTPMKI:           peerMKI,
 		localConnectionID:     internalState.LocalConnectionID(),
 		remoteConnectionID:    internalState.RemoteConnectionID,
 		isClient:              internalState.IsClient,
@@ -156,6 +164,7 @@ func (s *State) serialize() (*serializedState, error) {
 		LocalRandom:           s.localRandom.MarshalFixed(),
 		RemoteRandom:          s.remoteRandom.MarshalFixed(),
 		SRTPProtectionProfile: uint16(s.srtpProtectionProfile),
+		PeerSRTPMKI:           bytes.Clone(s.peerSRTPMKI),
 		PeerCertificates:      s.PeerCertificates,
 		IdentityHint:          s.IdentityHint,
 		SessionID:             s.SessionID,
@@ -178,6 +187,7 @@ func (s *State) deserialize(serialized serializedState) {
 	s.masterSecret = serialized.MasterSecret
 	s.sequenceNumber = serialized.SequenceNumber
 	s.srtpProtectionProfile = SRTPProtectionProfile(serialized.SRTPProtectionProfile)
+	s.peerSRTPMKI = bytes.Clone(serialized.PeerSRTPMKI)
 	s.localConnectionID = serialized.LocalConnectionID
 	s.remoteConnectionID = serialized.RemoteConnectionID
 	s.isClient = serialized.IsClient
@@ -241,6 +251,7 @@ func (s *State) generateInternalState() (*dtlsstate.State, error) {
 	}
 	state.SetLocalEpoch(s.localEpoch)
 	state.SetRemoteEpoch(s.remoteEpoch)
+	state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(s.peerSRTPMKI)
 	state.SetSRTPProtectionProfile(s.srtpProtectionProfile)
 	state.SetLocalConnectionID(s.localConnectionID)
 


### PR DESCRIPTION
#### Description
This mainly refactors use_srtp and MKI as a common helpers to be used in 1.3, and fixes some issues with the dual-state.

This refactor / rework fixes use-srtp selection handling issues that will show in the dual mode. by selecting profiles from the final ClientHello and not early retry, and similar to #1029  it prevents servers from sending an unrelated non-empty MKI, validates the server’s selected profile/MKI against the client’s final offer.

Avoids publishing SRTP state until the complete handshake flight is valid. and renegotiates SRTP on resumption.

part of #1021 and #727 