### PR TITLE
Add RRC record encoding

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1042,7 +1042,8 @@ func (c *Conn) processProtectedPacket(pkt *dtlsflight.Packet, seq uint64) ([]byt
 
 func marshalRecordContent(content protocol.Content) (protocol.ContentType, []byte, error) {
 	switch content.(type) {
-	case *handshake.Handshake, *alert.Alert, *protocol.ApplicationData, *protocol.ACK:
+	case *handshake.Handshake, *alert.Alert, *protocol.ApplicationData, *protocol.ACK,
+		*protocol.ReturnRoutabilityCheck:
 	default:
 		return 0, nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
 	}
@@ -1607,7 +1608,8 @@ func (c *Conn) openCiphertextWithGeneration(
 	case protocol.ContentTypeAlert,
 		protocol.ContentTypeHandshake,
 		protocol.ContentTypeApplicationData,
-		protocol.ContentTypeACK:
+		protocol.ContentTypeACK,
+		protocol.ContentTypeReturnRoutabilityCheck:
 		return innerPlaintext, sequenceNumber, nil
 	default:
 		return recordlayer.InnerPlaintext{}, 0, dtlserrors.ErrInvalidContentType
@@ -1754,7 +1756,8 @@ func (c *Conn) prepareInnerPlaintextRecord(
 ) (incomingPacketState, bool) {
 	switch innerPlaintext.RealType {
 	case protocol.ContentTypeHandshake, protocol.ContentTypeAlert,
-		protocol.ContentTypeApplicationData, protocol.ContentTypeACK:
+		protocol.ContentTypeApplicationData, protocol.ContentTypeACK,
+		protocol.ContentTypeReturnRoutabilityCheck:
 		plaintext, header, err := marshalInnerPlaintextRecord(remoteEpoch, sequenceNumber, innerPlaintext)
 		if err != nil {
 			c.log.Debugf("converting ciphertext record to inner plaintext failed: %s", err)

--- a/pkg/protocol/content.go
+++ b/pkg/protocol/content.go
@@ -10,12 +10,13 @@ type ContentType uint8
 
 // ContentType enums.
 const (
-	ContentTypeChangeCipherSpec ContentType = 20
-	ContentTypeAlert            ContentType = 21
-	ContentTypeHandshake        ContentType = 22
-	ContentTypeApplicationData  ContentType = 23
-	ContentTypeConnectionID     ContentType = 25
-	ContentTypeACK              ContentType = 26
+	ContentTypeChangeCipherSpec       ContentType = 20
+	ContentTypeAlert                  ContentType = 21
+	ContentTypeHandshake              ContentType = 22
+	ContentTypeApplicationData        ContentType = 23
+	ContentTypeConnectionID           ContentType = 25
+	ContentTypeACK                    ContentType = 26
+	ContentTypeReturnRoutabilityCheck ContentType = 27
 )
 
 // Content is the top level distinguisher for a DTLS Datagram.

--- a/pkg/protocol/recordlayer/recordlayer.go
+++ b/pkg/protocol/recordlayer/recordlayer.go
@@ -84,6 +84,8 @@ func (r *RecordLayer) Unmarshal(data []byte) error {
 		r.Content = &protocol.ApplicationData{}
 	case protocol.ContentTypeACK:
 		r.Content = &protocol.ACK{}
+	case protocol.ContentTypeReturnRoutabilityCheck:
+		r.Content = &protocol.ReturnRoutabilityCheck{}
 	default:
 		return dtlserrors.ErrInvalidContentType
 	}

--- a/pkg/protocol/recordlayer/recordlayer_test.go
+++ b/pkg/protocol/recordlayer/recordlayer_test.go
@@ -76,6 +76,26 @@ func TestRecordLayerRoundTrip(t *testing.T) {
 				Content: &protocol.ChangeCipherSpec{},
 			},
 		},
+		{
+			Name: "Return Routability Check",
+			Data: []byte{
+				0x1b, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x00, 0x09,
+				0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			},
+			Want: &RecordLayer{
+				Header: Header{
+					ContentType:    protocol.ContentTypeReturnRoutabilityCheck,
+					ContentLen:     9,
+					Version:        protocol.Version1_2,
+					Epoch:          0,
+					SequenceNumber: 18,
+				},
+				Content: &protocol.ReturnRoutabilityCheck{
+					MessageType: protocol.ReturnRoutabilityCheckPathResponse,
+					Cookie:      [protocol.ReturnRoutabilityCheckCookieLength]byte{1, 2, 3, 4, 5, 6, 7, 8},
+				},
+			},
+		},
 	} {
 		r := &RecordLayer{}
 		assert.ErrorIs(t, r.Unmarshal(test.Data), test.WantUnmarshalError)

--- a/pkg/protocol/return_routability_check.go
+++ b/pkg/protocol/return_routability_check.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package protocol
+
+import dtlserrors "github.com/pion/dtls/v3/internal/errors"
+
+// ReturnRoutabilityCheckMessageType identifies an RFC 9853 RRC message.
+type ReturnRoutabilityCheckMessageType uint8
+
+// Return Routability Check message types (rrc_msg_type).
+// https://datatracker.ietf.org/doc/html/rfc9853#section-4
+const (
+	ReturnRoutabilityCheckPathChallenge ReturnRoutabilityCheckMessageType = iota
+	ReturnRoutabilityCheckPathResponse
+	ReturnRoutabilityCheckPathDrop
+)
+
+// ReturnRoutabilityCheckCookieLength is the wire size of an RRC cookie.
+// https://datatracker.ietf.org/doc/html/rfc9853#section-4
+const ReturnRoutabilityCheckCookieLength = 8
+
+// ReturnRoutabilityCheck carries an RRC path validation message.
+type ReturnRoutabilityCheck struct {
+	MessageType ReturnRoutabilityCheckMessageType
+	Cookie      [ReturnRoutabilityCheckCookieLength]byte
+}
+
+// ContentType returns the RRC content type (27).
+func (r ReturnRoutabilityCheck) ContentType() ContentType {
+	return ContentTypeReturnRoutabilityCheck
+}
+
+// Marshal encodes the RRC message to its wire format.
+func (r *ReturnRoutabilityCheck) Marshal() ([]byte, error) {
+	out := make([]byte, 1, 1+len(r.Cookie))
+	out[0] = byte(r.MessageType)
+
+	return append(out, r.Cookie[:]...), nil
+}
+
+// Unmarshal decodes an RRC message.
+func (r *ReturnRoutabilityCheck) Unmarshal(data []byte) error {
+	if len(data) == 0 {
+		return dtlserrors.ErrBufferTooSmall
+	}
+
+	r.MessageType = ReturnRoutabilityCheckMessageType(data[0])
+	// implementations MUST be able to parse and gracefully ignore messages with an unknown msg_type
+	// https://datatracker.ietf.org/doc/html/rfc9853#section-4.2
+	if r.MessageType > ReturnRoutabilityCheckPathDrop {
+		r.Cookie = [ReturnRoutabilityCheckCookieLength]byte{}
+
+		return nil
+	}
+	if len(data) != 1+len(r.Cookie) {
+		return dtlserrors.ErrLengthMismatch
+	}
+
+	copy(r.Cookie[:], data[1:])
+
+	return nil
+}

--- a/pkg/protocol/return_routability_check_test.go
+++ b/pkg/protocol/return_routability_check_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package protocol
+
+import (
+	"testing"
+
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReturnRoutabilityCheck(t *testing.T) {
+	want := ReturnRoutabilityCheck{
+		MessageType: ReturnRoutabilityCheckPathResponse,
+		Cookie:      [ReturnRoutabilityCheckCookieLength]byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+
+	raw, err := want.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{1, 1, 2, 3, 4, 5, 6, 7, 8}, raw)
+
+	var got ReturnRoutabilityCheck
+	require.NoError(t, got.Unmarshal(raw))
+	assert.Equal(t, want, got)
+	assert.Equal(t, ContentTypeReturnRoutabilityCheck, got.ContentType())
+}
+
+func TestReturnRoutabilityCheckUnmarshal(t *testing.T) {
+	tests := map[string]struct {
+		raw         []byte
+		expectedErr error
+	}{
+		"Empty":       {raw: nil, expectedErr: dtlserrors.ErrBufferTooSmall},
+		"ShortKnown":  {raw: []byte{byte(ReturnRoutabilityCheckPathChallenge)}, expectedErr: dtlserrors.ErrLengthMismatch},
+		"LongKnown":   {raw: make([]byte, 10), expectedErr: dtlserrors.ErrLengthMismatch},
+		"UnknownType": {raw: []byte{42, 1, 2, 3}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var message ReturnRoutabilityCheck
+			err := message.Unmarshal(test.raw)
+			assert.ErrorIs(t, err, test.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
#### Description
Adds record encoding / content type for Return Routability Check as defined in https://datatracker.ietf.org/doc/html/rfc9853#section-4

part of #1026 