### PR TITLE
Validate ClientHello retries

### DIFF
--- a/flight_test.go
+++ b/flight_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"hash"
+	"slices"
 	"testing"
 	"time"
 
@@ -67,10 +68,11 @@ func newTestState13(tb testing.TB, isClient bool) *dtlsstate.State13 {
 
 	state := dtlsstate.NewState13(isClient)
 	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		CipherSuiteIDs: []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
 		Extensions: []extension.Value{
 			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 			&extension.SignatureAlgorithms{Schemes: []uint16{0x0403}},
-			&extension.SupportedGroups{Groups: []elliptic.Curve{elliptic.X25519}},
+			&extension.SupportedGroups{Groups: slices.Clone(testCurves13)},
 			&extension13.ClientKeyShare{},
 		},
 	}, nil)
@@ -79,6 +81,23 @@ func newTestState13(tb testing.TB, isClient bool) *dtlsstate.State13 {
 	require.NoError(tb, state.RemoteClientHelloSnapshots.Record(snapshot))
 
 	return &state
+}
+
+func omitInitialKeyShares() func(handshake.MessageClientHello) handshake.Message {
+	initial := true
+
+	return func(clientHello handshake.MessageClientHello) handshake.Message {
+		if initial {
+			initial = false
+			for i, value := range clientHello.Extensions {
+				if value.ExtensionType() == extension.TypeKeyShare {
+					clientHello.Extensions[i] = &extension13.ClientKeyShare{}
+				}
+			}
+		}
+
+		return &clientHello
+	}
 }
 
 func flight13ParseForTest(
@@ -163,6 +182,30 @@ func flight13GenerateForTest(
 	require.True(testingT, ok)
 
 	return gen(nil, flightCtx.state, flightCtx.cache, flightCtx.cfg)
+}
+
+func retryRequestForTest(
+	tb testing.TB,
+	state *dtlsstate.State13,
+	cfg *dtlsconfig.HandshakeConfig,
+	initial negotiation.ClientHelloSnapshot,
+	group elliptic.Curve,
+) negotiation.RetryRequest {
+	tb.Helper()
+	id := uint16(cfg.LocalCipherSuites[0].ID())
+	extensions := []extension.Value{&extension13.SelectedVersion{Version: protocol.Version1_3}}
+	if group != 0 {
+		extensions = append(extensions, &extension13.RetryKeyShare{SelectedGroup: group})
+	}
+	if state.Cookie != nil {
+		extensions = append(extensions, &extension13.Cookie{Cookie: state.Cookie})
+	}
+	request, err := negotiation.ValidateHelloRetryRequest(
+		initial, &handshake.MessageServerHello{CipherSuiteID: &id, Extensions: extensions},
+	)
+	require.NoError(tb, err)
+
+	return request
 }
 
 func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Packet) []byte {
@@ -880,6 +923,7 @@ func TestFlight13_1GenerateClientHelloIncludesX25519MLKEM768KeyShare(t *testing.
 func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	selectedGroup := elliptic.P384
+	cfg.ClientHelloMessageHook = omitInitialKeyShares()
 
 	rawServerHello := marshalHelloRetryRequestServerHello(
 		t,
@@ -910,10 +954,7 @@ func TestFlight13_1ParseStoresHelloRetryRequestSelectedGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, dtlsflight13.Flight3, nextFlight)
-	entries := state.RemoteKeyEntries
-	require.Len(t, entries, 1)
-	assert.Equal(t, selectedGroup, entries[0].Group)
-	assert.Empty(t, entries[0].KeyExchange)
+	assert.Equal(t, selectedGroup, state.HelloRetryRequest.SelectedGroup)
 }
 
 func TestFlight13_1ParseRejectsHelloRetryRequestWithoutSupportedVersions(t *testing.T) {
@@ -1023,7 +1064,9 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 	state := newTestState13(t, false)
 	state.Cookie = []byte{0x01, 0x02, 0x03, 0x04}
 	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	require.NoError(t, state.LocalRandom.Populate())
+	state.HelloRetryRequest = retryRequestForTest(
+		t, state, cfg, state.LocalClientHelloSnapshots.Initial(), 0,
+	)
 
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight3, &handshakeTestContext13{
 		state: state,
@@ -1064,7 +1107,7 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 		}
 	}
 	require.NotNil(t, signatureAlgorithms)
-	assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalSignatureSchemes), signatureAlgorithms.Schemes)
+	assert.Equal(t, []uint16{0x0403}, signatureAlgorithms.Schemes)
 
 	var cookieExt *extension13.Cookie
 	for _, ext := range clientHello.Extensions {
@@ -1082,69 +1125,11 @@ func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.
 	cfg := testHandshakeConfig13(t)
 	selectedGroup := elliptic.P384
 
-	originalKeypair, err := elliptic.GenerateKeypair(elliptic.X25519)
-	require.NoError(t, err)
 	state := newTestState13(t, false)
 	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	state.LocalKeyEntries = []extension13.KeyShareEntry{
-		{Group: originalKeypair.Curve, KeyExchange: originalKeypair.PublicKey},
-	}
-	state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: selectedGroup}}
-	state.HasRemoteKeyEntries = true
-	require.NoError(t, state.LocalRandom.Populate())
-
-	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight3, &handshakeTestContext13{
-		state: state,
-		cfg:   cfg,
-	})
-
-	require.NoError(t, err)
-	require.Nil(t, dtlsAlert)
-	require.Len(t, pkts, 1)
-
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
-	require.True(t, ok)
-	raw, err := hand.Marshal()
-	require.NoError(t, err)
-
-	var parsed handshake.Handshake
-	require.NoError(t, parsed.Unmarshal(raw))
-	clientHello, ok := parsed.Message.(*handshake.MessageClientHello)
-	require.True(t, ok)
-
-	var keyShare *extension13.ClientKeyShare
-	for _, ext := range clientHello.Extensions {
-		if ks, ok := ext.(*extension13.ClientKeyShare); ok {
-			keyShare = ks
-
-			break
-		}
-	}
-	require.NotNil(t, keyShare)
-	require.Len(t, keyShare.Shares, 2)
-	assert.Equal(t, selectedGroup, keyShare.Shares[0].Group)
-	assert.NotEmpty(t, keyShare.Shares[0].KeyExchange)
-	assert.Equal(t, elliptic.X25519, keyShare.Shares[1].Group)
-
-	selectedKeypair := state.LocalKeypairs[selectedGroup]
-	require.NotNil(t, selectedKeypair)
-	assert.Equal(t, keyShare.Shares[0].KeyExchange, selectedKeypair.PublicKey)
-}
-
-func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-	selectedGroup := elliptic.X25519
-
-	keypair, err := elliptic.GenerateKeypair(selectedGroup)
-	require.NoError(t, err)
-	state := newTestState13(t, false)
-	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
-	state.LocalKeyEntries = []extension13.KeyShareEntry{
-		{Group: keypair.Curve, KeyExchange: keypair.PublicKey},
-	}
-	state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: selectedGroup}}
-	state.HasRemoteKeyEntries = true
-	require.NoError(t, state.LocalRandom.Populate())
+	state.HelloRetryRequest = retryRequestForTest(
+		t, state, cfg, state.LocalClientHelloSnapshots.Initial(), selectedGroup,
+	)
 
 	pkts, dtlsAlert, err := flight13GenerateForTest(t, dtlsflight13.Flight3, &handshakeTestContext13{
 		state: state,
@@ -1176,6 +1161,11 @@ func TestFlight13_3GenerateDoesNotRegenerateAlreadyAdvertisedGroup(t *testing.T)
 	require.NotNil(t, keyShare)
 	require.Len(t, keyShare.Shares, 1)
 	assert.Equal(t, selectedGroup, keyShare.Shares[0].Group)
+	assert.NotEmpty(t, keyShare.Shares[0].KeyExchange)
+
+	selectedKeypair := state.LocalKeypairs[selectedGroup]
+	require.NotNil(t, selectedKeypair)
+	assert.Equal(t, keyShare.Shares[0].KeyExchange, selectedKeypair.PublicKey)
 }
 
 func TestFlight13_3ParseNegotiatesVersionCipherAndKeyShare(t *testing.T) {
@@ -1553,6 +1543,7 @@ func TestFlight13ClientParseAppendsNoHRRTranscriptOrder(t *testing.T) {
 
 func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
+	cfg.ClientHelloMessageHook = omitInitialKeyShares()
 	state := newTestState13(t, false)
 	transcript := dtlshandshake.NewTranscript()
 
@@ -2601,8 +2592,15 @@ func TestFlight13ServerParseAppendsHRRTranscriptOrder(t *testing.T) {
 	)
 	helloRetryRequestCanonical := canonicalPacketHandshake13(t, helloRetryRequest[0])
 
-	exts := append(requiredClientHello13Extensions(t, cfg), &extension13.Cookie{Cookie: cookie})
-	rawClientHello2 := pushClientHello13WithSequence(t, cache, protocol.Version1_2, 1, exts)
+	retry, err := negotiation.BuildClientHelloRetry(
+		state.RemoteClientHelloSnapshots.Initial(), state.HelloRetryRequest, nil,
+	)
+	require.NoError(t, err)
+	rawClientHello2, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: 1}, Message: retry,
+	}).Marshal()
+	require.NoError(t, err)
+	cache.Push(rawClientHello2, 0, 1, handshake.TypeClientHello, true)
 	clientHello2Canonical, err := canonicalHandshake13(rawClientHello2)
 	require.NoError(t, err)
 
@@ -2625,6 +2623,9 @@ func serverHelloFromFlight13_2(
 
 	if state.CipherSuite == nil {
 		state.CipherSuite = cfg.LocalCipherSuites[0]
+	}
+	if state.SelectedGroup == 0 && state.Cookie == nil {
+		state.Cookie = []byte{0x01}
 	}
 	pkts, dtlsAlert, err := flight13GenerateForTest(
 		t, dtlsflight13.Flight2, flight13_2Context(state, dtlsflight.NewCache(), cfg),
@@ -2701,6 +2702,7 @@ func TestFlight13_2Generate(t *testing.T) {
 		state := newTestState13(t, false)
 		state.CipherSuite = cfg.LocalCipherSuites[0]
 		state.HandshakeSendSequence = 7
+		state.Cookie = []byte{0x01}
 
 		_, dtlsAlert, err := flight13GenerateForTest(
 			t, dtlsflight13.Flight2, flight13_2Context(state, dtlsflight.NewCache(), cfg),
@@ -2756,19 +2758,17 @@ func TestFlight13_2Generate(t *testing.T) {
 		assert.Equal(t, *serverHello.CipherSuiteID, *parsedServerHello.CipherSuiteID)
 	})
 
-	t.Run("OmitsKeyShareAndCookieByDefault", func(t *testing.T) {
+	t.Run("RejectsHelloRetryRequestWithNoEffect", func(t *testing.T) {
 		state := newTestState13(t, false)
 		cfg := testHandshakeConfig13(t)
+		state.CipherSuite = cfg.LocalCipherSuites[0]
 
-		serverHello := serverHelloFromFlight13_2(t, state, cfg)
-
-		_, hasKeyShare := findRetryKeyShare(serverHello.Extensions)
-		assert.False(t, hasKeyShare, "KeyShare must be omitted when no remote key entries were offered")
-
-		_, hasCookie := findCookie(serverHello.Extensions)
-		assert.False(t, hasCookie, "Cookie must be omitted when no cookie is set")
-
-		require.Len(t, serverHello.Extensions, 1)
+		packets, dtlsAlert, err := flight13GenerateForTest(
+			t, dtlsflight13.Flight2, flight13_2Context(state, dtlsflight.NewCache(), cfg),
+		)
+		require.ErrorIs(t, err, dtlserrors.ErrInvalidHelloRetryRequest)
+		require.Nil(t, dtlsAlert)
+		require.Nil(t, packets)
 	})
 
 	t.Run("IncludesKeyShareWhenRemoteKeyEntriesPresent", func(t *testing.T) {
@@ -2791,6 +2791,7 @@ func TestFlight13_2Generate(t *testing.T) {
 			KeyExchange: []byte{0x01},
 		}}
 		state.HasRemoteKeyEntries = true
+		state.Cookie = []byte{0x01}
 		cfg := testHandshakeConfig13(t)
 
 		serverHello := serverHelloFromFlight13_2(t, state, cfg)
@@ -3065,7 +3066,7 @@ func pushClientHello13WithSequence(
 		Message: &handshake.MessageClientHello{
 			Version:            version,
 			Random:             handshake.Random{},
-			CipherSuiteIDs:     []uint16{},
+			CipherSuiteIDs:     []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
 			CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 			Extensions:         exts,
 		},
@@ -3082,11 +3083,54 @@ func pushClientHello13WithSequence(
 func flight13_2Context(
 	state *dtlsstate.State13, cache *dtlsflight.Cache, cfg *dtlsconfig.HandshakeConfig,
 ) *handshakeTestContext13 {
+	seedFlight13RetryRequest(state, cache, cfg)
+
 	return &handshakeTestContext13{
 		state:      state,
 		cache:      cache,
 		cfg:        cfg,
 		transcript: dtlshandshake.NewTranscript(),
+	}
+}
+
+func seedFlight13RetryRequest(
+	state *dtlsstate.State13,
+	cache *dtlsflight.Cache,
+	cfg *dtlsconfig.HandshakeConfig,
+) {
+	if request := state.HelloRetryRequest; request.HasCookie || request.HasSelectedGroup {
+		return
+	}
+	pull := cache.FullPullMapItems(state.HandshakeRecvSequence, state.CipherSuite,
+		dtlsflight.HandshakeCachePullRule{
+			Typ: handshake.TypeClientHello, Epoch: cfg.InitialEpoch, IsClient: true,
+		})
+	retry, ok := pull.Messages[handshake.TypeClientHello].(*handshake.MessageClientHello)
+	if pull.Err != nil || !pull.Ready || !ok {
+		return
+	}
+	clientHello := *retry
+	clientHello.Extensions = slices.DeleteFunc(slices.Clone(retry.Extensions), func(value extension.Value) bool {
+		return value.ExtensionType() == extension.TypeCookie
+	})
+	_, initial, err := negotiation.FinalizeClientHello(&clientHello, nil)
+	if err != nil {
+		return
+	}
+	state.RemoteClientHelloSnapshots.Reset()
+	if recordErr := state.RemoteClientHelloSnapshots.Record(initial); recordErr != nil {
+		return
+	}
+	id := uint16(cfg.LocalCipherSuites[0].ID())
+	request, err := negotiation.ValidateHelloRetryRequest(initial, &handshake.MessageServerHello{
+		CipherSuiteID: &id,
+		Extensions: []extension.Value{
+			&extension13.SelectedVersion{Version: protocol.Version1_3},
+			&extension13.Cookie{Cookie: state.Cookie},
+		},
+	})
+	if err == nil {
+		state.HelloRetryRequest = request
 	}
 }
 
@@ -3202,7 +3246,7 @@ func TestFlight13_2Parse(t *testing.T) {
 		assert.Equal(t, 0, state.HandshakeRecvSequence)
 	})
 
-	t.Run("KeepsWaitingWhenCookieNotYetEchoed", func(t *testing.T) {
+	t.Run("RejectsMissingCookie", func(t *testing.T) {
 		state := newTestState13(t, false)
 		state.Cookie = cookie
 		state.ServerName = "original.example"
@@ -3215,8 +3259,8 @@ func TestFlight13_2Parse(t *testing.T) {
 		next, dtlsAlert, err := flight13ParseForTest(
 			t, dtlsflight13.Flight2, context.Background(), flight13_2Context(state, cache, cfg),
 		)
-		require.NoError(t, err)
-		require.Nil(t, dtlsAlert)
+		require.ErrorIs(t, err, dtlserrors.ErrCookieMismatch)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
 		assert.Equal(t, dtlsflight13.Flight(0), next)
 		assert.Equal(t, 0, state.HandshakeRecvSequence)
 		assert.Equal(t, "original.example", state.ServerName)
@@ -3241,7 +3285,7 @@ func TestFlight13_2Parse(t *testing.T) {
 		require.ErrorIs(t, err, dtlserrors.ErrCookieMismatch)
 		assert.Equal(t, dtlsflight13.Flight(0), next)
 		require.NotNil(t, dtlsAlert)
-		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlsAlert)
+		assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, dtlsAlert)
 		assert.Equal(t, 0, state.HandshakeRecvSequence)
 		assert.Equal(t, "original.example", state.ServerName)
 		assert.Empty(t, state.RemoteSignatureSchemes)
@@ -3299,7 +3343,10 @@ func findConnectionID(exts []extension.Value) (*extension.ConnectionID, bool) {
 
 func clientHello13SnapshotHistory(t *testing.T, extensions []extension.Value) (history negotiation.ClientHelloSnapshots) { //nolint:lll
 	t.Helper()
-	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{ //nolint:lll
+		Version: protocol.Version1_2, CipherSuiteIDs: []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
+		CompressionMethods: dtlsflight.DefaultCompressionMethods(), Extensions: extensions,
+	}, nil)
 	require.NoError(t, err)
 	require.NoError(t, history.Record(snapshot))
 
@@ -3501,6 +3548,7 @@ func TestFlight13_3GenerateConnectionIDOffer(t *testing.T) { //nolint:cyclop // 
 			require.Len(t, firstFlight, 1)
 			initialSnapshot := state.LocalClientHelloSnapshots.Current()
 			state.RemoteVersions, state.Cookie = []protocol.Version{protocol.Version1_3}, []byte{0xaa}
+			state.HelloRetryRequest = retryRequestForTest(t, state, cfg, initialSnapshot, 0)
 
 			secondFlight, dtlsAlert, err := flight13GenerateForTest(
 				t, dtlsflight13.Flight3, &handshakeTestContext13{state: state, cfg: cfg},
@@ -3558,8 +3606,15 @@ func TestFlight13_2ParseConnectionIDOffer(t *testing.T) {
 				initialExtensions = append(initialExtensions, &extension.ConnectionID{CID: test.firstCID})
 			}
 			state.RemoteClientHelloSnapshots = clientHello13SnapshotHistory(t, initialExtensions)
+			state.HelloRetryRequest = retryRequestForTest(
+				t, state, cfg, state.RemoteClientHelloSnapshots.Initial(), 0,
+			)
 			cache := dtlsflight.NewCache()
-			exts := requiredClientHello13Extensions(t, cfg)
+			initial, err := negotiation.ClientHelloFromSnapshot(state.RemoteClientHelloSnapshots.Initial())
+			require.NoError(t, err)
+			exts := slices.DeleteFunc(slices.Clone(initial.Extensions), func(value extension.Value) bool {
+				return value.ExtensionType() == extension.TypeConnectionID
+			})
 			for _, cid := range test.secondCIDs {
 				exts = append(exts, &extension.ConnectionID{CID: cid})
 			}

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -56,6 +56,7 @@ func flight1Parse(
 				dtlserrors.ErrUnsupportedProtocolVersion
 		}
 		state.Cookie = bytes.Clone(h.Cookie)
+		state.HasHelloVerifyRequest = true
 		state.HandshakeRecvSequence = pull.NextSequence
 
 		return Flight3, nil, nil
@@ -84,6 +85,7 @@ func flight1Generate(
 	}
 	state.NamedCurve = ellipticCurves[0]
 	state.Cookie = nil
+	state.HasHelloVerifyRequest = false
 
 	if err := state.LocalRandom.Populate(); err != nil {
 		return nil, nil, err

--- a/internal/flight/flight12/flight2handler.go
+++ b/internal/flight/flight12/flight2handler.go
@@ -4,12 +4,12 @@
 package flight12
 
 import (
-	"bytes"
 	"context"
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
@@ -48,16 +48,16 @@ func flight2Parse(
 			dtlserrors.ErrUnsupportedProtocolVersion
 	}
 
-	if len(clientHello.Cookie) == 0 {
-		return 0, nil, nil
-	}
-	if !bytes.Equal(state.Cookie, clientHello.Cookie) {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlserrors.ErrCookieMismatch
-	}
-
-	if err := state.RemoteClientHelloSnapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
+	snapshots := state.RemoteClientHelloSnapshots
+	if err := snapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
+	if err := negotiation.ValidateHelloVerifyRequestResponse(
+		snapshots.Initial(), snapshots.Current(), state.Cookie,
+	); err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
+	}
+	state.RemoteClientHelloSnapshots = snapshots
 
 	return Flight4, nil, nil
 }

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -56,6 +56,7 @@ func flight3Parse(
 			return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion}, dtlserrors.ErrUnsupportedProtocolVersion //nolint:lll
 		}
 		state.Cookie = bytes.Clone(h.Cookie)
+		state.HasHelloVerifyRequest = true
 		state.HandshakeRecvSequence = serverResponsePull.NextSequence
 
 		return Flight3, nil, nil
@@ -386,10 +387,27 @@ func flight3Generate(
 		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 		Extensions:         extensions,
 	}
+	if state.HasHelloVerifyRequest {
+		retry, err := negotiation.ClientHelloFromSnapshot(
+			state.LocalClientHelloSnapshots.Initial(),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		retry.Cookie = state.Cookie
+		clientHello = retry
+	}
 
 	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
 	if err != nil {
 		return nil, nil, err
+	}
+	if state.HasHelloVerifyRequest {
+		if err := negotiation.ValidateHelloVerifyRequestResponse(
+			state.LocalClientHelloSnapshots.Initial(), snapshot, state.Cookie,
+		); err != nil {
+			return nil, nil, err
+		}
 	}
 	if err := state.RecordLocalClientHello(snapshot); err != nil {
 		return nil, nil, err

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -83,6 +83,28 @@ func TestFlight3GenerateRestoresCurveExtensionsAfterVersionDowngrade(t *testing.
 	})
 }
 
+func TestFlight3GenerateValidatesRetryWithEmptyCookie(t *testing.T) {
+	state := newTestState12()
+	suite := ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
+	cfg := &dtlsconfig.HandshakeConfig{
+		LocalCipherSuites: []dtlsconfig.CipherSuite{suite},
+		EllipticCurves:    []elliptic.Curve{elliptic.X25519},
+	}
+	_, _, err := generateForTest(t, Flight1, nil, state, nil, cfg)
+	require.NoError(t, err)
+	state.HasHelloVerifyRequest = true
+
+	cfg.ClientHelloMessageHook = func(clientHello handshake.MessageClientHello) handshake.Message {
+		clientHello.Random.RandomBytes[0] ^= 0xff
+
+		return &clientHello
+	}
+	packets, dtlsAlert, err := generateForTest(t, Flight3, nil, state, nil, cfg)
+	require.ErrorIs(t, err, dtlserrors.ErrInvalidClientHello)
+	require.Nil(t, dtlsAlert)
+	require.Nil(t, packets)
+}
+
 func TestFlight3RejectsUnsolicitedServerHelloExtension(t *testing.T) {
 	state := newTestState12()
 	clientHello := &handshake.MessageClientHello{
@@ -165,6 +187,39 @@ func TestFlight2RejectsChangedConnectionID(t *testing.T) {
 	assert.True(t, present)
 }
 
+func TestFlight2CommitsValidatedClientHello2AsCurrentOffer(t *testing.T) {
+	state := newTestState12()
+	state.Cookie, state.HandshakeRecvSequence = []byte{0xc0}, 1
+	recordCH12(t, &state.RemoteClientHelloSnapshots,
+		extension.Raw{Type: 0xfefe, Data: []byte{0x01}},
+	)
+	retry := &handshake.MessageClientHello{
+		Version:            protocol.Version1_2,
+		Cookie:             state.Cookie,
+		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+		Extensions: []extension.Value{
+			extension.Raw{Type: 0xfefe, Data: []byte{0x02}},
+		},
+	}
+	rawRetry, err := (&handshake.Handshake{
+		Header: handshake.Header{MessageSequence: 1}, Message: retry,
+	}).Marshal()
+	require.NoError(t, err)
+	cache := dtlsflight.NewCache()
+	cache.Push(rawRetry, 0, 1, handshake.TypeClientHello, true)
+
+	next, dtlsAlert, err := parseForTest(
+		t, Flight2, t.Context(), nil, state, cache,
+		&dtlsconfig.HandshakeConfig{EllipticCurves: []elliptic.Curve{elliptic.X25519}},
+	)
+	require.NoError(t, err)
+	require.Nil(t, dtlsAlert)
+	assert.Equal(t, Flight4, next)
+	current, present := state.RemoteClientHelloSnapshots.Current().Extension(0xfefe)
+	require.True(t, present)
+	assert.Equal(t, []byte{0x02}, current.Data)
+}
+
 func TestFlight4bGenerateCommitsConnectionIDOnce(t *testing.T) {
 	for name, test := range map[string]struct {
 		clientCID, serverCID []byte
@@ -243,7 +298,9 @@ func TestFlight5bFinishedUsesCommittedServerConnectionID(t *testing.T) {
 
 func recordCH12(t *testing.T, snapshots *negotiation.ClientHelloSnapshots, extensions ...extension.Value) {
 	t.Helper()
-	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{Extensions: extensions}, nil) //nolint:lll
+	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		Version: protocol.Version1_2, CompressionMethods: dtlsflight.DefaultCompressionMethods(), Extensions: extensions,
+	}, nil)
 	require.NoError(t, err)
 	require.NoError(t, snapshots.Record(snapshot))
 }

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -12,6 +12,7 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	"github.com/pion/dtls/v3/internal/negotiation"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
@@ -46,6 +47,7 @@ func flight0Parse(
 	// https://datatracker.ietf.org/doc/html/rfc9146#name-the-connection_id-extension
 	state.ResetConnectionIDs()
 	state.RemoteClientHelloSnapshots.Reset()
+	state.HelloRetryRequest = negotiation.RetryRequest{}
 
 	state.HandshakeRecvSequence = pull.NextSequence
 

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -43,6 +43,7 @@ func flight1Generate(
 	}
 	state.SelectedGroup = cfg.EllipticCurves[0]
 	state.Cookie = nil
+	state.HelloRetryRequest = negotiation.RetryRequest{}
 
 	if err := state.LocalRandom.Populate(); err != nil {
 		return nil, nil, err
@@ -235,27 +236,15 @@ func flight1Parse(
 	if err != nil {
 		return 0, dtlsAlert, err
 	}
-	state.CipherSuite = selectedCipherSuite
-
-	// nolint:godox
-	// TODO: negotiate minimial set of extensions necessary for the client
-	// to generate a correct CH pair. As with the ServerHello, a
-	// HelloRetryRequest MUST NOT contain any extensions that were not first
-	// offered by the client in its ClientHello, with the exception of
-	// optionally the "cookie" extension
-	for _, val := range sh.Extensions {
-		switch ext := val.(type) {
-		case *extension13.SelectedVersion:
-			// nolint:godox
-			// TODO: negotiate version
-			state.RemoteVersions = []protocol.Version{ext.Version}
-		case *extension13.Cookie:
-			state.Cookie = bytes.Clone(ext.Cookie)
-		case *extension13.RetryKeyShare:
-			state.RemoteKeyEntries = []extension13.KeyShareEntry{{Group: ext.SelectedGroup}}
-			state.HasRemoteKeyEntries = true
-		}
+	retryRequest, err := negotiation.ValidateHelloRetryRequest(
+		state.LocalClientHelloSnapshots.Initial(), sh,
+	)
+	if err != nil {
+		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
+	state.CipherSuite = selectedCipherSuite
+	state.HelloRetryRequest = retryRequest
+	state.RemoteVersions = []protocol.Version{protocol.Version1_3}
 
 	if flightCtx.inboundHandshakeHandler != nil {
 		if err := flightCtx.inboundHandshakeHandler(state.CipherSuite, pull.Items); err != nil {

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -4,7 +4,6 @@
 package flight13
 
 import (
-	"bytes"
 	"context"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -43,19 +42,13 @@ func flight2Parse( //nolint:cyclop
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.ProtocolVersion},
 			dtlserrors.ErrUnsupportedProtocolVersion
 	}
-	cookie := clientHelloCookie(clientHello.Extensions)
-
-	if len(cookie) == 0 {
-		return 0, nil, nil
-	}
-	if !bytes.Equal(flightCtx.state.Cookie, cookie) {
-		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.AccessDenied}, dtlserrors.ErrCookieMismatch
-	}
 	snapshots := flightCtx.state.RemoteClientHelloSnapshots
 	if err := snapshots.RecordWire(pull.Items[0].Raw.Data); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
-	if err := negotiation.ValidateSRTPRetry(snapshots.Initial(), snapshots.Current()); err != nil {
+	if err := negotiation.ValidateClientHelloRetry(
+		snapshots.Initial(), snapshots.Current(), flightCtx.state.HelloRetryRequest,
+	); err != nil {
 		return 0, &alert.Alert{Level: alert.Fatal, Description: alert.IllegalParameter}, err
 	}
 
@@ -111,6 +104,20 @@ func flight2Generate(
 			Cookie: flightCtx.state.Cookie,
 		})
 	}
+	serverHello := &handshake.MessageServerHello{
+		Version:           protocol.Version1_2,
+		Random:            random,
+		CipherSuiteID:     &cipherSuiteID,
+		CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+		Extensions:        exts,
+	}
+	request, err := negotiation.ValidateHelloRetryRequest(
+		flightCtx.state.RemoteClientHelloSnapshots.Initial(), serverHello,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	flightCtx.state.HelloRetryRequest = request
 
 	return []*dtlsflight.Packet{
 		{
@@ -119,13 +126,7 @@ func flight2Generate(
 					Version: protocol.Version1_2,
 				},
 				Content: &handshake.Handshake{
-					Message: &handshake.MessageServerHello{
-						Version:           protocol.Version1_2,
-						Random:            random,
-						CipherSuiteID:     &cipherSuiteID,
-						CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-						Extensions:        exts,
-					},
+					Message: serverHello,
 				},
 			},
 		},

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -4,13 +4,10 @@
 package flight13
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"maps"
 	"slices"
 
-	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/internal/negotiation"
@@ -18,8 +15,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/prf"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
-	"github.com/pion/dtls/v3/pkg/protocol/extension"
-	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
@@ -140,6 +135,11 @@ func processFlight3ServerHello(
 	offer := flightCtx.state.LocalClientHelloSnapshots.Current()
 	if err := negotiation.ValidateServerHelloResponse(offer, serverHello); err != nil {
 		return newFlightParseFailure(alert.UnsupportedExtension, err)
+	}
+	if request := flightCtx.state.HelloRetryRequest; request.HasCookie || request.HasSelectedGroup {
+		if err := negotiation.ValidateServerHelloAfterRetry(request, serverHello); err != nil {
+			return newFlightParseFailure(alert.IllegalParameter, err)
+		}
 	}
 	decision := negotiation.DecideConnectionID(offer, serverHello.Extensions)
 	flightCtx.state.RemoteVersions = versions
@@ -295,124 +295,39 @@ func handleFlight3ProtectedHandshake(
 	return nil
 }
 
-//nolint:cyclop,gocognit,nestif
 func flight3Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
 ) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	if len(flightCtx.cfg.LocalSignatureSchemes) == 0 {
-		return nil, nil, dtlserrors.ErrNoAvailableSignatureSchemes
-	}
-
-	extensions := []extension.Value{
-		&extension.SignatureAlgorithms{
-			Schemes: dtlsflight.SignatureSchemeIDs(flightCtx.cfg.LocalSignatureSchemes),
-		},
-	}
-
-	if flightCtx.cfg.ExtendedMasterSecret == dtlsconfig.RequestExtendedMasterSecret ||
-		flightCtx.cfg.ExtendedMasterSecret == dtlsconfig.RequireExtendedMasterSecret {
-		extensions = append(extensions, &extension12.ExtendedMasterSecret{})
-	}
-
-	extensions = append(extensions, &extension12.RenegotiationInfo{
-		RenegotiatedConnection: 0,
-	})
-
-	if flightCtx.state.SelectedGroup != 0 {
-		extensions = append(extensions, &extension12.SupportedPointFormats{
-			PointFormats: []elliptic.CurvePointFormat{elliptic.CurvePointFormatUncompressed},
-		})
-	}
-
-	if len(flightCtx.cfg.SupportedProtocols) > 0 {
-		extensions = append(extensions, &extension.ALPNOffer{Protocols: flightCtx.cfg.SupportedProtocols})
-	}
-
-	var localGroups []elliptic.Curve
-	var newEntries []extension13.KeyShareEntry
-	newKeypairs := map[elliptic.Curve]*elliptic.Keypair{}
-	if flightCtx.state.HasRemoteKeyEntries {
-		for _, entry := range flightCtx.state.LocalKeyEntries {
-			localGroups = append(localGroups, entry.Group)
-		}
-
-		for _, entry := range flightCtx.state.RemoteKeyEntries {
-			if !slices.Contains(localGroups, entry.Group) && slices.Contains(flightCtx.cfg.EllipticCurves, entry.Group) {
-				keypair, err := elliptic.GenerateKeypair(entry.Group)
-				if err != nil {
-					return nil, nil, err
-				}
-				newEntries = append(newEntries, extension13.KeyShareEntry{
-					Group: keypair.Curve, KeyExchange: keypair.PublicKey,
-				})
-				newKeypairs[keypair.Curve] = keypair
-			}
-		}
-	}
-	if len(newEntries) > 0 {
-		flightCtx.state.LocalKeyEntries = append(newEntries, flightCtx.state.LocalKeyEntries...)
-		if flightCtx.state.LocalKeypairs == nil {
-			flightCtx.state.LocalKeypairs = make(map[elliptic.Curve]*elliptic.Keypair, len(newKeypairs))
-		}
-		maps.Copy(flightCtx.state.LocalKeypairs, newKeypairs)
-	}
-	extensions = append(extensions, &extension.SupportedGroups{
-		Groups: supportedGroupsForKeyShares(flightCtx.state.LocalKeyEntries, flightCtx.cfg.EllipticCurves),
-	})
-	extensions = append(extensions, &extension13.ClientKeyShare{
-		Shares: flightCtx.state.LocalKeyEntries,
-	})
-
 	if !slices.Contains(flightCtx.state.RemoteVersions, protocol.Version1_3) {
 		return nil, nil, dtlserrors.ErrNoCommonProtocolVersion
 	}
-	extensions = append(extensions, &extension13.OfferedVersions{
-		Versions: dtlsconfig.SupportedVersionsRange(flightCtx.cfg.MinVersion, flightCtx.cfg.MaxVersion),
-	})
 
-	if len(flightCtx.cfg.LocalCertSignatureSchemes) > 0 {
-		extensions = append(extensions, &extension.CertificateSignatureAlgorithms{
-			Schemes: dtlsflight.SignatureSchemeIDs(flightCtx.cfg.LocalCertSignatureSchemes),
-		})
+	request := flightCtx.state.HelloRetryRequest
+	var freshShare *extension13.KeyShareEntry
+	if request.HasSelectedGroup {
+		keypair, err := elliptic.GenerateKeypair(request.SelectedGroup)
+		if err != nil {
+			return nil, nil, err
+		}
+		entry := extension13.KeyShareEntry{Group: keypair.Curve, KeyExchange: keypair.PublicKey}
+		freshShare = &entry
+		flightCtx.state.LocalKeyEntries = []extension13.KeyShareEntry{entry}
+		flightCtx.state.LocalKeypairs = map[elliptic.Curve]*elliptic.Keypair{entry.Group: keypair}
 	}
 
-	if len(flightCtx.cfg.ServerName) > 0 {
-		extensions = append(extensions, &extension.ServerNameOffer{ServerName: flightCtx.cfg.ServerName})
-	}
-
-	if len(flightCtx.cfg.LocalSRTPProtectionProfiles) > 0 {
-		extensions = append(extensions, &extension.SRTPOffer{
-			ProtectionProfiles:  flightCtx.cfg.LocalSRTPProtectionProfiles,
-			MasterKeyIdentifier: flightCtx.cfg.LocalSRTPMasterKeyIdentifier,
-		})
-	}
-
-	localCID, localCIDOffered := negotiation.ConnectionIDOffer(flightCtx.state.LocalClientHelloSnapshots.Current()) //nolint:lll
-	if flightCtx.cfg.ConnectionIDGenerator != nil && localCIDOffered {
-		extensions = append(extensions, &extension.ConnectionID{CID: bytes.Clone(localCID)})
-	}
-
-	if len(flightCtx.state.Cookie) > 0 {
-		extensions = append(extensions, &extension13.Cookie{Cookie: flightCtx.state.Cookie})
-	}
-
-	clientHello := &handshake.MessageClientHello{
-		Version:            protocol.Version1_2,
-		SessionID:          flightCtx.state.SessionID,
-		Cookie:             []byte{},
-		Random:             flightCtx.state.LocalRandom,
-		CipherSuiteIDs:     dtlsflight.CipherSuiteIDs(flightCtx.cfg.LocalCipherSuites),
-		CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-		Extensions:         extensions,
-	}
-
-	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook) //nolint:lll
+	clientHello, err := negotiation.BuildClientHelloRetry(
+		flightCtx.state.LocalClientHelloSnapshots.Initial(), request, freshShare,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := negotiation.ValidateSRTPRetry(
-		flightCtx.state.LocalClientHelloSnapshots.Initial(), snapshot,
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := negotiation.ValidateClientHelloRetry(
+		flightCtx.state.LocalClientHelloSnapshots.Initial(), snapshot, request,
 	); err != nil {
 		return nil, nil, err
 	}
@@ -431,23 +346,4 @@ func flight3Generate(
 			},
 		},
 	}, nil, nil
-}
-
-func supportedGroupsForKeyShares(
-	shares []extension13.KeyShareEntry,
-	configured []elliptic.Curve,
-) []elliptic.Curve {
-	groups := make([]elliptic.Curve, 0, len(configured))
-	for _, share := range shares {
-		if !slices.Contains(groups, share.Group) {
-			groups = append(groups, share.Group)
-		}
-	}
-	for _, group := range configured {
-		if !slices.Contains(groups, group) {
-			groups = append(groups, group)
-		}
-	}
-
-	return groups
 }

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -65,16 +65,6 @@ func flight4Parse(
 	return Flight4, nil, nil
 }
 
-func clientHelloCookie(extensions []extension.Value) []byte {
-	for _, ext := range extensions {
-		if cookieExt, ok := ext.(*extension13.Cookie); ok {
-			return cookieExt.Cookie
-		}
-	}
-
-	return nil
-}
-
 func selectClientKeyShare(
 	state *dtlsstate.State13,
 	cfg *dtlsconfig.HandshakeConfig,

--- a/internal/flight/flight13/srtp_test.go
+++ b/internal/flight/flight13/srtp_test.go
@@ -183,15 +183,29 @@ func TestFlight2ParseRejectsChangedSRTPOffer(t *testing.T) {
 	require.NoError(t, state.RemoteClientHelloSnapshots.Record(
 		srtpSnapshot13(t, srtpProfile13, srtpMKI13),
 	))
+	id := uint16(0x1301)
+	request, err := negotiation.ValidateHelloRetryRequest(
+		state.RemoteClientHelloSnapshots.Initial(), &handshake.MessageServerHello{
+			CipherSuiteID: &id, Extensions: []extension.Value{
+				&extension13.SelectedVersion{Version: protocol.Version1_3},
+				&extension13.Cookie{Cookie: state.Cookie},
+			},
+		})
+	require.NoError(t, err)
+	state.HelloRetryRequest = request
 	message := &handshake.Handshake{
 		Header: handshake.Header{MessageSequence: 1},
-		Message: &handshake.MessageClientHello{Version: protocol.Version1_2, Extensions: []extension.Value{
-			&extension13.Cookie{Cookie: state.Cookie},
-			&extension.SRTPOffer{
-				ProtectionProfiles:  []extension.SRTPProtectionProfile{srtpProfile13},
-				MasterKeyIdentifier: []byte("changed"),
+		Message: &handshake.MessageClientHello{
+			Version:        protocol.Version1_2,
+			CipherSuiteIDs: []uint16{0x1301},
+			Extensions: []extension.Value{
+				&extension13.Cookie{Cookie: state.Cookie},
+				&extension.SRTPOffer{
+					ProtectionProfiles:  []extension.SRTPProtectionProfile{srtpProfile13},
+					MasterKeyIdentifier: []byte("changed"),
+				},
 			},
-		}},
+		},
 	}
 	raw, err := message.Marshal()
 	require.NoError(t, err)
@@ -220,7 +234,9 @@ func srtpSnapshot13(
 		})
 	}
 	_, snapshot, err := negotiation.FinalizeClientHello(
-		&handshake.MessageClientHello{Extensions: extensions}, nil,
+		&handshake.MessageClientHello{
+			Version: protocol.Version1_2, CipherSuiteIDs: []uint16{0x1301}, Extensions: extensions,
+		}, nil,
 	)
 	require.NoError(t, err)
 

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -107,6 +107,7 @@ func newTestState13(t *testing.T, isClient bool) *dtlsstate.State13 {
 	t.Helper()
 	state := dtlsstate.NewState13(isClient)
 	_, snapshot, err := negotiation.FinalizeClientHello(&handshake.MessageClientHello{
+		CipherSuiteIDs: []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
 		Extensions: []extension.Value{
 			&extension13.OfferedVersions{Versions: []protocol.Version{protocol.Version1_3}},
 			&extension.SignatureAlgorithms{Schemes: dtlsflight.SignatureSchemeIDs(signaturehash.Algorithms13())},
@@ -340,6 +341,7 @@ func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testi
 	cfg := testHandshakeConfig13(t)
 	state := newTestState13(t, false)
 	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.Cookie = []byte{0x01}
 	cache := dtlsflight.NewCache()
 
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight2, nil, nil)
@@ -379,6 +381,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscri
 	cfg := testHandshakeConfig13(t)
 	state := newTestState13(t, false)
 	state.CipherSuite = cfg.LocalCipherSuites[0]
+	state.Cookie = []byte{0x01}
 	cache := dtlsflight.NewCache()
 	transcript := NewTranscript()
 	clientHello := transcriptTestClientHelloPacket13([]byte{0x01}, 0)

--- a/internal/state/state12.go
+++ b/internal/state/state12.go
@@ -24,6 +24,7 @@ type State12 struct {
 	LocalKeypair *elliptic.Keypair
 
 	Cookie                []byte
+	HasHelloVerifyRequest bool
 	HandshakeSendSequence int
 	HandshakeRecvSequence int
 

--- a/internal/state/state13.go
+++ b/internal/state/state13.go
@@ -117,6 +117,7 @@ type State13 struct {
 	RemoteGroups        []elliptic.Curve
 
 	Cookie                []byte
+	HelloRetryRequest     negotiation.RetryRequest
 	HandshakeSendSequence int
 	HandshakeRecvSequence int
 


### PR DESCRIPTION
#### Description
builds on #1039 and removes the incomplete and inconstant 1.2 and 1.3 retry validation code from flights and uses the common validation base.
Closes #1021 part of #1000 related to #825 