### PR TITLE
Require and test SRTP profiles

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -984,23 +984,24 @@ func TestClientTimeout(t *testing.T) {
 	assert.True(t, netErr.Timeout(), "Client error exp(Timeout) failed")
 }
 
+type srtpConfigurationTest struct {
+	Name                          string
+	ClientSRTP                    []SRTPProtectionProfile
+	ServerSRTP                    []SRTPProtectionProfile
+	ClientSRTPMasterKeyIdentifier []byte
+	ServerSRTPMasterKeyIdentifier []byte
+	ExpectedClientMKI             []byte
+	ExpectedServerMKI             []byte
+	ExpectedProfile               SRTPProtectionProfile
+	WantClientError               error
+	WantServerError               error
+}
+
 func TestSRTPConfiguration(t *testing.T) {
-	// Check for leaking routines
 	report := test.CheckRoutines(t)
 	defer report()
 
-	for _, test := range []struct {
-		Name                          string
-		ClientSRTP                    []SRTPProtectionProfile
-		ServerSRTP                    []SRTPProtectionProfile
-		ClientSRTPMasterKeyIdentifier []byte
-		ServerSRTPMasterKeyIdentifier []byte
-		ExpectedClientMKI             []byte
-		ExpectedServerMKI             []byte
-		ExpectedProfile               SRTPProtectionProfile
-		WantClientError               error
-		WantServerError               error
-	}{
+	tests := []srtpConfigurationTest{
 		{
 			Name: "No SRTP in use",
 		},
@@ -1036,8 +1037,8 @@ func TestSRTPConfiguration(t *testing.T) {
 			ClientSRTP:      nil,
 			ServerSRTP:      []SRTPProtectionProfile{SRTP_AES128_CM_HMAC_SHA1_80},
 			ExpectedProfile: 0,
-			WantClientError: nil,
-			WantServerError: nil,
+			WantClientError: &alertError{&alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}},
+			WantServerError: dtlserrors.ErrServerNoMatchingSRTPProfile,
 		},
 		{
 			Name:            "Multiple Suites",
@@ -1055,76 +1056,84 @@ func TestSRTPConfiguration(t *testing.T) {
 			WantClientError: nil,
 			WantServerError: nil,
 		},
-	} {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		ca, cb := dpipe.Pipe()
-		type result struct {
-			c   *Conn
-			err error
-		}
-		resultCh := make(chan result)
-
-		go func() {
-			opts := []ClientOption{
-				WithMinVersion(protocol.Version1_2),
-				WithMaxVersion(protocol.Version1_2),
-				WithSRTPMasterKeyIdentifier(test.ClientSRTPMasterKeyIdentifier),
-			}
-			if len(test.ClientSRTP) > 0 {
-				opts = append(opts, WithSRTPProtectionProfiles(test.ClientSRTP...))
-			}
-			client, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, true)
-			resultCh <- result{client, err}
-		}()
-
-		opts := []ServerOption{
-			WithMinVersion(protocol.Version1_2),
-			WithMaxVersion(protocol.Version1_2),
-			WithSRTPMasterKeyIdentifier(test.ServerSRTPMasterKeyIdentifier),
-		}
-		if len(test.ServerSRTP) > 0 {
-			opts = append(opts, WithSRTPProtectionProfiles(test.ServerSRTP...))
-		}
-		server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), opts, true)
-		assert.ErrorIs(t, err, test.WantServerError, "TestSRTPConfiguration: Server Error Mismatch")
-
-		if err == nil {
-			defer func() {
-				_ = server.Close()
-			}()
-		}
-
-		res := <-resultCh
-		if res.err == nil {
-			defer func() {
-				_ = res.c.Close()
-			}()
-		}
-		assert.ErrorIsf(t, res.err, test.WantClientError, "TestSRTPConfiguration: Client Error Mismatch '%s'", test.Name)
-		if res.c == nil {
-			return
-		}
-
-		actualClientSRTP, _ := res.c.SelectedSRTPProtectionProfile()
-		assert.Equalf(t, test.ExpectedProfile, actualClientSRTP,
-			"TestSRTPConfiguration: Client SRTPProtectionProfile Mismatch '%s'", test.Name)
-
-		actualServerSRTP, _ := server.SelectedSRTPProtectionProfile()
-		assert.Equalf(t, test.ExpectedProfile, actualServerSRTP,
-			"TestSRTPConfiguration: Server SRTPProtectionProfile Mismatch '%s'", test.Name)
-
-		actualServerMKI, _ := server.RemoteSRTPMasterKeyIdentifier()
-		assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI), test.Name)
-		if len(actualServerMKI) > 0 {
-			actualServerMKI[0] ^= 0xff
-			actualServerMKI, _ = server.RemoteSRTPMasterKeyIdentifier()
-			assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI), test.Name)
-		}
-		actualClientMKI, _ := res.c.RemoteSRTPMasterKeyIdentifier()
-		assert.True(t, bytes.Equal(test.ExpectedClientMKI, actualClientMKI), test.Name)
 	}
+	for _, version := range []struct {
+		name  string
+		value protocol.Version
+	}{
+		{name: "DTLS12", value: protocol.Version1_2},
+		{name: "DTLS13", value: protocol.Version1_3},
+	} {
+		for _, test := range tests {
+			t.Run(version.name+"/"+test.Name, func(t *testing.T) {
+				runSRTPConfiguration(t, version.value, test)
+			})
+		}
+	}
+}
+
+func runSRTPConfiguration(t *testing.T, version protocol.Version, test srtpConfigurationTest) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ca, cb := dpipe.Pipe()
+	type result struct {
+		c   *Conn
+		err error
+	}
+	resultCh := make(chan result)
+
+	go func() {
+		opts := []ClientOption{
+			WithMinVersion(version),
+			WithMaxVersion(version),
+			WithSRTPMasterKeyIdentifier(test.ClientSRTPMasterKeyIdentifier),
+		}
+		if len(test.ClientSRTP) > 0 {
+			opts = append(opts, WithSRTPProtectionProfiles(test.ClientSRTP...))
+		}
+		client, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, true)
+		resultCh <- result{client, err}
+	}()
+
+	opts := []ServerOption{
+		WithMinVersion(version),
+		WithMaxVersion(version),
+		WithSRTPMasterKeyIdentifier(test.ServerSRTPMasterKeyIdentifier),
+	}
+	if len(test.ServerSRTP) > 0 {
+		opts = append(opts, WithSRTPProtectionProfiles(test.ServerSRTP...))
+	}
+	server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), opts, true)
+	assert.ErrorIs(t, err, test.WantServerError)
+	if server != nil {
+		defer func() { _ = server.Close() }()
+	}
+
+	res := <-resultCh
+	assert.ErrorIs(t, res.err, test.WantClientError)
+	if res.c != nil {
+		defer func() { _ = res.c.Close() }()
+	}
+	if res.c == nil || server == nil {
+		return
+	}
+
+	actualClientSRTP, _ := res.c.SelectedSRTPProtectionProfile()
+	assert.Equal(t, test.ExpectedProfile, actualClientSRTP)
+	actualServerSRTP, _ := server.SelectedSRTPProtectionProfile()
+	assert.Equal(t, test.ExpectedProfile, actualServerSRTP)
+
+	actualServerMKI, _ := server.RemoteSRTPMasterKeyIdentifier()
+	assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI))
+	if len(actualServerMKI) > 0 {
+		actualServerMKI[0] ^= 0xff
+		actualServerMKI, _ = server.RemoteSRTPMasterKeyIdentifier()
+		assert.True(t, bytes.Equal(test.ExpectedServerMKI, actualServerMKI))
+	}
+	actualClientMKI, _ := res.c.RemoteSRTPMasterKeyIdentifier()
+	assert.True(t, bytes.Equal(test.ExpectedClientMKI, actualClientMKI))
 }
 
 func TestClientCertificate(t *testing.T) { //nolint:gocyclo,cyclop,maintidx

--- a/internal/extensionnegotiation/srtp.go
+++ b/internal/extensionnegotiation/srtp.go
@@ -27,8 +27,15 @@ func NegotiateSRTP(
 	acceptedMKI []byte,
 ) (SRTPDecision, error) {
 	offer, offered, err := readSRTPOffer(snapshot)
-	if err != nil || !offered {
+	if err != nil {
 		return SRTPDecision{}, err
+	}
+	if !offered {
+		if len(localProfiles) > 0 {
+			return SRTPDecision{}, srtpError(dtlserrors.ErrServerNoMatchingSRTPProfile, alert.InsufficientSecurity)
+		}
+
+		return SRTPDecision{}, nil
 	}
 
 	var profile extension.SRTPProtectionProfile
@@ -55,6 +62,8 @@ func NegotiateSRTP(
 }
 
 // ValidateSRTPSelection validates one server selection against the exact offer.
+//
+//nolint:cyclop
 func ValidateSRTPSelection(
 	snapshot ClientHelloSnapshot,
 	responses []extension.Value,
@@ -65,6 +74,10 @@ func ValidateSRTPSelection(
 		return SRTPDecision{}, err
 	}
 	if !offered {
+		if len(localProfiles) > 0 {
+			return SRTPDecision{}, srtpError(dtlserrors.ErrRequestedButNoSRTPExtension, alert.InsufficientSecurity)
+		}
+
 		return SRTPDecision{}, nil
 	}
 

--- a/internal/flight/flight12/srtp_test.go
+++ b/internal/flight/flight12/srtp_test.go
@@ -77,19 +77,17 @@ func TestFlight12ServerHelloUsesFinalSRTPOffer(t *testing.T) {
 	}
 }
 
-func TestFlight12ResumptionClearsStaleSRTPWithoutFinalOffer(t *testing.T) {
+func TestFlight12ResumptionRequiresFinalSRTPOffer(t *testing.T) {
 	state := newSRTPServerState12()
 	state.LocalVerifyData = []byte{1}
-	state.SetSRTPProtectionProfile(profile80)
-	state.RemoteSRTPMasterKeyIdentifier = []byte("stale")
 	recordCH12(t, &state.RemoteClientHelloSnapshots, srtpOffer12(profile80, initialMKI))
 	recordCH12(t, &state.RemoteClientHelloSnapshots)
 
 	packets, _, err := generateForTest(t, Flight4b, nil, state, dtlsflight.NewCache(), &dtlsconfig.HandshakeConfig{
 		LocalSRTPProtectionProfiles: []extension.SRTPProtectionProfile{profile80},
 	})
-	require.NoError(t, err)
-	assert.Nil(t, serverHelloSRTPSelection12(t, packets))
+	require.ErrorIs(t, err, dtlserrors.ErrServerNoMatchingSRTPProfile)
+	assert.Nil(t, packets)
 	assert.Zero(t, state.SRTPProtectionProfile())
 }
 

--- a/internal/flight/flight13/srtp_test.go
+++ b/internal/flight/flight13/srtp_test.go
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package flight13
+
+import (
+	"testing"
+
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	srtpProfile13 extension.SRTPProtectionProfile = extension.SRTP_AES128_CM_HMAC_SHA1_80
+	srtpMKI13                                     = "client-mki"
+)
+
+func TestFlight4GenerateNegotiatesSRTPInEncryptedExtensions(t *testing.T) {
+	for _, test := range []struct {
+		name, offerMKI, serverMKI, wantMKI string
+		offer                              bool
+		wantError                          bool
+	}{
+		{name: "echo", offer: true, offerMKI: srtpMKI13, serverMKI: srtpMKI13, wantMKI: srtpMKI13},
+		{name: "decline", offer: true, offerMKI: srtpMKI13, serverMKI: "other"},
+		{name: "not offered", wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flightCtx, _ := flight4TestContext(t)
+			flightCtx.cfg.LocalSRTPProtectionProfiles = []extension.SRTPProtectionProfile{srtpProfile13}
+			flightCtx.cfg.LocalSRTPMasterKeyIdentifier = []byte(test.serverMKI)
+			if test.offer {
+				flightCtx.state.RemoteClientHelloSnapshots.Reset()
+				require.NoError(t, flightCtx.state.RemoteClientHelloSnapshots.Record(
+					srtpSnapshot13(t, srtpProfile13, test.offerMKI),
+				))
+			}
+
+			packets, _, err := flight4Generate(nil, flightCtx)
+			if test.wantError {
+				require.ErrorIs(t, err, dtlserrors.ErrServerNoMatchingSRTPProfile)
+				assert.Nil(t, packets)
+				assert.Zero(t, flightCtx.state.SRTPProtectionProfile())
+
+				return
+			}
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(packets), 2)
+			serverHello := packets[0].Record.Content.(*handshake.Handshake).Message.(*handshake.MessageServerHello) //nolint:forcetypeassert,lll
+			assert.False(t, hasSRTPSelection13(serverHello.Extensions))
+			encryptedExtensions := packets[1].Record.Content.(*handshake.Handshake).Message.(*handshake.MessageEncryptedExtensions) //nolint:forcetypeassert,lll
+			selection := findSRTPSelection13(encryptedExtensions.Extensions)
+			require.NotNil(t, selection)
+			assert.Equal(t, srtpProfile13, selection.ProtectionProfile)
+			assert.Equal(t, test.wantMKI, string(selection.MasterKeyIdentifier))
+			assert.Equal(t, srtpProfile13, flightCtx.state.SRTPProtectionProfile())
+			assert.Equal(t, test.offerMKI, string(flightCtx.state.RemoteSRTPMasterKeyIdentifier))
+		})
+	}
+}
+
+func TestFlight3ParseValidatesAndRollsBackSRTP(t *testing.T) {
+	laterFailure := dtlserrors.ErrInvalidCertificate
+	for _, test := range []struct {
+		name       string
+		extensions []extension.Value
+		handlerErr error
+		wantError  error
+		wantCommit bool
+	}{
+		{
+			name: "valid",
+			extensions: []extension.Value{&extension.SRTPSelection{
+				ProtectionProfile: srtpProfile13, MasterKeyIdentifier: []byte(srtpMKI13),
+			}},
+			wantCommit: true,
+		},
+		{
+			name: "mismatched MKI",
+			extensions: []extension.Value{&extension.SRTPSelection{
+				ProtectionProfile: srtpProfile13, MasterKeyIdentifier: []byte("other"),
+			}},
+			wantError: dtlserrors.ErrClientNoMatchingSRTPProfile,
+		},
+		{name: "missing selection", wantError: dtlserrors.ErrRequestedButNoSRTPExtension},
+		{
+			name: "later failure",
+			extensions: []extension.Value{&extension.SRTPSelection{
+				ProtectionProfile: srtpProfile13, MasterKeyIdentifier: []byte(srtpMKI13),
+			}},
+			handlerErr: laterFailure,
+			wantError:  laterFailure,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state := dtlsstate.NewState13(true)
+			state.SetRemoteEpoch(EpochHandshake)
+			require.NoError(t, state.LocalClientHelloSnapshots.Record(
+				srtpSnapshot13(t, srtpProfile13, srtpMKI13),
+			))
+			cache := dtlsflight.NewCache()
+			cache.Push(marshalProtectedTestHandshake(t, 0, &handshake.MessageEncryptedExtensions{
+				Extensions: test.extensions,
+			}), EpochHandshake, 0, handshake.TypeEncryptedExtensions, false)
+			cache.Push(marshalProtectedTestHandshake(t, 1, &handshake.MessageFinished{}),
+				EpochHandshake, 1, handshake.TypeFinished, false)
+			handlerCalled := false
+			next, dtlsAlert, err := flight3Parse(t.Context(), nil, &handshakeContext{
+				state: &state,
+				cache: cache,
+				cfg: &dtlsconfig.HandshakeConfig{
+					LocalSRTPProtectionProfiles: []extension.SRTPProtectionProfile{srtpProfile13},
+				},
+				protectedHandshakeHandler: func(
+					_ dtlsconfig.CipherSuite,
+					_ []dtlsflight.DecodedHandshakeCacheItem,
+				) error {
+					handlerCalled = true
+					assert.Equal(t, srtpProfile13, state.SRTPProtectionProfile())
+					assert.Equal(t, srtpMKI13, string(state.RemoteSRTPMasterKeyIdentifier))
+
+					return test.handlerErr
+				},
+			})
+			if test.wantError != nil {
+				require.ErrorIs(t, err, test.wantError)
+				assert.Zero(t, next)
+				assert.Zero(t, state.SRTPProtectionProfile())
+				if test.handlerErr == nil {
+					assert.False(t, handlerCalled)
+				}
+
+				return
+			}
+			require.NoError(t, err)
+			require.Nil(t, dtlsAlert)
+			assert.Equal(t, Flight5, next)
+			assert.True(t, handlerCalled)
+			assert.Equal(t, test.wantCommit, state.SRTPProtectionProfile() != 0)
+		})
+	}
+}
+
+func TestValidateSRTPRetry(t *testing.T) {
+	initial := srtpSnapshot13(t, srtpProfile13, srtpMKI13)
+	for _, test := range []struct {
+		name      string
+		retry     extensionnegotiation.ClientHelloSnapshot
+		wantError bool
+	}{
+		{name: "identical", retry: srtpSnapshot13(t, srtpProfile13, srtpMKI13)},
+		{name: "changed MKI", retry: srtpSnapshot13(t, srtpProfile13, "other"), wantError: true},
+		{name: "removed", retry: srtpSnapshot13(t, 0, ""), wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := extensionnegotiation.ValidateSRTPRetry(initial, test.retry)
+			if test.wantError {
+				require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+				var dtlsAlert *alert.Alert
+				require.ErrorAs(t, err, &dtlsAlert)
+				assert.Equal(t, alert.IllegalParameter, dtlsAlert.Description)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFlight2ParseRejectsChangedSRTPOffer(t *testing.T) {
+	state := dtlsstate.NewState13(false)
+	state.Cookie = []byte("cookie")
+	state.HandshakeRecvSequence = 1
+	require.NoError(t, state.RemoteClientHelloSnapshots.Record(
+		srtpSnapshot13(t, srtpProfile13, srtpMKI13),
+	))
+	message := &handshake.Handshake{
+		Header: handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageClientHello{Version: protocol.Version1_2, Extensions: []extension.Value{
+			&extension13.Cookie{Cookie: state.Cookie},
+			&extension.SRTPOffer{
+				ProtectionProfiles:  []extension.SRTPProtectionProfile{srtpProfile13},
+				MasterKeyIdentifier: []byte("changed"),
+			},
+		}},
+	}
+	raw, err := message.Marshal()
+	require.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(raw, EpochInitial, 1, handshake.TypeClientHello, true)
+
+	next, dtlsAlert, err := flight2Parse(t.Context(), nil, &handshakeContext{
+		state: &state, cache: cache, cfg: &dtlsconfig.HandshakeConfig{},
+	})
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
+	assert.Zero(t, next)
+}
+
+func srtpSnapshot13(
+	t *testing.T,
+	profile extension.SRTPProtectionProfile,
+	mki string,
+) extensionnegotiation.ClientHelloSnapshot {
+	t.Helper()
+	extensions := []extension.Value{}
+	if profile != 0 {
+		extensions = append(extensions, &extension.SRTPOffer{
+			ProtectionProfiles:  []extension.SRTPProtectionProfile{profile},
+			MasterKeyIdentifier: []byte(mki),
+		})
+	}
+	_, snapshot, err := extensionnegotiation.FinalizeClientHello(
+		&handshake.MessageClientHello{Extensions: extensions}, nil,
+	)
+	require.NoError(t, err)
+
+	return snapshot
+}
+
+func hasSRTPSelection13(extensions []extension.Value) bool {
+	return findSRTPSelection13(extensions) != nil
+}
+
+func findSRTPSelection13(extensions []extension.Value) *extension.SRTPSelection {
+	for _, value := range extensions {
+		if selection, ok := value.(*extension.SRTPSelection); ok {
+			return selection
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Description
When WithSRTPProtectionProfiles is set, we require SRTP negotiation and selection on the the client side, but not when pion is the server, this enforces SRTP selection on both the client and the server and adds multiple tests to cover SRTP selection path.

part of #1021 