### PR TITLE
Add shared ClientHello retry validation

### DIFF
--- a/internal/extensionnegotiation/negotiation.go
+++ b/internal/extensionnegotiation/negotiation.go
@@ -18,8 +18,9 @@ import (
 
 // ClientHelloSnapshot is an immutable copy of a validated ClientHello body.
 type ClientHelloSnapshot struct {
-	body       []byte
-	extensions []extension.Raw
+	body            []byte
+	extensionOffset int
+	extensions      []extension.Raw
 }
 
 // Valid reports whether the snapshot contains a ClientHello.
@@ -138,7 +139,9 @@ func snapshotClientHello(body []byte) (ClientHelloSnapshot, error) {
 		return ClientHelloSnapshot{}, fmt.Errorf("extensions: %w", err)
 	}
 
-	return ClientHelloSnapshot{body: bytes.Clone(body), extensions: extensions}, nil
+	return ClientHelloSnapshot{
+		body: bytes.Clone(body), extensionOffset: len(body) - len(extensionData), extensions: extensions,
+	}, nil
 }
 
 func clientHelloExtensions(body []byte) ([]byte, error) {

--- a/internal/extensionnegotiation/retry.go
+++ b/internal/extensionnegotiation/retry.go
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extensionnegotiation
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+)
+
+var (
+	errRetryMissingInitial         = errors.New("missing initial ClientHello or cipher suite")
+	errRetryNoEffect               = errors.New("HelloRetryRequest has no effect")
+	errRetryUnvalidatedRequest     = errors.New("unvalidated HelloRetryRequest")
+	errRetryMissingFreshShare      = errors.New("missing fresh share for selected group")
+	errRetryMissingSnapshot        = errors.New("missing ClientHello snapshot or retry request")
+	errRetryChangedFields          = errors.New("ClientHello fields changed after HelloRetryRequest")
+	errRetryWrongKeyShare          = errors.New("ClientHello2 did not contain exactly one requested key share")
+	errRetryChangedExtensions      = errors.New("ClientHello extensions changed after HelloRetryRequest")
+	errHelloVerifyMissingSnapshot  = errors.New("missing ClientHello snapshot")
+	errHelloVerifyChangedFields    = errors.New("ClientHello fields changed after HelloVerifyRequest")
+	errRetryFinalCipherSuite       = errors.New("final ServerHello changed the HelloRetryRequest cipher suite")
+	errRetryCipherSuiteNotOffered  = errors.New("cipher suite was not offered")
+	errRetryGroupNotOffered        = errors.New("selected group was not offered in supported_groups")
+	errRetryGroupAlreadyShared     = errors.New("selected group already had a key share")
+	errHelloVerifyExtensionChanged = errors.New("extension changed after HelloVerifyRequest")
+)
+
+// RetryRequest is the set of changes authorized by one validated
+// HelloRetryRequest.
+type RetryRequest struct {
+	CipherSuiteID    uint16
+	SelectedGroup    elliptic.Curve
+	Cookie           []byte
+	HasSelectedGroup bool
+	HasCookie        bool
+	valid            bool
+}
+
+// ValidateHelloRetryRequest validates the parts of an HRR that constrain
+// ClientHello2 and the final ServerHello.
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.2.4
+func ValidateHelloRetryRequest(
+	initial ClientHelloSnapshot,
+	hrr *handshake.MessageServerHello,
+) (RetryRequest, error) {
+	if !initial.Valid() || hrr == nil || hrr.CipherSuiteID == nil {
+		return RetryRequest{}, negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			errRetryMissingInitial,
+			alert.IllegalParameter,
+		)
+	}
+
+	initialHello, err := ClientHelloFromSnapshot(initial)
+	if err != nil {
+		return RetryRequest{}, negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			err,
+			alert.IllegalParameter,
+		)
+	}
+	if !slices.Contains(initialHello.CipherSuiteIDs, *hrr.CipherSuiteID) {
+		return RetryRequest{}, negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			fmt.Errorf("%w: %d", errRetryCipherSuiteNotOffered, *hrr.CipherSuiteID),
+			alert.IllegalParameter,
+		)
+	}
+	request := retryRequest(*hrr.CipherSuiteID, hrr.Extensions)
+	if err = validateRetrySelectedGroup(initialHello, request); err != nil {
+		return RetryRequest{}, err
+	}
+	changed, err := helloRetryRequestChangesClientHello(initial, request)
+	if err != nil {
+		return RetryRequest{}, err
+	}
+	if !changed {
+		return RetryRequest{}, negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest, errRetryNoEffect, alert.IllegalParameter,
+		)
+	}
+
+	request.valid = true
+
+	return request, nil
+}
+
+// BuildClientHelloRetry clones the exact finalized ClientHello1 and applies
+// only the changes authorized by request. The caller may run its hook on the
+// result, but must validate the hook result with ValidateClientHelloRetry.
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.2.2
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.2.4
+func BuildClientHelloRetry(
+	initial ClientHelloSnapshot,
+	request RetryRequest,
+	freshShare *extension13.KeyShareEntry,
+) (*handshake.MessageClientHello, error) {
+	if !request.valid {
+		return nil, negotiationError(dtlserrors.ErrInvalidClientHello, errRetryUnvalidatedRequest, alert.IllegalParameter)
+	}
+	if request.HasSelectedGroup &&
+		(freshShare == nil || freshShare.Group != request.SelectedGroup || len(freshShare.KeyExchange) == 0) {
+		return nil, negotiationError(dtlserrors.ErrInvalidClientHello, errRetryMissingFreshShare, alert.IllegalParameter)
+	}
+
+	clientHello, err := ClientHelloFromSnapshot(initial)
+	if err != nil {
+		return nil, negotiationError(dtlserrors.ErrInvalidClientHello, err, alert.IllegalParameter)
+	}
+
+	clientHello.Extensions = buildRetryExtensions(clientHello.Extensions, request, freshShare)
+
+	return clientHello, nil
+}
+
+// ValidateClientHelloRetry requires ClientHello2 to equal ClientHello1
+// except for the changes authorized by a validated HelloRetryRequest, removal
+// of early_data, and padding changes.
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.2.2
+func ValidateClientHelloRetry(
+	initial, retry ClientHelloSnapshot,
+	request RetryRequest,
+) error {
+	if !initial.Valid() || !retry.Valid() || !request.valid {
+		return negotiationError(
+			dtlserrors.ErrInvalidClientHello, errRetryMissingSnapshot,
+			alert.IllegalParameter,
+		)
+	}
+
+	return validateRetryClientHello(initial, retry, request)
+}
+
+// ValidateHelloVerifyRequestResponse validates the RFC 6347 fields that must remain
+// stable across HelloVerifyRequest. DTLS 1.2 does
+// not require byte-for-byte extension equality, but the existing CID and SRTP
+// retry validation still apply.
+func ValidateHelloVerifyRequestResponse(initial, retry ClientHelloSnapshot, cookie []byte) error {
+	if !initial.Valid() || !retry.Valid() {
+		return negotiationError(dtlserrors.ErrInvalidClientHello, errHelloVerifyMissingSnapshot, alert.IllegalParameter)
+	}
+	firstBeforeCookie, firstAfterCookie, _ := helloVerifyClientHelloParts(initial)
+	secondBeforeCookie, secondAfterCookie, secondCookie := helloVerifyClientHelloParts(retry)
+	if !bytes.Equal(firstBeforeCookie, secondBeforeCookie) || !bytes.Equal(firstAfterCookie, secondAfterCookie) {
+		return negotiationError(dtlserrors.ErrInvalidClientHello, errHelloVerifyChangedFields, alert.IllegalParameter)
+	}
+	if !bytes.Equal(secondCookie, cookie) {
+		return negotiationError(
+			dtlserrors.ErrInvalidClientHello,
+			fmt.Errorf("ClientHello did not echo the latest cookie: %w", dtlserrors.ErrCookieMismatch),
+			alert.IllegalParameter,
+		)
+	}
+	if err := validateHelloVerifyExtension(initial, retry, extension.TypeConnectionID); err != nil {
+		return err
+	}
+	if err := ValidateSRTPRetry(initial, retry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateServerHelloAfterRetry binds the final ServerHello to the cipher
+// suite and selected group from the preceding HelloRetryRequest.
+func ValidateServerHelloAfterRetry(request RetryRequest, serverHello *handshake.MessageServerHello) error {
+	if !request.valid {
+		return negotiationError(dtlserrors.ErrInvalidServerHello, errRetryUnvalidatedRequest, alert.IllegalParameter)
+	}
+	if serverHello == nil || serverHello.CipherSuiteID == nil || *serverHello.CipherSuiteID != request.CipherSuiteID {
+		return negotiationError(dtlserrors.ErrInvalidServerHello, errRetryFinalCipherSuite, alert.IllegalParameter)
+	}
+	if request.HasSelectedGroup {
+		var share *extension13.ServerKeyShare
+		for _, value := range serverHello.Extensions {
+			if candidate, ok := value.(*extension13.ServerKeyShare); ok {
+				share = candidate
+
+				break
+			}
+		}
+		if share == nil {
+			return negotiationError(
+				dtlserrors.ErrInvalidServerHello, dtlserrors.ErrServerKeyShareMissing, alert.IllegalParameter,
+			)
+		}
+		if share.Share.Group != request.SelectedGroup {
+			return negotiationError(
+				dtlserrors.ErrInvalidServerHello, dtlserrors.ErrServerKeyShareUnknownGroup, alert.IllegalParameter,
+			)
+		}
+	}
+
+	return nil
+}
+
+// ClientHelloFromSnapshot returns a detached decoded copy of snapshot.
+func ClientHelloFromSnapshot(snapshot ClientHelloSnapshot) (*handshake.MessageClientHello, error) {
+	if !snapshot.Valid() {
+		return nil, dtlserrors.ErrInvalidClientHello
+	}
+	clientHello := &handshake.MessageClientHello{}
+	if err := clientHello.Unmarshal(snapshot.body); err != nil {
+		return nil, fmt.Errorf("snapshot ClientHello: %w", err)
+	}
+
+	return clientHello, nil
+}
+
+// RFC 9846 Section 4.2.4 permits HRR to request one group and / or a cookie.
+//
+// https://www.rfc-editor.org/rfc/rfc9846#section-4.2.4
+func retryRequest(cipherSuiteID uint16, values []extension.Value) RetryRequest {
+	request := RetryRequest{CipherSuiteID: cipherSuiteID}
+	for _, value := range values {
+		if selectedGroup, ok := value.(*extension13.RetryKeyShare); ok {
+			request.SelectedGroup = selectedGroup.SelectedGroup
+			request.HasSelectedGroup = true
+		}
+		if cookie, ok := value.(*extension13.Cookie); ok {
+			request.Cookie = bytes.Clone(cookie.Cookie)
+			request.HasCookie = true
+		}
+	}
+
+	return request
+}
+
+func validateRetrySelectedGroup(initial *handshake.MessageClientHello, request RetryRequest) error {
+	if !request.HasSelectedGroup {
+		return nil
+	}
+	var groups []elliptic.Curve
+	var shares []extension13.KeyShareEntry
+	for _, value := range initial.Extensions {
+		if supported, ok := value.(*extension.SupportedGroups); ok {
+			groups = supported.Groups
+		}
+		if keyShare, ok := value.(*extension13.ClientKeyShare); ok {
+			shares = keyShare.Shares
+		}
+	}
+	if !slices.Contains(groups, request.SelectedGroup) {
+		return negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			fmt.Errorf("%w: %d", errRetryGroupNotOffered, request.SelectedGroup),
+			alert.IllegalParameter,
+		)
+	}
+	if slices.ContainsFunc(shares, func(share extension13.KeyShareEntry) bool {
+		return share.Group == request.SelectedGroup
+	}) {
+		return negotiationError(
+			dtlserrors.ErrInvalidHelloRetryRequest,
+			fmt.Errorf("%w: %d", errRetryGroupAlreadyShared, request.SelectedGroup),
+			alert.IllegalParameter,
+		)
+	}
+
+	return nil
+}
+
+func helloRetryRequestChangesClientHello(initial ClientHelloSnapshot, request RetryRequest) (bool, error) {
+	if request.HasSelectedGroup {
+		return true, nil
+	}
+	if !request.HasCookie {
+		return false, nil
+	}
+	payload, err := (extension13.Cookie{Cookie: request.Cookie}).MarshalData()
+	if err != nil {
+		return false, negotiationError(dtlserrors.ErrInvalidHelloRetryRequest, err, alert.IllegalParameter)
+	}
+	initialCookie, present := initial.Extension(extension.TypeCookie)
+
+	return !present || !bytes.Equal(initialCookie.Data, payload), nil
+}
+
+func buildRetryExtensions(
+	initial []extension.Value,
+	request RetryRequest,
+	freshShare *extension13.KeyShareEntry,
+) []extension.Value {
+	result := make([]extension.Value, 0, len(initial)+2)
+	keyShareApplied, cookieApplied := false, false
+	for _, value := range initial {
+		replacement, replace, discard := retryExtensionReplacement(value, request, freshShare)
+		if discard {
+			continue
+		}
+		if replace {
+			result = append(result, replacement)
+			if replacement.ExtensionType() == extension.TypeKeyShare {
+				keyShareApplied = true
+			} else {
+				cookieApplied = true
+			}
+
+			continue
+		}
+		result = append(result, value)
+	}
+
+	return insertMissingRetryExtensions(result, request, freshShare, keyShareApplied, cookieApplied)
+}
+
+func retryExtensionReplacement(
+	value extension.Value,
+	request RetryRequest,
+	freshShare *extension13.KeyShareEntry,
+) (extension.Value, bool, bool) {
+	typ := value.ExtensionType()
+	if typ == extension.TypeEarlyData {
+		return nil, false, true
+	}
+	if typ == extension.TypeKeyShare && request.HasSelectedGroup {
+		return retryKeyShare(freshShare), true, false
+	}
+	if typ == extension.TypeCookie && request.HasCookie {
+		return &extension13.Cookie{Cookie: bytes.Clone(request.Cookie)}, true, false
+	}
+
+	return nil, false, false
+}
+
+func insertMissingRetryExtensions(
+	values []extension.Value,
+	request RetryRequest,
+	freshShare *extension13.KeyShareEntry,
+	keyShareApplied, cookieApplied bool,
+) []extension.Value {
+	insert := make([]extension.Value, 0, 2)
+	if request.HasSelectedGroup && !keyShareApplied {
+		insert = append(insert, retryKeyShare(freshShare))
+	}
+	if request.HasCookie && !cookieApplied {
+		insert = append(insert, &extension13.Cookie{Cookie: bytes.Clone(request.Cookie)})
+	}
+	if len(insert) == 0 {
+		return values
+	}
+	insertAt := len(values)
+	if insertAt > 0 && values[insertAt-1].ExtensionType() == extension.TypePreSharedKey {
+		insertAt--
+	}
+
+	return slices.Insert(values, insertAt, insert...)
+}
+
+func validateRetryClientHello(initial, retry ClientHelloSnapshot, request RetryRequest) error {
+	if !bytes.Equal(initial.body[:initial.extensionOffset], retry.body[:retry.extensionOffset]) {
+		return negotiationError(dtlserrors.ErrInvalidClientHello, errRetryChangedFields, alert.IllegalParameter)
+	}
+	if err := validateRetryKeyShare(retry, request); err != nil {
+		return err
+	}
+	if err := validateRetryCookie(retry, request); err != nil {
+		return err
+	}
+	if retryExtensionsMatch(initial, retry, request) {
+		return nil
+	}
+
+	return negotiationError(dtlserrors.ErrInvalidClientHello, errRetryChangedExtensions, alert.IllegalParameter)
+}
+
+func validateRetryKeyShare(retry ClientHelloSnapshot, request RetryRequest) error {
+	if !request.HasSelectedGroup {
+		return nil
+	}
+	shares, err := clientKeyShares(retry)
+	if err == nil && len(shares) == 1 && shares[0].Group == request.SelectedGroup {
+		return nil
+	}
+
+	return negotiationError(dtlserrors.ErrInvalidClientHello, errRetryWrongKeyShare, alert.IllegalParameter)
+}
+
+func validateRetryCookie(retry ClientHelloSnapshot, request RetryRequest) error {
+	if !request.HasCookie {
+		return nil
+	}
+	cookie, present := retry.Extension(extension.TypeCookie)
+	payload, err := (extension13.Cookie{Cookie: request.Cookie}).MarshalData()
+	if err == nil && present && bytes.Equal(cookie.Data, payload) {
+		return nil
+	}
+
+	return negotiationError(
+		dtlserrors.ErrInvalidClientHello,
+		fmt.Errorf("ClientHello2 did not echo the HelloRetryRequest cookie: %w", dtlserrors.ErrCookieMismatch),
+		alert.IllegalParameter,
+	)
+}
+
+func retryExtensionsMatch(initial, retry ClientHelloSnapshot, request RetryRequest) bool {
+	first := comparableRetryExtensions(initial.extensions, true, request)
+	second := comparableRetryExtensions(retry.extensions, false, request)
+
+	return slices.EqualFunc(first, second, func(a, b extension.Raw) bool {
+		return a.Type == b.Type && bytes.Equal(a.Data, b.Data)
+	})
+}
+
+func comparableRetryExtensions(
+	values []extension.Raw,
+	initial bool,
+	request RetryRequest,
+) []extension.Raw {
+	result := make([]extension.Raw, 0, len(values))
+	for _, value := range values {
+		if value.Type == extension.TypePadding ||
+			(value.Type == extension.TypeEarlyData && initial) ||
+			(value.Type == extension.TypeKeyShare && request.HasSelectedGroup) ||
+			(value.Type == extension.TypeCookie && request.HasCookie) {
+			continue
+		}
+		result = append(result, value)
+	}
+
+	return result
+}
+
+func clientKeyShares(snapshot ClientHelloSnapshot) ([]extension13.KeyShareEntry, error) {
+	raw, ok := snapshot.Extension(extension.TypeKeyShare)
+	if !ok {
+		return nil, nil
+	}
+	var keyShare extension13.ClientKeyShare
+	if err := keyShare.UnmarshalData(raw.Data); err != nil {
+		return nil, err
+	}
+
+	return keyShare.Shares, nil
+}
+
+func helloVerifyClientHelloParts(snapshot ClientHelloSnapshot) (beforeCookie, afterCookie, cookie []byte) {
+	cookieOffset := 2 + handshake.RandomLength
+	cookieOffset += 1 + int(snapshot.body[cookieOffset])
+	cookieStart := cookieOffset + 1
+	cookieEnd := cookieStart + int(snapshot.body[cookieOffset])
+
+	return snapshot.body[:cookieOffset], snapshot.body[cookieEnd:snapshot.extensionOffset],
+		snapshot.body[cookieStart:cookieEnd]
+}
+
+func validateHelloVerifyExtension(initial, retry ClientHelloSnapshot, typ extension.Type) error {
+	first, firstPresent := initial.Extension(typ)
+	second, secondPresent := retry.Extension(typ)
+	if firstPresent == secondPresent && bytes.Equal(first.Data, second.Data) {
+		return nil
+	}
+
+	return negotiationError(
+		dtlserrors.ErrInvalidClientHello,
+		fmt.Errorf("%w: %d", errHelloVerifyExtensionChanged, typ),
+		alert.IllegalParameter,
+	)
+}
+
+func retryKeyShare(share *extension13.KeyShareEntry) *extension13.ClientKeyShare {
+	return &extension13.ClientKeyShare{Shares: []extension13.KeyShareEntry{{
+		Group: share.Group, KeyExchange: bytes.Clone(share.KeyExchange),
+	}}}
+}

--- a/internal/extensionnegotiation/retry_test.go
+++ b/internal/extensionnegotiation/retry_test.go
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extensionnegotiation
+
+import (
+	"slices"
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const secondUnknownExtensionType extension.Type = 0xfefd
+
+func retryClientHelloForTest(withEarlyData bool) *handshake.MessageClientHello {
+	clientHello := clientHelloForTest(
+		&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519, elliptic.P256}},
+		&extension13.ClientKeyShare{Shares: []extension13.KeyShareEntry{{
+			Group: elliptic.P256, KeyExchange: []byte{0x04, 0x01},
+		}}},
+		extension.Raw{Type: unknownExtensionType, Data: []byte{0x01}},
+		extension.Raw{Type: secondUnknownExtensionType, Data: []byte{0x02}},
+	)
+	clientHello.CipherSuiteIDs = []uint16{0x1301, 0x1302}
+	clientHello.CompressionMethods = []*protocol.CompressionMethod{{ID: 0}, {ID: 0}}
+	clientHello.Random.RandomBytes[0] = 0xaa
+	if withEarlyData {
+		clientHello.Extensions = append(clientHello.Extensions,
+			&extension13.PSKKeyExchangeModes{Modes: []extension13.PSKKeyExchangeMode{extension13.PSKDHEKE}},
+			&extension13.EarlyData{},
+			&extension13.OfferedPSKs{
+				Identities: []extension13.PSKIdentity{{Identity: []byte("ticket")}},
+				Binders:    []extension13.PSKBinder{make([]byte, 32)},
+			},
+		)
+	}
+
+	return clientHello
+}
+
+func snapshotClientHelloForRetryTest(t *testing.T, clientHello *handshake.MessageClientHello) ClientHelloSnapshot {
+	t.Helper()
+	_, snapshot, err := FinalizeClientHello(clientHello, nil)
+	require.NoError(t, err)
+
+	return snapshot
+}
+
+func helloRetryRequest13ForTest(
+	cipherSuiteID uint16,
+	selectedGroup *elliptic.Curve,
+	cookie []byte,
+) *handshake.MessageServerHello {
+	exts := []extension.Value{&extension13.SelectedVersion{Version: protocol.Version1_3}}
+	if selectedGroup != nil {
+		exts = append(exts, &extension13.RetryKeyShare{SelectedGroup: *selectedGroup})
+	}
+	if cookie != nil {
+		exts = append(exts, &extension13.Cookie{Cookie: cookie})
+	}
+	hrr := helloRetryRequestForTest(exts...)
+	hrr.CipherSuiteID = &cipherSuiteID
+
+	return hrr
+}
+
+func finalizedRetryForTest(
+	t *testing.T,
+	initial ClientHelloSnapshot,
+	request RetryRequest,
+) ClientHelloSnapshot {
+	t.Helper()
+	var freshShare *extension13.KeyShareEntry
+	if request.HasSelectedGroup {
+		freshShare = &extension13.KeyShareEntry{Group: request.SelectedGroup, KeyExchange: []byte{0x11, 0x22}}
+	}
+	clientHello, err := BuildClientHelloRetry(initial, request, freshShare)
+	require.NoError(t, err)
+	_, snapshot, err := FinalizeClientHello(clientHello, nil)
+	require.NoError(t, err)
+
+	return snapshot
+}
+
+func mutateSnapshotForRetryTest(
+	t *testing.T,
+	snapshot ClientHelloSnapshot,
+	mutate func(*handshake.MessageClientHello),
+) ClientHelloSnapshot {
+	t.Helper()
+	clientHello, err := ClientHelloFromSnapshot(snapshot)
+	require.NoError(t, err)
+	mutate(clientHello)
+
+	return snapshotClientHelloForRetryTest(t, clientHello)
+}
+
+func replaceRetryExtension(
+	clientHello *handshake.MessageClientHello, typ extension.Type, replacement extension.Value,
+) {
+	for i, value := range clientHello.Extensions {
+		if value.ExtensionType() == typ {
+			clientHello.Extensions[i] = replacement
+		}
+	}
+}
+
+func TestValidateHelloRetryRequest13(t *testing.T) {
+	initial := snapshotClientHelloForRetryTest(t, retryClientHelloForTest(false))
+	selected := elliptic.X25519
+
+	for name, test := range map[string]struct {
+		hrr       *handshake.MessageServerHello
+		wantError bool
+	}{
+		"selected group and cookie": {hrr: helloRetryRequest13ForTest(0x1301, &selected, []byte("cookie"))},
+		"cookie only":               {hrr: helloRetryRequest13ForTest(0x1301, nil, []byte("cookie"))},
+		"selected group only":       {hrr: helloRetryRequest13ForTest(0x1301, &selected, nil)},
+		"unoffered cipher suite":    {hrr: helloRetryRequest13ForTest(0x1303, nil, []byte("cookie")), wantError: true},
+		"unsupported selected group": {
+			hrr: helloRetryRequest13ForTest(0x1301, ptrRetryGroup(elliptic.P384), nil), wantError: true,
+		},
+		"group already shared": {
+			hrr: helloRetryRequest13ForTest(0x1301, ptrRetryGroup(elliptic.P256), nil), wantError: true,
+		},
+		"no effect": {hrr: helloRetryRequest13ForTest(0x1301, nil, nil), wantError: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			request, err := ValidateHelloRetryRequest(initial, test.hrr)
+			if !test.wantError {
+				require.NoError(t, err)
+				assert.True(t, request.valid)
+
+				return
+			}
+			require.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
+			requireAlert(t, err, alert.IllegalParameter)
+			assert.False(t, request.valid)
+		})
+	}
+}
+
+func ptrRetryGroup(group elliptic.Curve) *elliptic.Curve { return &group }
+
+func TestValidateClientHelloRetryMatrix(t *testing.T) { //nolint:maintidx
+	initial := snapshotClientHelloForRetryTest(t, retryClientHelloForTest(true))
+	selected := elliptic.X25519
+	request, err := ValidateHelloRetryRequest(
+		initial, helloRetryRequest13ForTest(0x1301, &selected, []byte("cookie")),
+	)
+	require.NoError(t, err)
+	validRetry := finalizedRetryForTest(t, initial, request)
+
+	tests := map[string]struct {
+		mutate func(*handshake.MessageClientHello)
+		valid  bool
+	}{
+		"authorized changes": {valid: true},
+		"padding change": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.Extensions = slices.Insert(ch.Extensions, 2, extension.Value(extension.Raw{
+				Type: extension.TypePadding, Data: []byte{0x00, 0x00},
+			}))
+		}, valid: true},
+		"version": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.Version = protocol.Version1_0
+		}},
+		"random": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.Random.RandomBytes[0] ^= 0xff
+		}},
+		"session ID": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.SessionID = []byte{0xff}
+		}},
+		"cipher suites": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.CipherSuiteIDs = slices.Clone(ch.CipherSuiteIDs[:1])
+		}},
+		"compression methods": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.CompressionMethods = ch.CompressionMethods[:1]
+		}},
+		"unknown payload": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, unknownExtensionType,
+				extension.Raw{Type: unknownExtensionType, Data: []byte{0xff}})
+		}},
+		"unknown order": {mutate: func(ch *handshake.MessageClientHello) {
+			first, second := -1, -1
+			for i, value := range ch.Extensions {
+				if value.ExtensionType() == unknownExtensionType {
+					first = i
+				} else if value.ExtensionType() == secondUnknownExtensionType {
+					second = i
+				}
+			}
+			ch.Extensions[first], ch.Extensions[second] = ch.Extensions[second], ch.Extensions[first]
+		}},
+		"supported groups": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeSupportedGroups,
+				&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}})
+		}},
+		"missing cookie": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.Extensions = slices.DeleteFunc(ch.Extensions, func(value extension.Value) bool {
+				return value.ExtensionType() == extension.TypeCookie
+			})
+		}},
+		"wrong cookie": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeCookie, &extension13.Cookie{Cookie: []byte("wrong")})
+		}},
+		"wrong share": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeKeyShare, &extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{{Group: elliptic.P256, KeyExchange: []byte{0x01}}},
+			})
+		}},
+		"multiple shares": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeKeyShare, &extension13.ClientKeyShare{
+				Shares: []extension13.KeyShareEntry{
+					{Group: elliptic.X25519, KeyExchange: []byte{0x01}},
+					{Group: elliptic.P256, KeyExchange: []byte{0x02}},
+				},
+			})
+		}},
+		"early data retained": {mutate: func(ch *handshake.MessageClientHello) {
+			ch.Extensions = slices.Insert(
+				ch.Extensions, len(ch.Extensions)-1, extension.Value(&extension13.EarlyData{}),
+			)
+		}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			retry := validRetry
+			if test.mutate != nil {
+				retry = mutateSnapshotForRetryTest(t, retry, test.mutate)
+			}
+			err := ValidateClientHelloRetry(initial, retry, request)
+			if test.valid {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+			requireAlert(t, err, alert.IllegalParameter)
+		})
+	}
+}
+
+func TestValidateClientHelloRetryCookieOnlyKeepsKeyShare(t *testing.T) {
+	initial := snapshotClientHelloForRetryTest(t, retryClientHelloForTest(false))
+	request, err := ValidateHelloRetryRequest(
+		initial, helloRetryRequest13ForTest(0x1301, nil, []byte("cookie")),
+	)
+	require.NoError(t, err)
+	retry := finalizedRetryForTest(t, initial, request)
+	require.NoError(t, ValidateClientHelloRetry(initial, retry, request))
+
+	retry = mutateSnapshotForRetryTest(t, retry, func(ch *handshake.MessageClientHello) {
+		replaceRetryExtension(ch, extension.TypeKeyShare, &extension13.ClientKeyShare{
+			Shares: []extension13.KeyShareEntry{{Group: elliptic.P256, KeyExchange: []byte{0xff}}},
+		})
+	})
+	require.ErrorIs(t, ValidateClientHelloRetry(initial, retry, request), dtlserrors.ErrInvalidClientHello)
+}
+
+func TestValidateHelloVerifyRequestResponse(t *testing.T) {
+	initialHello := retryClientHelloForTest(false)
+	initialHello.Extensions = append(initialHello.Extensions,
+		&extension.ConnectionID{CID: []byte{0x01}},
+		&extension.SRTPOffer{ProtectionProfiles: []extension.SRTPProtectionProfile{extension.SRTP_AEAD_AES_128_GCM}},
+	)
+	initial := snapshotClientHelloForRetryTest(t, initialHello)
+	retryHello, err := ClientHelloFromSnapshot(initial)
+	require.NoError(t, err)
+	retryHello.Cookie = []byte("cookie")
+	retryHello.Extensions[2] = extension.Raw{Type: unknownExtensionType, Data: []byte{0xff}}
+	retry := snapshotClientHelloForRetryTest(t, retryHello)
+
+	tests := map[string]struct {
+		mutate    func(*handshake.MessageClientHello)
+		wantError bool
+	}{
+		"DTLS 1.2 extension changes allowed": {},
+		"version": {
+			mutate: func(ch *handshake.MessageClientHello) { ch.Version = protocol.Version1_0 }, wantError: true,
+		},
+		"random": {
+			mutate: func(ch *handshake.MessageClientHello) { ch.Random.RandomBytes[0] ^= 0xff }, wantError: true,
+		},
+		"session ID": {
+			mutate: func(ch *handshake.MessageClientHello) { ch.SessionID = []byte{0xff} }, wantError: true,
+		},
+		"cipher suites": {
+			mutate: func(ch *handshake.MessageClientHello) { ch.CipherSuiteIDs = ch.CipherSuiteIDs[:1] }, wantError: true,
+		},
+		"compression": {
+			mutate: func(ch *handshake.MessageClientHello) {
+				ch.CompressionMethods = ch.CompressionMethods[:1]
+			},
+			wantError: true,
+		},
+		"cookie": {
+			mutate: func(ch *handshake.MessageClientHello) { ch.Cookie = []byte("wrong") }, wantError: true,
+		},
+		"connection ID": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeConnectionID, &extension.ConnectionID{CID: []byte{0xff}})
+		}, wantError: true},
+		"use_srtp": {mutate: func(ch *handshake.MessageClientHello) {
+			replaceRetryExtension(ch, extension.TypeUseSRTP, &extension.SRTPOffer{
+				ProtectionProfiles: []extension.SRTPProtectionProfile{extension.SRTP_AEAD_AES_256_GCM},
+			})
+		}, wantError: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := retry
+			if test.mutate != nil {
+				candidate = mutateSnapshotForRetryTest(t, retry, test.mutate)
+			}
+			err := ValidateHelloVerifyRequestResponse(initial, candidate, []byte("cookie"))
+			if !test.wantError {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+			requireAlert(t, err, alert.IllegalParameter)
+		})
+	}
+}
+
+func TestValidateServerHelloAfterRetry(t *testing.T) {
+	initial := snapshotClientHelloForRetryTest(t, retryClientHelloForTest(false))
+	selected := elliptic.X25519
+	request, err := ValidateHelloRetryRequest(
+		initial, helloRetryRequest13ForTest(0x1301, &selected, nil),
+	)
+	require.NoError(t, err)
+
+	serverHello := func(cipherSuite uint16, share *extension13.ServerKeyShare) *handshake.MessageServerHello {
+		exts := []extension.Value{&extension13.SelectedVersion{Version: protocol.Version1_3}}
+		if share != nil {
+			exts = append(exts, share)
+		}
+
+		return &handshake.MessageServerHello{CipherSuiteID: &cipherSuite, Extensions: exts}
+	}
+	validShare := &extension13.ServerKeyShare{Share: extension13.KeyShareEntry{
+		Group: elliptic.X25519, KeyExchange: []byte{0x01},
+	}}
+	invalidRequestErr := ValidateServerHelloAfterRetry(RetryRequest{}, serverHello(0x1301, validShare))
+	require.ErrorIs(t, invalidRequestErr, dtlserrors.ErrInvalidServerHello)
+	requireAlert(t, invalidRequestErr, alert.IllegalParameter)
+
+	for name, test := range map[string]struct {
+		serverHello *handshake.MessageServerHello
+		wantError   error
+	}{
+		"valid":                {serverHello: serverHello(0x1301, validShare)},
+		"changed cipher suite": {serverHello: serverHello(0x1302, validShare), wantError: dtlserrors.ErrInvalidServerHello},
+		"missing share":        {serverHello: serverHello(0x1301, nil), wantError: dtlserrors.ErrServerKeyShareMissing},
+		"wrong group": {serverHello: serverHello(0x1301, &extension13.ServerKeyShare{Share: extension13.KeyShareEntry{
+			Group: elliptic.P256, KeyExchange: []byte{0x01},
+		}}), wantError: dtlserrors.ErrServerKeyShareUnknownGroup},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateServerHelloAfterRetry(request, test.serverHello)
+			if test.wantError == nil {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorIs(t, err, dtlserrors.ErrInvalidServerHello)
+			require.ErrorIs(t, err, test.wantError)
+			requireAlert(t, err, alert.IllegalParameter)
+		})
+	}
+}

--- a/pkg/protocol/extension/raw.go
+++ b/pkg/protocol/extension/raw.go
@@ -21,6 +21,7 @@ const (
 	TypeSignatureAlgorithms     Type = 13
 	TypeUseSRTP                 Type = 14
 	TypeALPN                    Type = 16
+	TypePadding                 Type = 21
 	TypeExtendedMasterSecret    Type = 23
 	TypePreSharedKey            Type = 41
 	TypeEarlyData               Type = 42


### PR DESCRIPTION
#### Description
This adds shared validation base for 1.3 ClientHello retry validation and primitives for 1.2 HelloVerifyRequest validation in one place. So we can remove this logic from flights code and make it use snapshots.
part of #1021 related to #825