### PR TITLE
Rename extensionnegotiation to negotiation

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -17,12 +17,12 @@ import (
 	"github.com/pion/dtls/v3/internal/closer"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight12 "github.com/pion/dtls/v3/internal/flight/flight12"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -2436,7 +2436,7 @@ func (c *Conn) pickVersionFromServerResponse() (bool, error) {
 
 func (c *Conn) pickVersionFromServerHello(sh *handshake.MessageServerHello) error {
 	common := dtlsstate.CommonState(c.state)
-	if err := extensionnegotiation.ValidateServerHelloResponse(
+	if err := negotiation.ValidateServerHelloResponse(
 		common.LocalClientHelloSnapshots.Current(),
 		sh,
 	); err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/hash"
@@ -2415,7 +2415,7 @@ func testVersionNegotiationHandshakeConfig13(t *testing.T) *dtlsconfig.Handshake
 
 func TestPickVersionFromServerHelloRejectsUnsolicitedExtension(t *testing.T) {
 	const offeredType extension.Type = 0xfefe
-	_, offer, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+	_, offer, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
 		Version:            protocol.Version1_2,
 		CipherSuiteIDs:     []uint16{0x1301},
 		CompressionMethods: []*protocol.CompressionMethod{{}},
@@ -4962,7 +4962,7 @@ func TestSealRecordContentUsesNegotiatedConnectionID(t *testing.T) {
 		Secret:     secret,
 		Protection: protection,
 	}, nil)
-	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
+	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
 
 	rawRecord, err := conn.sealRecordContent(
 		dtlsflight13.EpochApplication, 0, protocol.ContentTypeApplicationData, []byte("application"),
@@ -4989,7 +4989,7 @@ func TestOpenCiphertextRecordUsesNegotiatedConnectionID(t *testing.T) {
 		Protection: protection,
 	})
 	state.SetRemoteEpoch(dtlsflight13.EpochApplication)
-	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
+	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{ClientCID: []byte("local-cid"), ServerCID: []byte("remote-cid")}) //nolint:lll
 
 	sealed, err := protection.Seal(
 		recordlayer.UnifiedHeader{

--- a/flight_test.go
+++ b/flight_test.go
@@ -21,12 +21,12 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlsfragmentbuffer "github.com/pion/dtls/v3/internal/fragmentbuffer"
 	dtlshandshake "github.com/pion/dtls/v3/internal/handshake"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
@@ -66,7 +66,7 @@ func newTestState13(tb testing.TB, isClient bool) *dtlsstate.State13 {
 	tb.Helper()
 
 	state := dtlsstate.NewState13(isClient)
-	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
 		Extensions: []extension.Value{
 			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
@@ -3297,18 +3297,18 @@ func findConnectionID(exts []extension.Value) (*extension.ConnectionID, bool) {
 	return nil, false
 }
 
-func clientHello13SnapshotHistory(t *testing.T, extensions []extension.Value) (history extensionnegotiation.ClientHelloSnapshots) { //nolint:lll
+func clientHello13SnapshotHistory(t *testing.T, extensions []extension.Value) (history negotiation.ClientHelloSnapshots) { //nolint:lll
 	t.Helper()
-	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
 	require.NoError(t, err)
 	require.NoError(t, history.Record(snapshot))
 
 	return history
 }
 
-func assertSnapshotConnectionID(t *testing.T, snapshot extensionnegotiation.ClientHelloSnapshot, expectedCID []byte, expectedPresent bool) { //nolint:lll
+func assertSnapshotConnectionID(t *testing.T, snapshot negotiation.ClientHelloSnapshot, expectedCID []byte, expectedPresent bool) { //nolint:lll
 	t.Helper()
-	cid, present := extensionnegotiation.ConnectionIDOffer(snapshot)
+	cid, present := negotiation.ConnectionIDOffer(snapshot)
 	assert.Equal(t, expectedPresent, present)
 	assert.True(t, bytes.Equal(expectedCID, cid))
 }

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -9,8 +9,8 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -176,7 +176,7 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
@@ -63,28 +63,28 @@ func flight3Parse(
 
 	serverResponse = serverResponsePull.Messages[handshake.TypeServerHello]
 	serverHelloMsg, hasServerHello := serverResponse.(*handshake.MessageServerHello)
-	var decision *extensionnegotiation.ConnectionID
-	var srtpDecision extensionnegotiation.SRTPDecision
+	var decision *negotiation.ConnectionID
+	var srtpDecision negotiation.SRTPDecision
 	if hasServerHello { //nolint:nestif
 		if !serverHelloMsg.Version.Equal(protocol.Version1_2) {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
 		offer := state.LocalClientHelloSnapshots.Current()
-		if validationErr := extensionnegotiation.ValidateServerHello12Context(serverHelloMsg); validationErr != nil {
+		if validationErr := negotiation.ValidateServerHello12Context(serverHelloMsg); validationErr != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, validationErr
 		}
-		if validationErr := extensionnegotiation.ValidateServerHelloResponse(offer, serverHelloMsg); validationErr != nil {
+		if validationErr := negotiation.ValidateServerHelloResponse(offer, serverHelloMsg); validationErr != nil {
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, validationErr
 		}
-		if srtpDecision, err = extensionnegotiation.ValidateSRTPSelection(
+		if srtpDecision, err = negotiation.ValidateSRTPSelection(
 			offer,
 			serverHelloMsg.Extensions,
 			cfg.LocalSRTPProtectionProfiles,
 		); err != nil {
 			return 0, nil, err
 		}
-		decision = extensionnegotiation.DecideConnectionID(offer, serverHelloMsg.Extensions)
+		decision = negotiation.DecideConnectionID(offer, serverHelloMsg.Extensions)
 		if decision == nil {
 			state.CommitNegotiatedExtensions(nil)
 		}
@@ -372,7 +372,7 @@ func flight3Generate(
 
 	// If the generated first ClientHello offered a connection ID, use the
 	// exact post-hook value as the default in the second ClientHello.
-	cid, cidOffered := extensionnegotiation.ConnectionIDOffer(state.LocalClientHelloSnapshots.Initial())
+	cid, cidOffered := negotiation.ConnectionIDOffer(state.LocalClientHelloSnapshots.Initial())
 	if cfg.ConnectionIDGenerator != nil && cidOffered {
 		extensions = append(extensions, &extension.ConnectionID{CID: cid})
 	}
@@ -387,7 +387,7 @@ func flight3Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -90,7 +90,7 @@ func TestFlight3RejectsUnsolicitedServerHelloExtension(t *testing.T) {
 		CipherSuiteIDs:     []uint16{uint16(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)},
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 	}
-	_, offer, err := extensionnegotiation.FinalizeClientHello(clientHello, nil)
+	_, offer, err := negotiation.FinalizeClientHello(clientHello, nil)
 	require.NoError(t, err)
 	require.NoError(t, state.LocalClientHelloSnapshots.Record(offer))
 
@@ -160,7 +160,7 @@ func TestFlight2RejectsChangedConnectionID(t *testing.T) {
 	_, dtlsAlert, err := parseForTest(t, Flight2, t.Context(), nil, state, cache, &dtlsconfig.HandshakeConfig{})
 	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
 	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
-	cid, present := extensionnegotiation.ConnectionIDOffer(state.RemoteClientHelloSnapshots.Current())
+	cid, present := negotiation.ConnectionIDOffer(state.RemoteClientHelloSnapshots.Current())
 	assert.Equal(t, []byte{1}, cid)
 	assert.True(t, present)
 }
@@ -224,7 +224,7 @@ func TestFlight4bGenerateDoesNotCommitConnectionIDAfterLateResponseError(t *test
 }
 
 func TestFlight5bFinishedUsesCommittedServerConnectionID(t *testing.T) {
-	for name, decision := range map[string]*extensionnegotiation.ConnectionID{
+	for name, decision := range map[string]*negotiation.ConnectionID{
 		"not negotiated":   nil,
 		"bidirectional":    {ClientCID: []byte{0xc1}, ServerCID: []byte{0x51}},
 		"empty server CID": {ClientCID: []byte{0xc1}},
@@ -241,9 +241,9 @@ func TestFlight5bFinishedUsesCommittedServerConnectionID(t *testing.T) {
 	}
 }
 
-func recordCH12(t *testing.T, snapshots *extensionnegotiation.ClientHelloSnapshots, extensions ...extension.Value) {
+func recordCH12(t *testing.T, snapshots *negotiation.ClientHelloSnapshots, extensions ...extension.Value) {
 	t.Helper()
-	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
 	require.NoError(t, err)
 	require.NoError(t, snapshots.Record(snapshot))
 }

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -9,8 +9,8 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -71,7 +71,7 @@ func flight4bGenerate(
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	var pkts []*dtlsflight.Packet
 	offer := state.RemoteClientHelloSnapshots.Current()
-	srtpSelection, err := extensionnegotiation.NegotiateSRTP(
+	srtpSelection, err := negotiation.NegotiateSRTP(
 		offer, cfg.LocalSRTPProtectionProfiles, cfg.LocalSRTPMasterKeyIdentifier,
 	)
 	if err != nil {
@@ -112,7 +112,7 @@ func flight4bGenerate(
 		Extensions:        extensions,
 	}
 
-	serverHelloMessage, err = extensionnegotiation.FinalizeServerHello(serverHelloMessage, cfg.ServerHelloMessageHook, offer) //nolint:lll
+	serverHelloMessage, err = negotiation.FinalizeServerHello(serverHelloMessage, cfg.ServerHelloMessageHook, offer) //nolint:lll
 	if err != nil {
 		return nil, nil, err
 	}
@@ -121,7 +121,7 @@ func flight4bGenerate(
 	); err != nil {
 		return nil, nil, err
 	}
-	decision := extensionnegotiation.DecideConnectionID(offer, serverHelloMessage.Extensions)
+	decision := negotiation.DecideConnectionID(offer, serverHelloMessage.Extensions)
 	serverHello := handshake.Handshake{Message: serverHelloMessage}
 
 	serverHello.Header.MessageSequence = uint16(state.HandshakeSendSequence) //nolint:gosec // G115

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -13,9 +13,9 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/internal/util"
 	"github.com/pion/dtls/v3/pkg/crypto/clientcertificate"
@@ -265,7 +265,7 @@ func flight4Generate(
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
 	offer := state.RemoteClientHelloSnapshots.Current()
 	extensions := []extension.Value{}
-	srtpSelection, err := extensionnegotiation.NegotiateSRTP(
+	srtpSelection, err := negotiation.NegotiateSRTP(
 		offer, cfg.LocalSRTPProtectionProfiles, cfg.LocalSRTPMasterKeyIdentifier,
 	)
 	if err != nil {
@@ -321,7 +321,7 @@ func flight4Generate(
 		Extensions:        extensions,
 	}
 
-	serverHello, err = extensionnegotiation.FinalizeServerHello(serverHello, cfg.ServerHelloMessageHook, offer)
+	serverHello, err = negotiation.FinalizeServerHello(serverHello, cfg.ServerHelloMessageHook, offer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,7 +330,7 @@ func flight4Generate(
 	); err != nil {
 		return nil, nil, err
 	}
-	decision := extensionnegotiation.DecideConnectionID(offer, serverHello.Extensions)
+	decision := negotiation.DecideConnectionID(offer, serverHello.Extensions)
 	content := handshake.Handshake{Message: serverHello}
 
 	pkts = append(pkts, &dtlsflight.Packet{
@@ -493,7 +493,7 @@ func flight4Generate(
 	return pkts, nil, nil
 }
 
-func serverCIDExtension(state *dtlsstate.State12, cfg *dtlsconfig.HandshakeConfig, offer extensionnegotiation.ClientHelloSnapshot) *extension.ConnectionID { //nolint:lll
+func serverCIDExtension(state *dtlsstate.State12, cfg *dtlsconfig.HandshakeConfig, offer negotiation.ClientHelloSnapshot) *extension.ConnectionID { //nolint:lll
 	if cfg.ConnectionIDGenerator == nil || !offer.Offered(extension.TypeConnectionID) {
 		return nil
 	}

--- a/internal/flight/flight12/srtp.go
+++ b/internal/flight/flight12/srtp.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 )
 
 func validateServerSRTP(
-	snapshot extensionnegotiation.ClientHelloSnapshot,
+	snapshot negotiation.ClientHelloSnapshot,
 	responses []extension.Value,
 	localProfiles []extension.SRTPProtectionProfile,
-	want extensionnegotiation.SRTPDecision,
+	want negotiation.SRTPDecision,
 ) error {
-	got, err := extensionnegotiation.ValidateSRTPSelection(snapshot, responses, localProfiles)
+	got, err := negotiation.ValidateSRTPSelection(snapshot, responses, localProfiles)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func validateServerSRTP(
 
 func appendSRTPSelection(
 	extensions []extension.Value,
-	decision extensionnegotiation.SRTPDecision,
+	decision negotiation.SRTPDecision,
 ) []extension.Value {
 	if decision.ProtectionProfile == 0 {
 		return extensions

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -10,8 +10,8 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
@@ -149,7 +149,7 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -226,7 +226,7 @@ func flight1Parse(
 
 		return 0, &alert.Alert{Level: alert.Fatal, Description: description}, err
 	}
-	if err := extensionnegotiation.ValidateServerHelloResponse(
+	if err := negotiation.ValidateServerHelloResponse(
 		state.LocalClientHelloSnapshots.Current(), sh,
 	); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.UnsupportedExtension}, err

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -8,8 +8,8 @@ import (
 	"context"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
@@ -55,7 +55,7 @@ func flight2Parse( //nolint:cyclop
 	if err := snapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
-	if err := extensionnegotiation.ValidateSRTPRetry(snapshots.Initial(), snapshots.Current()); err != nil {
+	if err := negotiation.ValidateSRTPRetry(snapshots.Initial(), snapshots.Current()); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
 

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -12,8 +12,8 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -138,10 +138,10 @@ func processFlight3ServerHello(
 		return failure
 	}
 	offer := flightCtx.state.LocalClientHelloSnapshots.Current()
-	if err := extensionnegotiation.ValidateServerHelloResponse(offer, serverHello); err != nil {
+	if err := negotiation.ValidateServerHelloResponse(offer, serverHello); err != nil {
 		return newFlightParseFailure(alert.UnsupportedExtension, err)
 	}
-	decision := extensionnegotiation.DecideConnectionID(offer, serverHello.Extensions)
+	decision := negotiation.DecideConnectionID(offer, serverHello.Extensions)
 	flightCtx.state.RemoteVersions = versions
 	flightCtx.state.LocalVersion = protocol.Version1_3
 
@@ -258,18 +258,18 @@ func handleFlight3ProtectedHandshake(
 ) *flightParseFailure {
 	flightCtx.state.RemoteCertificateRequest = nil
 	offer := flightCtx.state.LocalClientHelloSnapshots.Current()
-	var srtpDecision extensionnegotiation.SRTPDecision
+	var srtpDecision negotiation.SRTPDecision
 	for _, item := range items {
 		if item.Parsed == nil {
 			continue
 		}
 		switch message := item.Parsed.Message.(type) {
 		case *handshake.MessageEncryptedExtensions:
-			if err := extensionnegotiation.ValidateResponseExtensions(offer, message.Extensions, nil); err != nil {
+			if err := negotiation.ValidateResponseExtensions(offer, message.Extensions, nil); err != nil {
 				return newFlightParseFailure(alert.UnsupportedExtension, err)
 			}
 			var err error
-			srtpDecision, err = extensionnegotiation.ValidateSRTPSelection(
+			srtpDecision, err = negotiation.ValidateSRTPSelection(
 				offer, message.Extensions, flightCtx.cfg.LocalSRTPProtectionProfiles,
 			)
 			if err != nil {
@@ -388,7 +388,7 @@ func flight3Generate(
 		})
 	}
 
-	localCID, localCIDOffered := extensionnegotiation.ConnectionIDOffer(flightCtx.state.LocalClientHelloSnapshots.Current()) //nolint:lll
+	localCID, localCIDOffered := negotiation.ConnectionIDOffer(flightCtx.state.LocalClientHelloSnapshots.Current()) //nolint:lll
 	if flightCtx.cfg.ConnectionIDGenerator != nil && localCIDOffered {
 		extensions = append(extensions, &extension.ConnectionID{CID: bytes.Clone(localCID)})
 	}
@@ -407,11 +407,11 @@ func flight3Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := extensionnegotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook) //nolint:lll
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook) //nolint:lll
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := extensionnegotiation.ValidateSRTPRetry(
+	if err := negotiation.ValidateSRTPRetry(
 		flightCtx.state.LocalClientHelloSnapshots.Initial(), snapshot,
 	); err != nil {
 		return nil, nil, err

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
@@ -237,7 +237,7 @@ func flight4Generate( //nolint:cyclop
 		},
 	})
 	offer := state.RemoteClientHelloSnapshots.Current()
-	srtpDecision, err := extensionnegotiation.NegotiateSRTP(
+	srtpDecision, err := negotiation.NegotiateSRTP(
 		offer, cfg.LocalSRTPProtectionProfiles, cfg.LocalSRTPMasterKeyIdentifier,
 	)
 	if err != nil {
@@ -260,7 +260,7 @@ func flight4Generate( //nolint:cyclop
 	if _, err = serverHelloMessage.Marshal(); err != nil {
 		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, err
 	}
-	decision := extensionnegotiation.DecideConnectionID(offer, serverHelloExtensions)
+	decision := negotiation.DecideConnectionID(offer, serverHelloExtensions)
 
 	serverHello := &dtlsflight.Packet{
 		Record: &recordlayer.RecordLayer{

--- a/internal/flight/flight13/flighthandler_test.go
+++ b/internal/flight/flight13/flighthandler_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
@@ -174,7 +174,7 @@ func TestHandleFlight3ProtectedHandshakeRetainsCertificateRequest(t *testing.T) 
 
 func TestFlight3ParseClearsConnectionIDAfterInvalidEncryptedExtensions(t *testing.T) {
 	state := dtlsstate.NewState13(true)
-	state.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte{1}, ServerCID: []byte{2}})
+	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{ClientCID: []byte{1}, ServerCID: []byte{2}})
 	state.SetRemoteEpoch(EpochHandshake)
 
 	cache := dtlsflight.NewCache()
@@ -270,7 +270,7 @@ func TestFlight4GenerateCertificateAuthenticatedFlight(t *testing.T) {
 
 func TestFlight4GenerateReusesNegotiatedConnectionID(t *testing.T) {
 	flightCtx, _ := flight4TestContext(t)
-	_, offer, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+	_, offer, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
 		Extensions: []extension.Value{
 			&extension.ConnectionID{CID: []byte{0x01}},
 		},
@@ -355,7 +355,7 @@ func flight4TestContext(t *testing.T) (*handshakeContext, tls.Certificate) {
 	keypair, err := elliptic.GenerateKeypair(elliptic.X25519)
 	require.NoError(t, err)
 	signatureSchemes := signaturehash.Algorithms13()
-	_, offer, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+	_, offer, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
 		Extensions: []extension.Value{
 			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(signaturehash.Algorithms13())},
@@ -364,7 +364,7 @@ func flight4TestContext(t *testing.T) (*handshakeContext, tls.Certificate) {
 		},
 	}, nil)
 	require.NoError(t, err)
-	var remoteOffers extensionnegotiation.ClientHelloSnapshots
+	var remoteOffers negotiation.ClientHelloSnapshots
 	require.NoError(t, remoteOffers.Record(offer))
 
 	return &handshakeContext{

--- a/internal/flight/flight13/srtp_test.go
+++ b/internal/flight/flight13/srtp_test.go
@@ -8,8 +8,8 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
@@ -155,7 +155,7 @@ func TestValidateSRTPRetry(t *testing.T) {
 	initial := srtpSnapshot13(t, srtpProfile13, srtpMKI13)
 	for _, test := range []struct {
 		name      string
-		retry     extensionnegotiation.ClientHelloSnapshot
+		retry     negotiation.ClientHelloSnapshot
 		wantError bool
 	}{
 		{name: "identical", retry: srtpSnapshot13(t, srtpProfile13, srtpMKI13)},
@@ -163,7 +163,7 @@ func TestValidateSRTPRetry(t *testing.T) {
 		{name: "removed", retry: srtpSnapshot13(t, 0, ""), wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := extensionnegotiation.ValidateSRTPRetry(initial, test.retry)
+			err := negotiation.ValidateSRTPRetry(initial, test.retry)
 			if test.wantError {
 				require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
 				var dtlsAlert *alert.Alert
@@ -210,7 +210,7 @@ func srtpSnapshot13(
 	t *testing.T,
 	profile extension.SRTPProtectionProfile,
 	mki string,
-) extensionnegotiation.ClientHelloSnapshot {
+) negotiation.ClientHelloSnapshot {
 	t.Helper()
 	extensions := []extension.Value{}
 	if profile != 0 {
@@ -219,7 +219,7 @@ func srtpSnapshot13(
 			MasterKeyIdentifier: []byte(mki),
 		})
 	}
-	_, snapshot, err := extensionnegotiation.FinalizeClientHello(
+	_, snapshot, err := negotiation.FinalizeClientHello(
 		&handshake.MessageClientHello{Extensions: extensions}, nil,
 	)
 	require.NoError(t, err)

--- a/internal/flight/helpers.go
+++ b/internal/flight/helpers.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 )
@@ -26,7 +26,7 @@ func FindMatchingSRTPProfile(a, b []dtlsconfig.SRTPProtectionProfile) (dtlsconfi
 }
 
 // CommitSRTP publishes a validated SRTP decision.
-func CommitSRTP(state *dtlsstate.Common, decision extensionnegotiation.SRTPDecision) {
+func CommitSRTP(state *dtlsstate.Common, decision negotiation.SRTPDecision) {
 	if decision.ProtectionProfile != 0 {
 		state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(decision.PeerMasterKeyIdentifier)
 	}

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
@@ -106,7 +106,7 @@ func (c *flightTestConn) SessionKey() []byte {
 func newTestState13(t *testing.T, isClient bool) *dtlsstate.State13 {
 	t.Helper()
 	state := dtlsstate.NewState13(isClient)
-	_, snapshot, err := extensionnegotiation.FinalizeClientHello(&handshake.MessageClientHello{
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
 		Extensions: []extension.Value{
 			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(signaturehash.Algorithms13())},

--- a/internal/negotiation/negotiation.go
+++ b/internal/negotiation/negotiation.go
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-// Package extensionnegotiation finalizes and retains ClientHello offers.
-package extensionnegotiation
+// Package negotiation finalizes ClientHello offers and validates handshake negotiation against them.
+package negotiation
 
 import (
 	"bytes"

--- a/internal/negotiation/negotiation_test.go
+++ b/internal/negotiation/negotiation_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package extensionnegotiation
+package negotiation
 
 import (
 	"bytes"

--- a/internal/negotiation/retry.go
+++ b/internal/negotiation/retry.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package extensionnegotiation
+package negotiation
 
 import (
 	"bytes"

--- a/internal/negotiation/retry_test.go
+++ b/internal/negotiation/retry_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package extensionnegotiation
+package negotiation
 
 import (
 	"slices"

--- a/internal/negotiation/srtp.go
+++ b/internal/negotiation/srtp.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package extensionnegotiation
+package negotiation
 
 import (
 	"bytes"

--- a/internal/state/common.go
+++ b/internal/state/common.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
@@ -70,8 +70,8 @@ type Common struct {
 
 	// ClientHello snapshots are transient negotiation state.
 	// they aren't serialized with resumable connection state.
-	LocalClientHelloSnapshots  extensionnegotiation.ClientHelloSnapshots
-	RemoteClientHelloSnapshots extensionnegotiation.ClientHelloSnapshots
+	LocalClientHelloSnapshots  negotiation.ClientHelloSnapshots
+	RemoteClientHelloSnapshots negotiation.ClientHelloSnapshots
 }
 
 func (s *Common) RemoteEpoch() uint16 {
@@ -111,11 +111,11 @@ func (s *Common) SetLocalConnectionID(v []byte) {
 }
 
 // RecordLocalClientHello retains an offer and publishes its pending CID.
-func (s *Common) RecordLocalClientHello(snapshot extensionnegotiation.ClientHelloSnapshot) error {
+func (s *Common) RecordLocalClientHello(snapshot negotiation.ClientHelloSnapshot) error {
 	if err := s.LocalClientHelloSnapshots.Record(snapshot); err != nil {
 		return err
 	}
-	if cid, offered := extensionnegotiation.ConnectionIDOffer(snapshot); offered {
+	if cid, offered := negotiation.ConnectionIDOffer(snapshot); offered {
 		s.pendingLocalConnectionID.Store(&cid)
 	} else {
 		s.pendingLocalConnectionID.Store(nil)
@@ -132,7 +132,7 @@ func (s *Common) ResetConnectionIDs() {
 }
 
 // CommitNegotiatedExtensions applies a fully validated extension decision.
-func (s *Common) CommitNegotiatedExtensions(decision *extensionnegotiation.ConnectionID) {
+func (s *Common) CommitNegotiatedExtensions(decision *negotiation.ConnectionID) {
 	if decision == nil {
 		s.ResetConnectionIDs()
 

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -6,7 +6,7 @@ package state
 import (
 	"bytes"
 
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
@@ -138,7 +138,7 @@ func (*State13) ShouldWrapConnectionID() bool {
 func (s *State13) ResetConnectionIDs() { s.CommitNegotiatedExtensions(nil) }
 
 // CommitNegotiatedExtensions applies a fully validated extension decision.
-func (s *State13) CommitNegotiatedExtensions(decision *extensionnegotiation.ConnectionID) {
+func (s *State13) CommitNegotiatedExtensions(decision *negotiation.ConnectionID) {
 	s.Common.CommitNegotiatedExtensions(decision)
 	if decision == nil {
 		s.CID = CIDState{}

--- a/internal/state/state13_test.go
+++ b/internal/state/state13_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/pion/dtls/v3/internal/extensionnegotiation"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/stretchr/testify/assert"
@@ -61,9 +61,9 @@ func TestCommitNegotiatedExtensions(t *testing.T) {
 			if test.isClient {
 				local, remote = remote, local
 			}
-			var decision *extensionnegotiation.ConnectionID
+			var decision *negotiation.ConnectionID
 			if test.negotiated {
-				decision = &extensionnegotiation.ConnectionID{
+				decision = &negotiation.ConnectionID{
 					ClientCID: bytes.Clone(test.client), ServerCID: bytes.Clone(test.server),
 				}
 			}
@@ -71,7 +71,7 @@ func TestCommitNegotiatedExtensions(t *testing.T) {
 			state12.SetLocalConnectionID([]byte{0xff})
 			state12.LocalCIDOffered, state12.RemoteCIDOffered = true, true
 			state12.RemoteConnectionID = []byte{0xff}
-			state13.CommitNegotiatedExtensions(&extensionnegotiation.ConnectionID{ClientCID: []byte{0xff}, ServerCID: []byte{0xff}}) //nolint:lll
+			state13.CommitNegotiatedExtensions(&negotiation.ConnectionID{ClientCID: []byte{0xff}, ServerCID: []byte{0xff}}) //nolint:lll
 
 			state12.CommitNegotiatedExtensions(decision)
 			state13.CommitNegotiatedExtensions(decision)
@@ -104,7 +104,7 @@ func TestCommitNegotiatedExtensions(t *testing.T) {
 
 func TestRecordLocalClientHelloTracksCIDPresence(t *testing.T) {
 	for _, extensions := range [][]extension.Value{nil, {&extension.ConnectionID{}}} {
-		_, snapshot, err := extensionnegotiation.FinalizeClientHello(
+		_, snapshot, err := negotiation.FinalizeClientHello(
 			&handshake.MessageClientHello{Extensions: extensions}, nil,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
#### Description
Renames extensionnegotiation to negotiation, the scope is now a bit bigger than extension-negotiation, also the name extensionnegotiation is bad.