### PR TITLE
Implement 1.3 CID routing and rebinding

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1734,7 +1734,16 @@ func (c *Conn) prepareCiphertextPacket(
 		return incomingPacketState{}, false
 	}
 
-	return c.prepareInnerPlaintextRecord(epoch, sequenceNumber, innerPlaintext, markPacketAsValid)
+	prepared, ok := c.prepareInnerPlaintextRecord(epoch, sequenceNumber, innerPlaintext, markPacketAsValid)
+	if ok {
+		// The datagram's source address remains a candidate until the CID and
+		// ciphertext have both been authenticated and replay checks confirm this
+		// is the latest valid record.
+		// https://datatracker.ietf.org/doc/html/rfc9146#section-6
+		prepared.originalCID = len(ciphertext.Header.ConnectionID) > 0
+	}
+
+	return prepared, ok
 }
 
 func (c *Conn) prepareInnerPlaintextRecord(

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -12,12 +12,116 @@ import (
 	"testing"
 	"time"
 
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	dtlsnet "github.com/pion/dtls/v3/pkg/net"
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/transport/v4/dpipe"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+var errAcceptedConnectionNotDTLS = errors.New("accepted connection is not a DTLS Conn")
+
+func TestListenDTLS13ConnectionIDRebinding(t *testing.T) {
+	defer test.CheckRoutines(t)()
+	defer test.TimeOut(10 * time.Second).Stop()
+
+	serverCert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+	serverCID := []byte("server-cid")
+	listener, err := ListenWithOptions(
+		"udp4",
+		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)},
+		WithCertificates(serverCert),
+		WithMinVersion(protocol.Version1_3),
+		WithMaxVersion(protocol.Version1_3),
+		WithConnectionIDGenerator(func() []byte { return serverCID }),
+	)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, listener.Close())
+	}()
+
+	initialSocket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	client, err := ClientWithOptions(
+		initialSocket,
+		listener.Addr(),
+		WithInsecureSkipVerify(true),
+		WithMinVersion(protocol.Version1_3),
+		WithMaxVersion(protocol.Version1_3),
+		WithConnectionIDGenerator(func() []byte { return []byte("client-cid") }),
+	)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, client.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	type serverResult struct {
+		conn *Conn
+		err  error
+	}
+	serverCh := make(chan serverResult, 1)
+	go func() {
+		accepted, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverCh <- serverResult{err: acceptErr}
+
+			return
+		}
+		server, ok := accepted.(*Conn)
+		if !ok {
+			serverCh <- serverResult{err: errAcceptedConnectionNotDTLS}
+
+			return
+		}
+		serverCh <- serverResult{conn: server, err: server.HandshakeContext(ctx)}
+	}()
+
+	require.NoError(t, client.HandshakeContext(ctx))
+	result := <-serverCh
+	require.NoError(t, result.err)
+	server := result.conn
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	initialRemoteAddr := server.RemoteAddr().String()
+
+	reboundSocket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, reboundSocket.Close())
+	}()
+
+	reboundPacket := client.newApplicationDataPacket([]byte("rebound"))
+	reboundPacket.Record.Header.Epoch = dtlsstate.CommonState(client.state).LocalEpoch()
+	datagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Packet{reboundPacket})
+	require.NoError(t, err)
+	require.Len(t, datagrams, 1)
+	_, err = reboundSocket.WriteTo(datagrams[0].raw, listener.Addr())
+	require.NoError(t, err)
+
+	require.NoError(t, server.SetReadDeadline(time.Now().Add(time.Second)))
+	buf := make([]byte, 64)
+	n, err := server.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("rebound"), buf[:n])
+	assert.NotEqual(t, initialRemoteAddr, server.RemoteAddr().String())
+	assert.Equal(t, reboundSocket.LocalAddr().String(), server.RemoteAddr().String())
+
+	_, err = server.Write([]byte("new path"))
+	require.NoError(t, err)
+	require.NoError(t, reboundSocket.SetReadDeadline(time.Now().Add(time.Second)))
+	n, source, err := reboundSocket.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Positive(t, n)
+	assert.Equal(t, listener.Addr().String(), source.String())
+}
 
 func TestContextConfig(t *testing.T) { //nolint:cyclop
 	// Limit runtime in case of deadlocks

--- a/conn_test.go
+++ b/conn_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
+	"github.com/pion/dtls/v3/internal/closer"
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
@@ -5235,6 +5236,45 @@ func TestOpenCiphertextRecordUsesNegotiatedConnectionID(t *testing.T) {
 	require.NoError(t, err)
 	_, err = conn.unmarshalCiphertextRecord(rawRecord)
 	assert.ErrorIs(t, err, dtlserrors.ErrInvalidCiphertextHeader)
+}
+
+func TestCiphertextConnectionIDPromotesAuthenticatedCandidateAddress(t *testing.T) {
+	conn, peerProtection := newTestConnWithReadProtection(t)
+	state, ok := conn.state.(*dtlsstate.State13)
+	require.True(t, ok)
+	localCID := []byte("local-cid")
+	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{
+		ClientCID: localCID,
+		ServerCID: []byte("remote-cid"),
+	})
+	conn.setRemoteEpoch(dtlsflight13.EpochApplication)
+	conn.decrypted = make(chan any, 1)
+	conn.closed = closer.NewCloser()
+	conn.rAddr = &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5000}
+	candidateAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 6000}
+
+	sealed, err := peerProtection.Seal(
+		recordlayer.UnifiedHeader{
+			ConnectionID: localCID,
+			EpochLow:     uint8(dtlsflight13.EpochApplication & recordlayer.TwoLowBitsMask),
+		},
+		0,
+		protocol.ContentTypeApplicationData,
+		[]byte("application"),
+	)
+	require.NoError(t, err)
+	rawRecord, err := sealed.Marshal()
+	require.NoError(t, err)
+
+	invalidRecord := bytes.Clone(rawRecord)
+	invalidRecord[len(invalidRecord)-1] ^= 0xff
+	_, err = conn.handleIncomingPacket(t.Context(), invalidRecord, candidateAddr, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, candidateAddr, conn.RemoteAddr())
+
+	_, err = conn.handleIncomingPacket(t.Context(), rawRecord, candidateAddr, nil)
+	require.NoError(t, err)
+	assert.Equal(t, candidateAddr, conn.RemoteAddr())
 }
 
 func TestOpenCiphertextRecordUsesReadTrafficGeneration(t *testing.T) {

--- a/connection_id.go
+++ b/connection_id.go
@@ -41,6 +41,13 @@ func OnlySendCIDGenerator() func() []byte {
 // constant size connection IDs.
 func cidDatagramRouter(size int) func([]byte) (string, bool) {
 	return func(packet []byte) (string, bool) {
+		if len(packet) == 0 {
+			return "", false
+		}
+		if protocol.IsDTLS13Ciphertext(protocol.ContentType(packet[0])) {
+			return cidDatagramRouter13(packet, size)
+		}
+
 		pkts, err := recordlayer.ContentAwareUnpackDatagram(packet, size)
 		if err != nil || len(pkts) == 0 {
 			return "", false
@@ -63,6 +70,35 @@ func cidDatagramRouter(size int) func([]byte) (string, bool) {
 	}
 }
 
+// cidDatagramRouter13 extracts the fixed-length connection ID from a DTLS 1.3
+// unified header. The CID bit is authenticated only when Conn opens the record,
+// so routing by it selects a candidate connection rather than authenticating a
+// peer address.
+//
+// https://datatracker.ietf.org/doc/html/rfc9147#section-4
+func cidDatagramRouter13(packet []byte, size int) (string, bool) {
+	pkts, err := recordlayer.UnpackDatagram13(packet, size, false, true)
+	if err != nil || len(pkts) == 0 {
+		return "", false
+	}
+	for _, pkt := range pkts {
+		if len(pkt) == 0 ||
+			!protocol.IsDTLS13Ciphertext(protocol.ContentType(pkt[0])) ||
+			pkt[0]&recordlayer.UnifiedHeaderCIDBit == 0 {
+			continue
+		}
+
+		h := recordlayer.UnifiedHeader{ConnectionID: make([]byte, size)}
+		if err := h.Unmarshal(pkt); err != nil {
+			continue
+		}
+
+		return string(h.ConnectionID), true
+	}
+
+	return "", false
+}
+
 // cidConnIdentifier extracts connection IDs from outgoing ServerHello records
 // and associates them with the associated connection.
 // NOTE: a ServerHello should always be the first record in a datagram if
@@ -70,28 +106,25 @@ func cidDatagramRouter(size int) func([]byte) (string, bool) {
 // is not a ServerHello.
 func cidConnIdentifier() func([]byte) (string, bool) { //nolint:cyclop
 	return func(packet []byte) (string, bool) {
-		pkts, err := recordlayer.UnpackDatagram(packet)
-		if err != nil || len(pkts) == 0 {
-			return "", false
-		}
 		var h recordlayer.Header
-		if hErr := h.Unmarshal(pkts[0]); hErr != nil {
+		if err := h.Unmarshal(packet); err != nil {
 			return "", false
 		}
 		if h.ContentType != protocol.ContentTypeHandshake {
 			return "", false
 		}
+		firstRecordSize := h.Size() + int(h.ContentLen)
+		if len(packet) < firstRecordSize {
+			return "", false
+		}
+		firstRecord := packet[:firstRecordSize]
+
 		var hh handshake.Header
 		var sh handshake.MessageServerHello
-		for _, pkt := range pkts {
-			if hhErr := hh.Unmarshal(pkt[recordlayer.FixedHeaderSize:]); hhErr != nil {
-				continue
-			}
-			if err = sh.Unmarshal(pkt[recordlayer.FixedHeaderSize+handshake.HeaderLength:]); err == nil {
-				break
-			}
+		if err := hh.Unmarshal(firstRecord[recordlayer.FixedHeaderSize:]); err != nil {
+			return "", false
 		}
-		if err != nil {
+		if err := sh.Unmarshal(firstRecord[recordlayer.FixedHeaderSize+handshake.HeaderLength:]); err != nil {
 			return "", false
 		}
 		for _, ext := range sh.Extensions {

--- a/connection_id_test.go
+++ b/connection_id_test.go
@@ -179,6 +179,71 @@ func TestCIDDatagramRouter(t *testing.T) {
 	}
 }
 
+func TestCIDDatagramRouter13(t *testing.T) {
+	cid := []byte("abcd1234")
+	makeRecord := func(t *testing.T, connectionID []byte, sequenceNumber uint16) []byte {
+		t.Helper()
+
+		record, err := (&recordlayer.CiphertextRecord13{
+			Header: recordlayer.UnifiedHeader{
+				ConnectionID:   connectionID,
+				SequenceNumber: sequenceNumber,
+			},
+			EncryptedRecord: make([]byte, 16),
+		}).Marshal()
+		assert.NoError(t, err)
+
+		return record
+	}
+
+	recordWithCID := makeRecord(t, cid, 1)
+	recordWithoutCID := makeRecord(t, nil, 2)
+	otherCID := []byte("1234abcd")
+	recordWithOtherCID := makeRecord(t, otherCID, 3)
+
+	cases := map[string]struct {
+		reason   string
+		size     int
+		datagram []byte
+		ok       bool
+		want     string
+	}{
+		"OneRecordConnectionID": {
+			reason:   "A unified-header record with the C bit should expose its CID.",
+			size:     len(cid),
+			datagram: recordWithCID,
+			ok:       true,
+			want:     string(cid),
+		},
+		"NoConnectionIDBit": {
+			reason:   "A unified-header record without the C bit has no routing identifier.",
+			size:     len(cid),
+			datagram: recordWithoutCID,
+			ok:       false,
+		},
+		"WrongConfiguredLength": {
+			reason:   "A unified-header CID must have the listener's configured fixed length.",
+			size:     len(cid) - 1,
+			datagram: recordWithCID,
+			ok:       false,
+		},
+		"MultipleRecords": {
+			reason:   "The first CID in a datagram containing unified-header records should be used.",
+			size:     len(cid),
+			datagram: append(append([]byte{}, recordWithCID...), recordWithOtherCID...),
+			ok:       true,
+			want:     string(cid),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, ok := cidDatagramRouter(tc.size)(tc.datagram)
+			assert.Equal(t, tc.ok, ok, "%s\ncidDatagramRouter mismatch", tc.reason)
+			assert.Equal(t, tc.want, got, "%s\ncidDatagramRouter mismatch", tc.reason)
+		})
+	}
+}
+
 func TestCIDConnIdentifier(t *testing.T) {
 	cid := []byte("abcd1234")
 	cs := uint16(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
@@ -212,6 +277,11 @@ func TestCIDConnIdentifier(t *testing.T) {
 		Content: &protocol.ApplicationData{
 			Data: []byte("application data"),
 		},
+	}).Marshal()
+	assert.NoError(t, err)
+	dtls13Ciphertext, err := (&recordlayer.CiphertextRecord13{
+		Header:          recordlayer.UnifiedHeader{SequenceNumber: 1},
+		EncryptedRecord: make([]byte, 16),
 	}).Marshal()
 	assert.NoError(t, err)
 
@@ -249,6 +319,13 @@ func TestCIDConnIdentifier(t *testing.T) {
 			//nolint:lll
 			reason:   "If datagram contains multiple records and the first is a ServerHello record, we should be able to extract an identifier.",
 			datagram: append(sh, appRecord...),
+			ok:       true,
+			want:     string(cid),
+		},
+		"DTLS13ServerFlight": {
+			//nolint:lll
+			reason:   "A ServerHello followed by DTLS 1.3 unified-header records should register its Connection ID.",
+			datagram: append(append([]byte{}, sh...), dtls13Ciphertext...),
 			ok:       true,
 			want:     string(cid),
 		},


### PR DESCRIPTION
#### Description
Updates the CID routing and rebinding so it's DTLS 1.3 aware https://datatracker.ietf.org/doc/html/rfc9146#section-6 and https://datatracker.ietf.org/doc/html/rfc9147#section-4 

Was implemented against https://github.com/pion/dtls-interop/pull/16 

part of #775 