### PR TITLE
Register RCC extension

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -260,6 +260,7 @@ var (
 	ErrMissingPSKKeyExchangeModesExtension = stderrors.New(
 		"pre_shared_key requires psk_key_exchange_modes",
 	)
+	ErrMissingConnectionIDExtension   = stderrors.New("rrc requires connection_id")
 	ErrEarlyDataWithoutPreSharedKey   = stderrors.New("early_data requires pre_shared_key")
 	ErrKeyShareWithoutSupportedGroups = stderrors.New(
 		"key_share requires supported_groups",

--- a/pkg/protocol/extension/raw.go
+++ b/pkg/protocol/extension/raw.go
@@ -34,6 +34,7 @@ const (
 	TypeSignatureAlgorithmsCert Type = 50
 	TypeKeyShare                Type = 51
 	TypeConnectionID            Type = 54
+	TypeReturnRoutabilityCheck  Type = 61
 	TypeRenegotiationInfo       Type = 65281
 )
 

--- a/pkg/protocol/extension/return_routability_check.go
+++ b/pkg/protocol/extension/return_routability_check.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import dtlserrors "github.com/pion/dtls/v3/internal/errors"
+
+// ReturnRoutabilityCheck negotiates the RFC 9853 RRC subprotocol.
+type ReturnRoutabilityCheck struct{}
+
+// ExtensionType returns the IANA extension type for RRC.
+func (ReturnRoutabilityCheck) ExtensionType() Type { return TypeReturnRoutabilityCheck }
+
+// MarshalData returns the empty RRC extension_data.
+func (ReturnRoutabilityCheck) MarshalData() ([]byte, error) { return nil, nil }
+
+// UnmarshalData validates the empty RRC extension_data.
+func (*ReturnRoutabilityCheck) UnmarshalData(data []byte) error {
+	if len(data) != 0 {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	return nil
+}

--- a/pkg/protocol/extension/return_routability_check_test.go
+++ b/pkg/protocol/extension/return_routability_check_test.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package extension
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReturnRoutabilityCheckExtension(t *testing.T) {
+	extension := ReturnRoutabilityCheck{}
+	raw, err := extension.MarshalData()
+	require.NoError(t, err)
+	assert.Empty(t, raw)
+	assert.Equal(t, TypeReturnRoutabilityCheck, extension.ExtensionType())
+
+	require.NoError(t, extension.UnmarshalData(nil))
+	assert.ErrorIs(t, extension.UnmarshalData([]byte{0}), dtlserrors.ErrLengthMismatch)
+}

--- a/pkg/protocol/handshake/extensions.go
+++ b/pkg/protocol/handshake/extensions.go
@@ -162,6 +162,11 @@ var extensionRegistry = map[extension.Type]map[extensionContext]extensionPayload
 		extensionContextServerHello12: func() extensionPayloadValue { return &extension.ConnectionID{} },
 		extensionContextServerHello13: func() extensionPayloadValue { return &extension.ConnectionID{} },
 	},
+	extension.TypeReturnRoutabilityCheck: {
+		extensionContextClientHello:   func() extensionPayloadValue { return &extension.ReturnRoutabilityCheck{} },
+		extensionContextServerHello12: func() extensionPayloadValue { return &extension.ReturnRoutabilityCheck{} },
+		extensionContextServerHello13: func() extensionPayloadValue { return &extension.ReturnRoutabilityCheck{} },
+	},
 	extension.TypeRenegotiationInfo: {
 		extensionContextClientHello:   func() extensionPayloadValue { return &extension12.RenegotiationInfo{} },
 		extensionContextServerHello12: func() extensionPayloadValue { return &extension12.RenegotiationInfo{} },
@@ -338,6 +343,17 @@ func validateSupportedGroups(groups *extension.SupportedGroups, context extensio
 func validateClientHelloDependencies(dependencies extensionDependencyValues) error {
 	if err := validatePSKDependencies(dependencies); err != nil {
 		return err
+	}
+	if dependencies.present[extension.TypeReturnRoutabilityCheck] &&
+		!dependencies.present[extension.TypeConnectionID] {
+		return fmt.Errorf(
+			"extension %d in %s requires extension %d: %w: %w",
+			extension.TypeReturnRoutabilityCheck,
+			extensionContextClientHello,
+			extension.TypeConnectionID,
+			dtlserrors.ErrMissingConnectionIDExtension,
+			&alert.Alert{Level: alert.Fatal, Description: alert.MissingExtension},
+		)
 	}
 	if err := validateTLS13ClientHelloDependencies(dependencies); err != nil {
 		return err

--- a/pkg/protocol/handshake/extensions_test.go
+++ b/pkg/protocol/handshake/extensions_test.go
@@ -153,6 +153,13 @@ func TestExtensionBlockOrderingAndDependencies(t *testing.T) {
 		assertExtensionAlert(t, err, alert.MissingExtension)
 	})
 
+	t.Run("return routability check requires connection ID", func(t *testing.T) {
+		rrc := rawExtensionValue(t, &extension.ReturnRoutabilityCheck{})
+		_, err := decodeRawExtensions([]extension.Raw{rrc}, extensionContextClientHello)
+		assert.ErrorIs(t, err, dtlserrors.ErrMissingConnectionIDExtension)
+		assertExtensionAlert(t, err, alert.MissingExtension)
+	})
+
 	t.Run("early data requires pre shared key", func(t *testing.T) {
 		earlyData := rawExtensionValue(t, &extension13.EarlyData{})
 		_, err := decodeRawExtensions([]extension.Raw{earlyData}, extensionContextClientHello)
@@ -359,6 +366,11 @@ func expectedExtensionRegistry() map[extension.Type]map[extensionContext]extensi
 			extensionContextClientHello:   &extension.ConnectionID{},
 			extensionContextServerHello12: &extension.ConnectionID{},
 			extensionContextServerHello13: &extension.ConnectionID{},
+		},
+		extension.TypeReturnRoutabilityCheck: {
+			extensionContextClientHello:   &extension.ReturnRoutabilityCheck{},
+			extensionContextServerHello12: &extension.ReturnRoutabilityCheck{},
+			extensionContextServerHello13: &extension.ReturnRoutabilityCheck{},
 		},
 		extension.TypeRenegotiationInfo: {
 			extensionContextClientHello:   &extension12.RenegotiationInfo{},


### PR DESCRIPTION
#### Description
Registers Return Routability Check and adds basic scaffold for the extension.
part of #1026 