### PR TITLE
Drop the 13 suffix from CiphertextRecord13

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1567,8 +1567,8 @@ func (c *Conn) queueableCiphertextEpoch(epochLow uint8, remoteEpoch uint16) bool
 func (c *Conn) unmarshalCiphertextRecord(
 	buf []byte,
 	datagramContainsCID bool,
-) (recordlayer.CiphertextRecord13, error) {
-	record := recordlayer.CiphertextRecord13{}
+) (recordlayer.CiphertextRecord, error) {
+	record := recordlayer.CiphertextRecord{}
 	hasCID := buf[0]&recordlayer.UnifiedHeaderCIDBit != 0
 	localCID := dtlsstate.CommonState(c.state).LocalConnectionIDForInboundRecords()
 	cidExpected, cidAllowed, err := c.ciphertextCIDPolicy(localCID)
@@ -1611,7 +1611,7 @@ func (c *Conn) ciphertextCIDPolicy(localCID []byte) (expected, allowed bool, err
 }
 
 func (c *Conn) openCiphertextRecord(
-	record recordlayer.CiphertextRecord13,
+	record recordlayer.CiphertextRecord,
 ) (recordlayer.InnerPlaintext, uint64, uint16, error) {
 	var candidateBuffer [4]*dtlsstate.TrafficGeneration
 	candidates, remoteEpoch, err := c.readTrafficCandidates(record.Header.EpochLow, candidateBuffer[:0])
@@ -1667,7 +1667,7 @@ func (c *Conn) readTrafficCandidates(
 }
 
 func (c *Conn) openCiphertextWithGeneration(
-	record recordlayer.CiphertextRecord13,
+	record recordlayer.CiphertextRecord,
 	generation *dtlsstate.TrafficGeneration,
 ) (recordlayer.InnerPlaintext, uint64, error) {
 	clearHeader, err := generation.Protection.UnmaskSequenceNumber(record.Header, record.EncryptedRecord)

--- a/conn_test.go
+++ b/conn_test.go
@@ -3819,7 +3819,7 @@ func TestReadAndBufferNoFSMQueuesExactRecordCopy(t *testing.T) {
 			LocalVersion: protocol.Version1_3,
 		}},
 	}
-	rawPacket, err := (&recordlayer.CiphertextRecord13{
+	rawPacket, err := (&recordlayer.CiphertextRecord{
 		Header: recordlayer.UnifiedHeader{
 			EpochLow:       uint8(dtlsflight13.EpochHandshake),
 			SequenceNumber: 1,
@@ -5002,26 +5002,26 @@ func TestOpenCiphertextRecordHandshake(t *testing.T) {
 func TestOpenCiphertextRecordRejectsInvalidRecords(t *testing.T) {
 	tests := []struct {
 		name    string
-		mutate  func(*Conn, *recordlayer.CiphertextRecord13)
+		mutate  func(*Conn, *recordlayer.CiphertextRecord)
 		wantErr error
 	}{
 		{
 			name: "wrong sequence number",
-			mutate: func(conn *Conn, _ *recordlayer.CiphertextRecord13) {
+			mutate: func(conn *Conn, _ *recordlayer.CiphertextRecord) {
 				conn.updateRemoteSequenceNumber(dtlsflight13.EpochHandshake, 0xffff)
 			},
 			wantErr: dtlserrors.ErrDecryptPacket,
 		},
 		{
 			name: "wrong epoch",
-			mutate: func(_ *Conn, record *recordlayer.CiphertextRecord13) {
+			mutate: func(_ *Conn, record *recordlayer.CiphertextRecord) {
 				record.Header.EpochLow ^= 0x01
 			},
 			wantErr: dtlserrors.ErrInvalidEpoch,
 		},
 		{
 			name: "tampered ciphertext",
-			mutate: func(_ *Conn, record *recordlayer.CiphertextRecord13) {
+			mutate: func(_ *Conn, record *recordlayer.CiphertextRecord) {
 				record.EncryptedRecord[0] ^= 0x80
 			},
 			wantErr: dtlserrors.ErrDecryptPacket,
@@ -5230,7 +5230,7 @@ func sealTestProtectedHandshakeRecord(
 	t *testing.T,
 	protection ciphersuite.RecordProtection13,
 	plaintext []byte,
-) recordlayer.CiphertextRecord13 {
+) recordlayer.CiphertextRecord {
 	t.Helper()
 
 	return sealTestProtectedHandshakeRecordWithSequence(t, protection, plaintext, 0)
@@ -5241,7 +5241,7 @@ func sealTestProtectedHandshakeRecordWithSequence(
 	protection ciphersuite.RecordProtection13,
 	plaintext []byte,
 	sequenceNumber uint64,
-) recordlayer.CiphertextRecord13 {
+) recordlayer.CiphertextRecord {
 	t.Helper()
 
 	record, err := protection.Seal(
@@ -5280,7 +5280,7 @@ func unmarshalCiphertextRecordForTest(
 	t *testing.T,
 	raw []byte,
 	cidLength int,
-) recordlayer.CiphertextRecord13 {
+) recordlayer.CiphertextRecord {
 	t.Helper()
 
 	records, err := recordlayer.UnpackDatagram(raw, recordlayer.UnpackDatagramConfig{
@@ -5290,7 +5290,7 @@ func unmarshalCiphertextRecordForTest(
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 
-	record := recordlayer.CiphertextRecord13{}
+	record := recordlayer.CiphertextRecord{}
 	if records[0][0]&recordlayer.UnifiedHeaderCIDBit != 0 {
 		record.Header.ConnectionID = make([]byte, cidLength)
 	}
@@ -5766,7 +5766,7 @@ func sealTrafficKeyTestRecord(
 	epoch uint16,
 	contentType protocol.ContentType,
 	plaintext []byte,
-) recordlayer.CiphertextRecord13 {
+) recordlayer.CiphertextRecord {
 	t.Helper()
 
 	record, err := protection.Seal(

--- a/connection_id_test.go
+++ b/connection_id_test.go
@@ -216,7 +216,7 @@ func TestCIDDatagramRouter13(t *testing.T) {
 	makeRecord := func(t *testing.T, connectionID []byte, sequenceNumber uint16) []byte {
 		t.Helper()
 
-		record, err := (&recordlayer.CiphertextRecord13{
+		record, err := (&recordlayer.CiphertextRecord{
 			Header: recordlayer.UnifiedHeader{
 				ConnectionID:   connectionID,
 				SequenceNumber: sequenceNumber,
@@ -325,7 +325,7 @@ func TestCIDConnIdentifier(t *testing.T) {
 		},
 	}).Marshal()
 	assert.NoError(t, err)
-	dtls13Ciphertext, err := (&recordlayer.CiphertextRecord13{
+	dtls13Ciphertext, err := (&recordlayer.CiphertextRecord{
 		Header:          recordlayer.UnifiedHeader{SequenceNumber: 1},
 		EncryptedRecord: make([]byte, 16),
 	}).Marshal()

--- a/internal/ciphersuite/tls_13.go
+++ b/internal/ciphersuite/tls_13.go
@@ -26,7 +26,7 @@ type RecordProtection13 interface {
 		sequenceNumber uint64,
 		contentType protocol.ContentType,
 		plaintext []byte,
-	) (recordlayer.CiphertextRecord13, error)
+	) (recordlayer.CiphertextRecord, error)
 	Open(
 		header recordlayer.UnifiedHeader,
 		sequenceNumber uint64,

--- a/internal/ciphersuite/tls_13_record_protection.go
+++ b/internal/ciphersuite/tls_13_record_protection.go
@@ -109,9 +109,9 @@ func (r *recordTrafficProtection13) seal(
 	sequenceNumber uint64,
 	contentType protocol.ContentType,
 	plaintext []byte,
-) (recordlayer.CiphertextRecord13, error) {
+) (recordlayer.CiphertextRecord, error) {
 	if len(plaintext) > maxDTLSPlaintextRecordLen13 {
-		return recordlayer.CiphertextRecord13{}, dtlserrors.ErrInvalidPacketLength
+		return recordlayer.CiphertextRecord{}, dtlserrors.ErrInvalidPacketLength
 	}
 
 	innerPlaintext, err := (&recordlayer.InnerPlaintext{
@@ -119,12 +119,12 @@ func (r *recordTrafficProtection13) seal(
 		RealType: contentType,
 	}).Marshal()
 	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
+		return recordlayer.CiphertextRecord{}, err
 	}
 
 	ciphertextLen := len(innerPlaintext) + r.aead.Overhead()
 	if ciphertextLen > maxDTLSCiphertextRecordLen13 {
-		return recordlayer.CiphertextRecord13{}, dtlserrors.ErrInvalidPacketLength
+		return recordlayer.CiphertextRecord{}, dtlserrors.ErrInvalidPacketLength
 	}
 
 	header.SeqBit = true
@@ -132,16 +132,16 @@ func (r *recordTrafficProtection13) seal(
 	header.LengthBit = true
 	additionalData, err := header.Marshal()
 	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
+		return recordlayer.CiphertextRecord{}, err
 	}
 
 	nonce, err := recordNonce13(r.iv, sequenceNumber)
 	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
+		return recordlayer.CiphertextRecord{}, err
 	}
 
 	// Sequence-number masking is kept separate until DTLS 1.3 record writer integration.
-	return recordlayer.CiphertextRecord13{
+	return recordlayer.CiphertextRecord{
 		Header:          header,
 		EncryptedRecord: r.aead.Seal(nil, nonce, innerPlaintext, additionalData),
 	}, nil
@@ -200,15 +200,15 @@ func (r *recordTrafficProtection13) Seal(
 	sequenceNumber uint64,
 	contentType protocol.ContentType,
 	plaintext []byte,
-) (recordlayer.CiphertextRecord13, error) {
+) (recordlayer.CiphertextRecord, error) {
 	header.SequenceNumber = uint16(sequenceNumber & 0xffff)
 	record, err := r.seal(header, sequenceNumber, contentType, plaintext)
 	if err != nil {
-		return recordlayer.CiphertextRecord13{}, err
+		return recordlayer.CiphertextRecord{}, err
 	}
 
 	if err = r.maskSequenceNumber(&record.Header, record.EncryptedRecord); err != nil {
-		return recordlayer.CiphertextRecord13{}, err
+		return recordlayer.CiphertextRecord{}, err
 	}
 
 	return record, nil

--- a/internal/ciphersuite/tls_13_record_protection_test.go
+++ b/internal/ciphersuite/tls_13_record_protection_test.go
@@ -42,7 +42,7 @@ func (r *recordProtectionPair13) seal(
 	sequenceNumber uint64,
 	contentType protocol.ContentType,
 	plaintext []byte,
-) (recordlayer.CiphertextRecord13, error) {
+) (recordlayer.CiphertextRecord, error) {
 	return r.local.seal(header, sequenceNumber, contentType, plaintext)
 }
 
@@ -396,7 +396,7 @@ func assertTLS13RecordProtectionKnownVector(t *testing.T, vector tls13KnownVecto
 	require.NoError(t, applySequenceNumberMask13(&maskedHeader, mask))
 	assert.Equal(t, vector.expectedMaskedSequenceNumber, maskedHeader.SequenceNumber)
 
-	maskedRaw, err := (&recordlayer.CiphertextRecord13{
+	maskedRaw, err := (&recordlayer.CiphertextRecord{
 		Header:          maskedHeader,
 		EncryptedRecord: record.EncryptedRecord,
 	}).Marshal()

--- a/pkg/protocol/recordlayer/recordlayer.go
+++ b/pkg/protocol/recordlayer/recordlayer.go
@@ -264,14 +264,14 @@ func unpackDatagramRecord(buf []byte, headerSize int) ([]byte, int, error) {
 	return buf[:consumed], consumed, nil
 }
 
-// CiphertextRecord13 implements DTLSCiphertext for protected records.
-type CiphertextRecord13 struct {
+// CiphertextRecord implements DTLSCiphertext for protected records.
+type CiphertextRecord struct {
 	Header          UnifiedHeader
 	EncryptedRecord []byte
 }
 
 // Marshal encodes a DTLS 1.3 DTLSCiphertext record.
-func (r *CiphertextRecord13) Marshal() ([]byte, error) {
+func (r *CiphertextRecord) Marshal() ([]byte, error) {
 	if !isValidDTLSCiphertextRecordLen(len(r.EncryptedRecord)) {
 		return nil, ErrInvalidPacketLength
 	}

--- a/pkg/protocol/recordlayer/recordlayer_test.go
+++ b/pkg/protocol/recordlayer/recordlayer_test.go
@@ -451,7 +451,7 @@ func fixedRecordForScannerTest(
 func unifiedRecordForScannerTest(t *testing.T, cid []byte, sequenceNumber uint8) []byte {
 	t.Helper()
 
-	raw, err := (&CiphertextRecord13{
+	raw, err := (&CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   cid,
 			SequenceNumber: uint16(sequenceNumber),
@@ -465,7 +465,7 @@ func unifiedRecordForScannerTest(t *testing.T, cid []byte, sequenceNumber uint8)
 
 func TestCiphertextRecord13RoundTrip(t *testing.T) {
 	encryptedRecord := ciphertext13Payload(0xde)
-	record := &CiphertextRecord13{
+	record := &CiphertextRecord{
 		Header: UnifiedHeader{
 			EpochLow:       3,
 			SequenceNumber: 0xaabb,
@@ -496,7 +496,7 @@ func TestCiphertextRecord13RoundTrip(t *testing.T) {
 
 func TestCiphertextRecord13MarshalRefreshesLength(t *testing.T) {
 	encryptedRecord := ciphertext13Payload(0xaa)
-	record := &CiphertextRecord13{
+	record := &CiphertextRecord{
 		Header: UnifiedHeader{
 			SequenceNumber: 0x01,
 			Length:         4,
@@ -514,7 +514,7 @@ func TestCiphertextRecord13MarshalRefreshesLength(t *testing.T) {
 
 func TestCiphertextRecord13MarshalRejectsShortEncryptedRecord(t *testing.T) {
 	for recordLen := range minDTLSCiphertextRecordLen {
-		record := &CiphertextRecord13{
+		record := &CiphertextRecord{
 			EncryptedRecord: make([]byte, recordLen),
 		}
 
@@ -524,7 +524,7 @@ func TestCiphertextRecord13MarshalRejectsShortEncryptedRecord(t *testing.T) {
 }
 
 func TestCiphertextRecord13RejectsOversizedEncryptedRecord(t *testing.T) {
-	record := &CiphertextRecord13{
+	record := &CiphertextRecord{
 		EncryptedRecord: make([]byte, maxDTLSCiphertextRecordLen+1),
 	}
 
@@ -564,7 +564,7 @@ func TestUnpackDatagramPlaintext13(t *testing.T) {
 
 func TestUnpackDatagramCiphertext13(t *testing.T) {
 	encryptedRecord := ciphertext13Payload(0xaa)
-	ciphertextWithLength := &CiphertextRecord13{
+	ciphertextWithLength := &CiphertextRecord{
 		Header: UnifiedHeader{
 			SequenceNumber: 0x01,
 		},
@@ -611,7 +611,7 @@ func TestUnpackDatagramAutoTargetAllowsMixedFixedAndUnified(t *testing.T) {
 	plaintextRaw, err := plaintext.Marshal()
 	require.NoError(t, err)
 
-	ciphertext := &CiphertextRecord13{
+	ciphertext := &CiphertextRecord{
 		Header: UnifiedHeader{
 			SequenceNumber: 0x01,
 		},
@@ -795,7 +795,7 @@ func TestUnpackDatagramUnifiedWithCID(t *testing.T) {
 	plaintextRaw, err := plaintext.Marshal()
 	require.NoError(t, err)
 
-	ciphertext := &CiphertextRecord13{
+	ciphertext := &CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   []byte{0x01, 0x02, 0x03, 0x04},
 			SequenceNumber: 0x01,
@@ -812,7 +812,7 @@ func TestUnpackDatagramUnifiedWithCID(t *testing.T) {
 }
 
 func TestUnpackDatagramAllowsCIDLessUnifiedWithConfiguredCIDLength(t *testing.T) {
-	ciphertext := &CiphertextRecord13{
+	ciphertext := &CiphertextRecord{
 		Header: UnifiedHeader{
 			SequenceNumber: 0x01,
 		},
@@ -827,7 +827,7 @@ func TestUnpackDatagramAllowsCIDLessUnifiedWithConfiguredCIDLength(t *testing.T)
 }
 
 func TestUnpackDatagramRejectsUnifiedCIDWithoutConfiguredLength(t *testing.T) {
-	ciphertext := &CiphertextRecord13{
+	ciphertext := &CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   []byte{0x01, 0x02, 0x03, 0x04},
 			SequenceNumber: 0x01,
@@ -847,7 +847,7 @@ func TestUnpackDatagramRejectsTruncatedUnifiedCID(t *testing.T) {
 }
 
 func TestUnpackDatagramDoesNotApplyCIDAssociationPolicy(t *testing.T) {
-	first := &CiphertextRecord13{
+	first := &CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   []byte{0x01, 0x02, 0x03, 0x04},
 			SequenceNumber: 0x01,
@@ -857,7 +857,7 @@ func TestUnpackDatagramDoesNotApplyCIDAssociationPolicy(t *testing.T) {
 	firstRaw, err := first.Marshal()
 	require.NoError(t, err)
 
-	second := &CiphertextRecord13{
+	second := &CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   []byte{0x04, 0x03, 0x02, 0x01},
 			SequenceNumber: 0x02,
@@ -911,7 +911,7 @@ func TestUnpackDatagramAllRecordForms(t *testing.T) {
 	cidRaw := append([]byte{}, cidHeaderRaw...)
 	cidRaw = append(cidRaw, 0xb2)
 
-	unified := &CiphertextRecord13{
+	unified := &CiphertextRecord{
 		Header: UnifiedHeader{
 			ConnectionID:   cid,
 			SequenceNumber: 3,


### PR DESCRIPTION
#### Description
Now that https://github.com/pion/dtls/pull/1056 is merged it doesn't make sense to keep the 13 suffix for CiphertextRecord13 

Part of #1007 