### PR TITLE
Add path migration policies

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type connConfigValues struct {
 	certificateSignatureSchemes []signaturehash.Algorithm
 	ellipticCurves              []elliptic.Curve
 	serverName                  string
+	cidPathMigrationPolicy      cidPathMigrationPolicy
 }
 
 func newConnConfigValues(config *dtlsConfig) (connConfigValues, error) {
@@ -84,6 +85,7 @@ func newConnConfigValues(config *dtlsConfig) (connConfigValues, error) {
 		certificateSignatureSchemes: certSignatureSchemes,
 		ellipticCurves:              effectiveEllipticCurves(config.EllipticCurves),
 		serverName:                  effectiveServerName(config.ServerName),
+		cidPathMigrationPolicy:      config.CIDPathMigrationPolicy,
 	}, nil
 }
 
@@ -274,6 +276,7 @@ func newHandshakeConfig(
 		EllipticCurves:                configValues.ellipticCurves,
 		InsecureSkipHelloVerify:       config.InsecureSkipVerifyHello,
 		ConnectionIDGenerator:         config.ConnectionIDGenerator,
+		EnableRRC:                     config.CIDPathMigrationPolicy == CIDPathMigrationRRC,
 		HelloRandomBytesGenerator:     config.HelloRandomBytesGenerator,
 		Log:                           configValues.logger,
 		KeyLogWriter:                  config.KeyLogWriter,

--- a/conn.go
+++ b/conn.go
@@ -228,7 +228,8 @@ type Conn struct {
 
 	handshakeConfig *dtlsconfig.HandshakeConfig
 
-	rrc dtlsrrc.Manager
+	cidPathMigrationPolicy cidPathMigrationPolicy
+	rrc                    dtlsrrc.Manager
 }
 
 // createConn creates a new DTLS connection.
@@ -273,6 +274,7 @@ func newConn(
 		handshakeCache:          dtlsflight.NewCache(),
 		maximumTransmissionUnit: configValues.maximumTransmissionUnit,
 		paddingLengthGenerator:  configValues.paddingLengthGenerator,
+		cidPathMigrationPolicy:  configValues.cidPathMigrationPolicy,
 
 		decrypted: make(chan any, 1),
 		log:       configValues.logger,
@@ -2196,7 +2198,7 @@ func (c *Conn) handleIncomingPacket(
 		rAddr,
 		len(buf),
 		c.RemoteAddr,
-		dtlsstate.CommonState(c.state).RRCNegotiated,
+		c.cidPathMigrationPolicy == CIDPathMigrationRRC && dtlsstate.CommonState(c.state).RRCNegotiated,
 	)
 	if outcome, handled, isLatestSeqNum := c.bufferHandshakeRecord(
 		prepared.buf,

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -72,7 +72,7 @@ func testListenConnectionIDRebindingRequiresRRC(
 		WithCertificates(serverCert),
 		WithMinVersion(serverMin),
 		WithMaxVersion(serverMax),
-		WithConnectionIDGenerator(func() []byte { return serverCID }),
+		WithConnectionID(func() []byte { return serverCID }, CIDPathMigrationRRC),
 	)
 	require.NoError(t, err)
 	defer func() {
@@ -87,7 +87,7 @@ func testListenConnectionIDRebindingRequiresRRC(
 		WithInsecureSkipVerify(true),
 		WithMinVersion(clientMin),
 		WithMaxVersion(clientMax),
-		WithConnectionIDGenerator(func() []byte { return []byte("client-cid") }),
+		WithConnectionID(func() []byte { return []byte("client-cid") }, CIDPathMigrationRRC),
 	)
 	require.NoError(t, err)
 	defer func() {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1420,26 +1420,26 @@ func TestConnectionID(t *testing.T) {
 		serverConnectionID []byte
 	}{
 		"BidirectionalConnectionIDs": {
-			clientOpts:         []ClientOption{WithConnectionIDGenerator(cidEcho(clientCID))},
-			serverOpts:         []ServerOption{WithConnectionIDGenerator(cidEcho(serverCID))},
+			clientOpts:         []ClientOption{WithConnectionID(cidEcho(clientCID), CIDPathMigrationReject)},
+			serverOpts:         []ServerOption{WithConnectionID(cidEcho(serverCID), CIDPathMigrationReject)},
 			clientConnectionID: clientCID,
 			serverConnectionID: serverCID,
 		},
 		"BothSupportOnlyClientSends": {
-			clientOpts:         []ClientOption{WithConnectionIDGenerator(cidEcho(nil))},
-			serverOpts:         []ServerOption{WithConnectionIDGenerator(cidEcho(serverCID))},
+			clientOpts:         []ClientOption{WithConnectionID(cidEcho(nil), CIDPathMigrationReject)},
+			serverOpts:         []ServerOption{WithConnectionID(cidEcho(serverCID), CIDPathMigrationReject)},
 			serverConnectionID: serverCID,
 		},
 		"BothSupportOnlyServerSends": {
-			clientOpts:         []ClientOption{WithConnectionIDGenerator(cidEcho(clientCID))},
-			serverOpts:         []ServerOption{WithConnectionIDGenerator(cidEcho(nil))},
+			clientOpts:         []ClientOption{WithConnectionID(cidEcho(clientCID), CIDPathMigrationReject)},
+			serverOpts:         []ServerOption{WithConnectionID(cidEcho(nil), CIDPathMigrationReject)},
 			clientConnectionID: clientCID,
 		},
 		"ClientDoesNotSupport": {
-			serverOpts: []ServerOption{WithConnectionIDGenerator(cidEcho(serverCID))},
+			serverOpts: []ServerOption{WithConnectionID(cidEcho(serverCID), CIDPathMigrationReject)},
 		},
 		"ServerDoesNotSupport": {
-			clientOpts: []ClientOption{WithConnectionIDGenerator(cidEcho(clientCID))},
+			clientOpts: []ClientOption{WithConnectionID(cidEcho(clientCID), CIDPathMigrationReject)},
 		},
 		"NeitherSupport": {},
 	}
@@ -1482,6 +1482,8 @@ func TestConnectionID(t *testing.T) {
 				"Unexpected server local connection ID")
 			assert.True(t, bytes.Equal(tt.clientConnectionID, dtlsstate.CommonState(server.state).RemoteConnectionID),
 				"Unexpected server remote connection ID")
+			assert.False(t, dtlsstate.CommonState(res.c.state).RRCNegotiated)
+			assert.False(t, dtlsstate.CommonState(server.state).RRCNegotiated)
 		})
 	}
 }
@@ -3238,7 +3240,7 @@ func TestSessionResume(t *testing.T) {
 				WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
 				WithServerName("example.com"),
 				WithSessionStore(ss),
-				WithConnectionIDGenerator(func() []byte { return clientCID }),
+				WithConnectionID(func() []byte { return clientCID }, CIDPathMigrationReject),
 				WithMTU(100),
 			}
 			c, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts, false)
@@ -3249,7 +3251,7 @@ func TestSessionResume(t *testing.T) {
 			WithCipherSuites(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
 			WithServerName("example.com"),
 			WithSessionStore(ss),
-			WithConnectionIDGenerator(func() []byte { return serverCID }),
+			WithConnectionID(func() []byte { return serverCID }, CIDPathMigrationReject),
 			WithMTU(100),
 		}
 		server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), opts, true)
@@ -4049,7 +4051,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 		WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3),
 		WithMaxVersion(protocol.Version1_3),
-		WithConnectionIDGenerator(func() []byte { return clientCID }),
+		WithConnectionID(func() []byte { return clientCID }, CIDPathMigrationReject),
 	)
 	assert.NoError(t, err)
 	defer func() {
@@ -4071,7 +4073,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 		WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3),
 		WithMaxVersion(protocol.Version1_3),
-		WithConnectionIDGenerator(func() []byte { return serverCID }),
+		WithConnectionID(func() []byte { return serverCID }, CIDPathMigrationReject),
 	)
 	assert.NoError(t, err)
 	defer func() {
@@ -4096,6 +4098,8 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	assert.Equal(t, serverCID, dtlsstate.CommonState(client.state).RemoteConnectionID)
 	assert.Equal(t, serverCID, dtlsstate.CommonState(server.state).LocalConnectionID())
 	assert.Equal(t, clientCID, dtlsstate.CommonState(server.state).RemoteConnectionID)
+	assert.False(t, dtlsstate.CommonState(client.state).RRCNegotiated)
+	assert.False(t, dtlsstate.CommonState(server.state).RRCNegotiated)
 
 	_, ok = client.ConnectionState()
 	require.True(t, ok)
@@ -5379,6 +5383,7 @@ func testLatestCIDControlRecordStartsRRC(
 ) {
 	t.Helper()
 	conn, peerProtection := newTestConnWithReadProtection(t)
+	conn.cidPathMigrationPolicy = CIDPathMigrationRRC
 	state, ok := conn.state.(*dtlsstate.State13)
 	require.True(t, ok)
 	localCID := []byte("local-cid")
@@ -5433,33 +5438,111 @@ func testLatestCIDControlRecordStartsRRC(
 	assert.Equal(t, activeAddr.String(), conn.RemoteAddr().String())
 }
 
-func TestRRCRejectsUnprotectedRecord(t *testing.T) {
-	state := dtlsstate.NewState12(true)
-	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{
-		ClientCID:              []byte("local-cid"),
-		ServerCID:              []byte("remote-cid"),
-		ReturnRoutabilityCheck: true,
-	})
-	marked := false
-	conn := &Conn{state: &state}
-	_, outcome, err := conn.handleRecordContent(
-		t.Context(),
-		&protocol.ReturnRoutabilityCheck{MessageType: protocol.ReturnRoutabilityCheckPathChallenge},
-		incomingPacketState{
-			header: &recordlayer.Header{Epoch: 0},
-			markPacketAsValid: func() bool {
-				marked = true
+func TestRRCRequiresProtectionPolicyAndNegotiation(t *testing.T) {
+	for name, test := range map[string]struct {
+		policy     cidPathMigrationPolicy
+		negotiated bool
+		epoch      uint16
+	}{
+		"Unprotected":    {policy: CIDPathMigrationRRC, negotiated: true},
+		"PolicyDisabled": {policy: CIDPathMigrationReject, negotiated: true, epoch: 1},
+		"NotNegotiated":  {policy: CIDPathMigrationRRC, epoch: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := dtlsstate.NewState12(true)
+			state.CommitNegotiatedExtensions(&negotiation.ConnectionID{
+				ClientCID:              []byte("local-cid"),
+				ServerCID:              []byte("remote-cid"),
+				ReturnRoutabilityCheck: test.negotiated,
+			})
+			marked := false
+			conn := &Conn{state: &state, cidPathMigrationPolicy: test.policy}
+			_, outcome, err := conn.handleRecordContent(
+				t.Context(),
+				&protocol.ReturnRoutabilityCheck{MessageType: protocol.ReturnRoutabilityCheckPathChallenge},
+				incomingPacketState{
+					header: &recordlayer.Header{Epoch: test.epoch},
+					markPacketAsValid: func() bool {
+						marked = true
 
-				return true
-			},
+						return true
+					},
+				},
+				&net.UDPAddr{},
+				nil,
+			)
+
+			assert.ErrorIs(t, err, dtlserrors.ErrUnexpectedPostHandshakeMessage)
+			assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, outcome.responseAlert)
+			assert.False(t, marked)
+		})
+	}
+}
+
+func TestWriteRRCRequiresPolicyAndNegotiation(t *testing.T) {
+	for name, test := range map[string]struct {
+		policy     cidPathMigrationPolicy
+		negotiated bool
+	}{
+		"PolicyDisabled": {policy: CIDPathMigrationReject, negotiated: true},
+		"NotNegotiated":  {policy: CIDPathMigrationRRC},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := dtlsstate.NewState12(true)
+			state.CommitNegotiatedExtensions(&negotiation.ConnectionID{
+				ClientCID:              []byte("local-cid"),
+				ServerCID:              []byte("remote-cid"),
+				ReturnRoutabilityCheck: test.negotiated,
+			})
+			conn := &Conn{state: &state, cidPathMigrationPolicy: test.policy}
+			err := (returnRoutabilityConn{conn: conn}).WriteRRC(
+				t.Context(), &net.UDPAddr{}, protocol.ReturnRoutabilityCheckPathChallenge,
+				[protocol.ReturnRoutabilityCheckCookieLength]byte{},
+			)
+			assert.ErrorIs(t, err, dtlserrors.ErrUnexpectedPostHandshakeMessage)
+		})
+	}
+}
+
+func TestCIDPathMigrationPolicies(t *testing.T) {
+	activeAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5000}
+	candidateAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 6000}
+	for name, test := range map[string]struct {
+		policy       cidPathMigrationPolicy
+		expectedAddr net.Addr
+		expectedLog  string
+	}{
+		"Reject": {
+			policy: CIDPathMigrationReject, expectedAddr: activeAddr,
+			expectedLog: "rejected CID path migration",
 		},
-		&net.UDPAddr{},
-		nil,
-	)
+		"Unsafe": {policy: CIDPathMigrationUnsafe, expectedAddr: candidateAddr},
+		"RRCNotNegotiated": {
+			policy: CIDPathMigrationRRC, expectedAddr: activeAddr,
+			expectedLog: "RRC was not negotiated",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var logs bytes.Buffer
+			conn := &Conn{
+				rAddr:                  activeAddr,
+				cidPathMigrationPolicy: test.policy,
+				log: logging.NewDefaultLeveledLoggerForScope(
+					"dtls", logging.LogLevelError, &logs,
+				),
+			}
+			(returnRoutabilityConn{conn: conn}).HandleCandidate(
+				t.Context(), false, true, true, candidateAddr,
+			)
 
-	assert.ErrorIs(t, err, dtlserrors.ErrUnexpectedPostHandshakeMessage)
-	assert.Equal(t, &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage}, outcome.responseAlert)
-	assert.False(t, marked)
+			assert.Equal(t, test.expectedAddr.String(), conn.RemoteAddr().String())
+			if test.expectedLog == "" {
+				assert.Empty(t, logs.String())
+			} else {
+				assert.Contains(t, logs.String(), test.expectedLog)
+			}
+		})
+	}
 }
 
 func TestOpenCiphertextRecordUsesReadTrafficGeneration(t *testing.T) {

--- a/connection_id.go
+++ b/connection_id.go
@@ -57,7 +57,7 @@ func (c returnRoutabilityConn) WriteRRC(
 
 	c.conn.lock.Lock()
 	common := dtlsstate.CommonState(c.conn.state)
-	if !common.RRCNegotiated {
+	if c.conn.cidPathMigrationPolicy != CIDPathMigrationRRC || !common.RRCNegotiated {
 		c.conn.lock.Unlock()
 
 		return dtlserrors.ErrUnexpectedPostHandshakeMessage
@@ -99,7 +99,9 @@ func (c returnRoutabilityConn) HandleRecord(
 	prepared incomingPacketState,
 	addr net.Addr,
 ) (bool, packetOutcome, error) {
-	if prepared.header.Epoch == 0 || !dtlsstate.CommonState(c.conn.state).RRCNegotiated {
+	if c.conn.cidPathMigrationPolicy != CIDPathMigrationRRC ||
+		prepared.header.Epoch == 0 ||
+		!dtlsstate.CommonState(c.conn.state).RRCNegotiated {
 		return false, packetOutcome{
 			responseAlert: &alert.Alert{Level: alert.Fatal, Description: alert.UnexpectedMessage},
 		}, dtlserrors.ErrUnexpectedPostHandshakeMessage
@@ -133,19 +135,78 @@ func (c returnRoutabilityConn) HandleRecord(
 
 func (c returnRoutabilityConn) HandleCandidate(
 	ctx context.Context,
-	enabled, hasCID, latest bool,
+	rrcNegotiated, hasCID, latest bool,
 	addr net.Addr,
 ) {
-	cookie, ok, err := c.conn.rrc.Start(enabled && hasCID && latest, addr, c.conn.RemoteAddr())
+	if !hasCID || !latest {
+		return
+	}
+
+	currentAddr := c.conn.RemoteAddr()
+	if sameNetworkAddress(currentAddr, addr) {
+		return
+	}
+	if !c.useCandidatePath(rrcNegotiated, currentAddr, addr) {
+		return
+	}
+
+	c.startCandidateRRC(ctx, currentAddr, addr)
+}
+
+func (c returnRoutabilityConn) useCandidatePath(
+	rrcNegotiated bool,
+	currentAddr, candidateAddr net.Addr,
+) bool {
+	switch c.conn.cidPathMigrationPolicy {
+	case CIDPathMigrationReject:
+		c.conn.log.Errorf(
+			"rejected CID path migration from %s to %s: path migration is disabled",
+			currentAddr,
+			candidateAddr,
+		)
+	case CIDPathMigrationUnsafe:
+		c.conn.lock.Lock()
+		c.conn.rAddr = candidateAddr
+		c.conn.lock.Unlock()
+	case CIDPathMigrationRRC:
+		if rrcNegotiated {
+			return true
+		}
+		c.conn.log.Errorf(
+			"rejected CID path migration from %s to %s: RRC was not negotiated",
+			currentAddr,
+			candidateAddr,
+		)
+	default:
+		c.conn.log.Errorf(
+			"rejected CID path migration from %s to %s: invalid path migration policy",
+			currentAddr,
+			candidateAddr,
+		)
+	}
+
+	return false
+}
+
+func (c returnRoutabilityConn) startCandidateRRC(ctx context.Context, currentAddr, candidateAddr net.Addr) {
+	cookie, ok, err := c.conn.rrc.Start(true, candidateAddr, currentAddr)
 	if err == nil && ok {
-		err = c.WriteRRC(ctx, addr, protocol.ReturnRoutabilityCheckPathChallenge, cookie)
+		err = c.WriteRRC(ctx, candidateAddr, protocol.ReturnRoutabilityCheckPathChallenge, cookie)
 		if err != nil {
-			c.conn.rrc.Cancel(addr, cookie)
+			c.conn.rrc.Cancel(candidateAddr, cookie)
 		}
 	}
 	if err != nil {
 		c.conn.log.Debugf("unable to start return routability check: %v", err)
 	}
+}
+
+func sameNetworkAddress(a, b net.Addr) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	return a.Network() == b.Network() && a.String() == b.String()
 }
 
 // cidDatagramRouter extracts connection IDs from incoming datagram payloads and

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -323,10 +323,10 @@ type dtlsTestOpts struct {
 	serverOpts []dtls.ServerOption
 }
 
-func withConnectionIDGenerator(g func() []byte) dtlsTestOpts {
+func withConnectionID(g func() []byte) dtlsTestOpts {
 	return dtlsTestOpts{
-		clientOpts: []dtls.ClientOption{dtls.WithConnectionIDGenerator(g)},
-		serverOpts: []dtls.ServerOption{dtls.WithConnectionIDGenerator(g)},
+		clientOpts: []dtls.ClientOption{dtls.WithConnectionID(g, dtls.CIDPathMigrationUnsafe)},
+		serverOpts: []dtls.ServerOption{dtls.WithConnectionID(g, dtls.CIDPathMigrationUnsafe)},
 	}
 }
 
@@ -941,43 +941,43 @@ func TestPionE2ESimpleRSAClientCert(t *testing.T) {
 }
 
 func TestPionE2ESimpleCID(t *testing.T) {
-	testPionE2ESimple(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimple(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2EChaCha20Poly1305CID(t *testing.T) {
-	testPionE2EChaCha20Poly1305(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2EChaCha20Poly1305(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2EChaCha20Poly1305RSACID(t *testing.T) {
-	testPionE2EChaCha20Poly1305RSA(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2EChaCha20Poly1305RSA(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimplePSKCID(t *testing.T) {
-	testPionE2ESimplePSK(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimplePSK(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2EChaCha20Poly1305PSKCID(t *testing.T) {
-	testPionE2EChaCha20Poly1305PSK(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2EChaCha20Poly1305PSK(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2EMTUsCID(t *testing.T) {
-	testPionE2EMTUs(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2EMTUs(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimpleED25519CID(t *testing.T) {
-	testPionE2ESimpleED25519(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimpleED25519(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimpleED25519ClientCertCID(t *testing.T) {
-	testPionE2ESimpleED25519ClientCert(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimpleED25519ClientCert(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimpleECDSAClientCertCID(t *testing.T) {
-	testPionE2ESimpleECDSAClientCert(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimpleECDSAClientCert(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimpleRSAClientCertCID(t *testing.T) {
-	testPionE2ESimpleRSAClientCert(t, serverPion, clientPion, withConnectionIDGenerator(dtls.RandomCIDGenerator(8)))
+	testPionE2ESimpleRSAClientCert(t, serverPion, clientPion, withConnectionID(dtls.RandomCIDGenerator(8)))
 }
 
 func TestPionE2ESimpleClientHelloHook(t *testing.T) {

--- a/examples/dial/cid/main.go
+++ b/examples/dial/cid/main.go
@@ -34,7 +34,7 @@ func main() {
 		dtls.WithPSKIdentityHint([]byte("Pion DTLS Client")),
 		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
-		dtls.WithConnectionIDGenerator(dtls.OnlySendCIDGenerator()),
+		dtls.WithConnectionID(dtls.OnlySendCIDGenerator(), dtls.CIDPathMigrationUnsafe),
 	)
 	util.Check(err)
 	defer func() {

--- a/examples/listen/cid/main.go
+++ b/examples/listen/cid/main.go
@@ -31,7 +31,7 @@ func main() {
 		dtls.WithPSKIdentityHint([]byte("Pion DTLS Server")),
 		dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM_8),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
-		dtls.WithConnectionIDGenerator(dtls.RandomCIDGenerator(8)),
+		dtls.WithConnectionID(dtls.RandomCIDGenerator(8), dtls.CIDPathMigrationUnsafe),
 	)
 	util.Check(err)
 	defer func() {

--- a/flight_test.go
+++ b/flight_test.go
@@ -3453,6 +3453,7 @@ func TestFlight13_1GenerateConnectionIDOffer(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			cfg, calls := testHandshakeConfig13(t), 0
+			cfg.EnableRRC = true
 			if test.generator {
 				cfg.ConnectionIDGenerator = func() []byte {
 					calls++
@@ -3661,6 +3662,7 @@ func TestFlight13_4GenerateNegotiatesConnectionIDs(t *testing.T) { //nolint:cycl
 				serverCID = test.serverCIDs[0]
 			}
 			cfg := testHandshakeConfig13(t)
+			cfg.EnableRRC = true
 			certificate, err := selfsign.GenerateSelfSigned()
 			require.NoError(t, err)
 			cfg.LocalCertificates = []tls.Certificate{certificate}

--- a/internal/config/handshake.go
+++ b/internal/config/handshake.go
@@ -125,6 +125,7 @@ type HandshakeConfig struct {
 	EllipticCurves                []elliptic.Curve
 	InsecureSkipHelloVerify       bool
 	ConnectionIDGenerator         func() []byte
+	EnableRRC                     bool
 	HelloRandomBytesGenerator     func() [handshake.RandomBytesLength]byte
 	Log                           logging.LeveledLogger
 	KeyLogWriter                  io.Writer

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -10,7 +10,6 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
-	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -165,8 +164,9 @@ func flight1Generate(
 	// in which case we are just requesting that the server send us a CID to
 	// use.
 	if cfg.ConnectionIDGenerator != nil {
-		extensions = append(extensions, &extension.ConnectionID{CID: cfg.ConnectionIDGenerator()})
-		extensions = append(extensions, &extension.ReturnRoutabilityCheck{})
+		extensions = dtlsflight.AppendConnectionIDExtensions(
+			extensions, cfg.ConnectionIDGenerator(), cfg.EnableRRC,
+		)
 	}
 
 	clientHello := &handshake.MessageClientHello{
@@ -179,7 +179,9 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := dtlsflight.FinalizeClientHello(
+		clientHello, cfg.ClientHelloMessageHook, cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -375,10 +375,11 @@ func flight3Generate(
 	// exact post-hook value as the default in the second ClientHello.
 	cid, cidOffered := negotiation.ConnectionIDOffer(state.LocalClientHelloSnapshots.Initial())
 	if cfg.ConnectionIDGenerator != nil && cidOffered {
-		extensions = append(extensions, &extension.ConnectionID{CID: cid})
-		if state.LocalClientHelloSnapshots.Initial().Offered(extension.TypeReturnRoutabilityCheck) {
-			extensions = append(extensions, &extension.ReturnRoutabilityCheck{})
-		}
+		extensions = dtlsflight.AppendConnectionIDExtensions(
+			extensions,
+			cid,
+			cfg.EnableRRC && state.LocalClientHelloSnapshots.Initial().Offered(extension.TypeReturnRoutabilityCheck),
+		)
 	}
 
 	clientHello := &handshake.MessageClientHello{
@@ -401,7 +402,9 @@ func flight3Generate(
 		clientHello = retry
 	}
 
-	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := dtlsflight.FinalizeClientHello(
+		clientHello, cfg.ClientHelloMessageHook, cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -99,10 +99,9 @@ func flight4bGenerate(
 		state.NegotiatedProtocol = selectedProto
 	}
 	if cid := serverCIDExtension(state, cfg, offer); cid != nil {
-		extensions = append(extensions, cid)
-		if offer.Offered(extension.TypeReturnRoutabilityCheck) {
-			extensions = append(extensions, &extension.ReturnRoutabilityCheck{})
-		}
+		extensions = dtlsflight.AppendConnectionIDExtensions(
+			extensions, cid.CID, cfg.EnableRRC && offer.Offered(extension.TypeReturnRoutabilityCheck),
+		)
 	}
 
 	cipherSuiteID := uint16(state.CipherSuite.ID())
@@ -115,7 +114,9 @@ func flight4bGenerate(
 		Extensions:        extensions,
 	}
 
-	serverHelloMessage, err = negotiation.FinalizeServerHello(serverHelloMessage, cfg.ServerHelloMessageHook, offer) //nolint:lll
+	serverHelloMessage, err = dtlsflight.FinalizeServerHello(
+		serverHelloMessage, cfg.ServerHelloMessageHook, offer, cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -299,10 +299,9 @@ func flight4Generate(
 	}
 
 	if cid := serverCIDExtension(state, cfg, offer); cid != nil {
-		extensions = append(extensions, cid)
-		if offer.Offered(extension.TypeReturnRoutabilityCheck) {
-			extensions = append(extensions, &extension.ReturnRoutabilityCheck{})
-		}
+		extensions = dtlsflight.AppendConnectionIDExtensions(
+			extensions, cid.CID, cfg.EnableRRC && offer.Offered(extension.TypeReturnRoutabilityCheck),
+		)
 	}
 
 	var pkts []*dtlsflight.Packet
@@ -324,7 +323,9 @@ func flight4Generate(
 		Extensions:        extensions,
 	}
 
-	serverHello, err = negotiation.FinalizeServerHello(serverHello, cfg.ServerHelloMessageHook, offer)
+	serverHello, err = dtlsflight.FinalizeServerHello(
+		serverHello, cfg.ServerHelloMessageHook, offer, cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -4,7 +4,6 @@
 package flight13
 
 import (
-	"bytes"
 	"context"
 	"errors"
 
@@ -132,10 +131,9 @@ func flight1Generate(
 	}
 
 	if cfg.ConnectionIDGenerator != nil {
-		extensions = append(extensions, &extension.ConnectionID{
-			CID: bytes.Clone(cfg.ConnectionIDGenerator()),
-		})
-		extensions = append(extensions, &extension.ReturnRoutabilityCheck{})
+		extensions = dtlsflight.AppendConnectionIDExtensions(
+			extensions, cfg.ConnectionIDGenerator(), cfg.EnableRRC,
+		)
 	}
 
 	// Pre_shared_key must be last extension
@@ -151,7 +149,9 @@ func flight1Generate(
 		Extensions:         extensions,
 	}
 
-	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := dtlsflight.FinalizeClientHello(
+		clientHello, cfg.ClientHelloMessageHook, cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -322,7 +322,9 @@ func flight3Generate(
 	if err != nil {
 		return nil, nil, err
 	}
-	clientHello, snapshot, err := negotiation.FinalizeClientHello(clientHello, flightCtx.cfg.ClientHelloMessageHook)
+	clientHello, snapshot, err := dtlsflight.FinalizeClientHello(
+		clientHello, flightCtx.cfg.ClientHelloMessageHook, flightCtx.cfg.EnableRRC,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -238,10 +238,11 @@ func flight4Generate( //nolint:cyclop
 		if !state.CID.Negotiated {
 			localCID = bytes.Clone(cfg.ConnectionIDGenerator())
 		}
-		serverHelloExtensions = append(serverHelloExtensions, &extension.ConnectionID{CID: bytes.Clone(localCID)})
-		if offer.Offered(extension.TypeReturnRoutabilityCheck) {
-			serverHelloExtensions = append(serverHelloExtensions, &extension.ReturnRoutabilityCheck{})
-		}
+		serverHelloExtensions = dtlsflight.AppendConnectionIDExtensions(
+			serverHelloExtensions,
+			localCID,
+			cfg.EnableRRC && offer.Offered(extension.TypeReturnRoutabilityCheck),
+		)
 	}
 	serverHelloMessage := &handshake.MessageServerHello{
 		Version:           protocol.Version1_2,

--- a/internal/flight/helpers.go
+++ b/internal/flight/helpers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pion/dtls/v3/internal/negotiation"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
+	"github.com/pion/dtls/v3/pkg/protocol/extension"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 )
 
 func FindMatchingSRTPProfile(a, b []dtlsconfig.SRTPProtectionProfile) (dtlsconfig.SRTPProtectionProfile, bool) {
@@ -31,6 +33,66 @@ func CommitSRTP(state *dtlsstate.Common, decision negotiation.SRTPDecision) {
 		state.RemoteSRTPMasterKeyIdentifier = bytes.Clone(decision.PeerMasterKeyIdentifier)
 	}
 	state.SetSRTPProtectionProfile(decision.ProtectionProfile)
+}
+
+// AppendConnectionIDExtensions appends a connection ID and, when enabled, RRC.
+func AppendConnectionIDExtensions(
+	values []extension.Value,
+	cid []byte,
+	enableRRC bool,
+) []extension.Value {
+	values = append(values, &extension.ConnectionID{CID: bytes.Clone(cid)})
+	if enableRRC {
+		values = append(values, &extension.ReturnRoutabilityCheck{})
+	}
+
+	return values
+}
+
+// FinalizeClientHello applies the hook and prevents it from enabling RRC when
+// the configured CID path-migration policy does not permit RRC.
+func FinalizeClientHello(
+	base *handshake.MessageClientHello,
+	hook func(handshake.MessageClientHello) handshake.Message,
+	enableRRC bool,
+) (*handshake.MessageClientHello, negotiation.ClientHelloSnapshot, error) {
+	clientHello, snapshot, err := negotiation.FinalizeClientHello(base, hook)
+	if err != nil || enableRRC || !snapshot.Offered(extension.TypeReturnRoutabilityCheck) {
+		return clientHello, snapshot, err
+	}
+
+	clientHello.Extensions = withoutExtension(clientHello.Extensions, extension.TypeReturnRoutabilityCheck)
+
+	return negotiation.FinalizeClientHello(clientHello, nil)
+}
+
+// FinalizeServerHello applies the hook and prevents it from enabling RRC when
+// the configured CID path-migration policy does not permit RRC.
+func FinalizeServerHello(
+	base *handshake.MessageServerHello,
+	hook func(handshake.MessageServerHello) handshake.Message,
+	offer negotiation.ClientHelloSnapshot,
+	enableRRC bool,
+) (*handshake.MessageServerHello, error) {
+	serverHello, err := negotiation.FinalizeServerHello(base, hook, offer)
+	if err != nil || enableRRC {
+		return serverHello, err
+	}
+
+	serverHello.Extensions = withoutExtension(serverHello.Extensions, extension.TypeReturnRoutabilityCheck)
+
+	return serverHello, nil
+}
+
+func withoutExtension(values []extension.Value, typ extension.Type) []extension.Value {
+	filtered := make([]extension.Value, 0, len(values))
+	for _, value := range values {
+		if value.ExtensionType() != typ {
+			filtered = append(filtered, value)
+		}
+	}
+
+	return filtered
 }
 
 // SignatureSchemeIDs converts negotiated signature algorithms to their

--- a/options.go
+++ b/options.go
@@ -62,6 +62,7 @@ type dtlsConfig struct {
 	EllipticCurves                []elliptic.Curve
 	InsecureSkipVerifyHello       bool
 	ConnectionIDGenerator         func() []byte
+	CIDPathMigrationPolicy        cidPathMigrationPolicy
 	PaddingLengthGenerator        func(uint) uint
 	HelloRandomBytesGenerator     func() [handshake.RandomBytesLength]byte
 	ClientHelloMessageHook        func(handshake.MessageClientHello) handshake.Message
@@ -440,14 +441,34 @@ func WithGetClientCertificate(fn func(*CertificateRequestInfo) (*tls.Certificate
 	})
 }
 
-// WithConnectionIDGenerator sets the connection ID generator.
-// Returns an error if the generator is nil.
-func WithConnectionIDGenerator(fn func() []byte) Option {
+type cidPathMigrationPolicy uint8
+
+const (
+	// CIDPathMigrationReject retains the current peer address and logs CID path
+	// migration attempts. This is required when no reachability validation
+	// strategy is configured
+	// https://datatracker.ietf.org/doc/html/rfc9146#section-6
+	// https://datatracker.ietf.org/doc/html/rfc9147#section-11
+	CIDPathMigrationReject cidPathMigrationPolicy = iota
+	// CIDPathMigrationUnsafe immediately accepts an authenticated CID path.
+	// It is intended only for transports, such as ICE, that validate paths
+	// outside DTLS.
+	CIDPathMigrationUnsafe
+	// CIDPathMigrationRRC validates a CID path with return routability checks
+	// before accepting it. RRC is advertised and negotiated only in this mode.
+	// https://datatracker.ietf.org/doc/html/rfc9853
+	CIDPathMigrationRRC
+)
+
+// WithConnectionID enables connection IDs and configures how authenticated
+// connection ID records may change the peer address.
+func WithConnectionID(generator func() []byte, policy cidPathMigrationPolicy) Option {
 	return sharedOption(func(c *dtlsConfig) error {
-		if fn == nil {
+		if generator == nil {
 			return dtlserrors.ErrNilConnectionIDGenerator
 		}
-		c.ConnectionIDGenerator = fn
+		c.ConnectionIDGenerator = generator
+		c.CIDPathMigrationPolicy = policy
 
 		return nil
 	})

--- a/options_test.go
+++ b/options_test.go
@@ -18,6 +18,7 @@ import (
 	dtlsnet "github.com/pion/dtls/v3/pkg/net"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/transport/v4/dpipe"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -227,11 +228,11 @@ func TestNilCallbackOptionsReturnError(t *testing.T) {
 		require.ErrorIs(t, err, dtlserrors.ErrNilGetClientCertificate)
 	})
 
-	t.Run("NilConnectionIDGenerator", func(t *testing.T) {
-		err := clientOptionsError(t, WithConnectionIDGenerator(nil))
+	t.Run("InvalidConnectionID", func(t *testing.T) {
+		err := clientOptionsError(t, WithConnectionID(nil, CIDPathMigrationReject))
 		require.ErrorIs(t, err, dtlserrors.ErrNilConnectionIDGenerator)
 
-		err = serverOptionsError(t, WithConnectionIDGenerator(nil))
+		err = serverOptionsError(t, WithConnectionID(nil, CIDPathMigrationReject))
 		require.ErrorIs(t, err, dtlserrors.ErrNilConnectionIDGenerator)
 	})
 
@@ -258,6 +259,37 @@ func TestNilCallbackOptionsReturnError(t *testing.T) {
 		err = serverOptionsError(t, WithClientHelloMessageHook(nil))
 		require.ErrorIs(t, err, dtlserrors.ErrNilClientHelloMessageHook)
 	})
+}
+
+func TestWithConnectionID(t *testing.T) {
+	for name, test := range map[string]struct {
+		policy    cidPathMigrationPolicy
+		enableRRC bool
+	}{
+		"Reject": {policy: CIDPathMigrationReject},
+		"Unsafe": {policy: CIDPathMigrationUnsafe},
+		"RRC":    {policy: CIDPathMigrationRRC, enableRRC: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			expectedCID := []byte{0x01, 0x02}
+			cfg, err := buildConfig(WithConnectionID(
+				func() []byte { return expectedCID },
+				test.policy,
+			))
+			require.NoError(t, err)
+			assert.Equal(t, expectedCID, cfg.ConnectionIDGenerator())
+			assert.Equal(t, test.policy, cfg.CIDPathMigrationPolicy)
+
+			values, err := newConnConfigValues(cfg)
+			require.NoError(t, err)
+			assert.Equal(t, test.policy, values.cidPathMigrationPolicy)
+			assert.Equal(t, test.enableRRC, newHandshakeConfig(cfg, values, nil).EnableRRC)
+		})
+	}
+
+	cfg, err := buildConfig()
+	require.NoError(t, err)
+	assert.Equal(t, CIDPathMigrationReject, cfg.CIDPathMigrationPolicy)
 }
 
 // TestServerOnlyNilCallbackOptionsReturnError verifies server-only options


### PR DESCRIPTION
#### Description
This removes `WithConnectionIDGenerator` and adds `WithConnectionID(generator, policy)`.
Policy controls the CID migration policy, as required by:
https://datatracker.ietf.org/doc/html/rfc9146#section-6 and  https://datatracker.ietf.org/doc/html/rfc9147#section-11

> There is a strategy for ensuring that the new peer address is able to receive and process DTLS records. No strategy is mandated by this specification, but see note (*) below.

Pion@v3 assumed that applications that enable CID use a transport like ICE with CID validation, now we support RRC #1026 native DTLS applications can have path migration without using another transport.

This adds 3 different polices when CID is enabled:
1. migration is rejected and disabled, but CID is still enabled.
2. migration is enabled and not verified for applications that use transports like ICE to verify paths.
3. RRC-based migration, where we use RRC to ensure that the new peer address is able to receive and process DTLS records. (RRC is only sent and negotiated if this option is used).


I did some refactors to avoid adding multiple conditions in 1.2 and 1.3 flight codes. and extracted the CID code to common helpers.

(Interop will fail because of the API change).