### PR TITLE
Add accessor for negotiated DTLS role + version

### DIFF
--- a/state.go
+++ b/state.go
@@ -144,6 +144,32 @@ func generateState13(internalState *dtlsstate.State13) (*State, error) {
 	}, nil
 }
 
+// NegotiatedVersion returns the DTLS version negotiated for this connection.
+func (s *State) NegotiatedVersion() protocol.Version {
+	return s.version
+}
+
+// Role indicates which side of the DTLS handshake an endpoint took.
+type Role uint8
+
+const (
+	// RoleUnknown is the zero value, used when the role is not yet resolved.
+	RoleUnknown Role = iota
+	// RoleClient is the endpoint that sends the ClientHello.
+	RoleClient
+	// RoleServer is the endpoint that answers with the ServerHello.
+	RoleServer
+)
+
+// Role reports which side of the handshake the local endpoint took.
+func (s *State) Role() Role {
+	if s.isClient {
+		return RoleClient
+	}
+
+	return RoleServer
+}
+
 func (s *State) serialize() (*serializedState, error) {
 	// 0 (TLS_NULL_WITH_NULL_NULL) is never negotiated, so it signals an unset suite.
 	if s.CipherSuiteID == 0 {

--- a/state_test.go
+++ b/state_test.go
@@ -5,12 +5,16 @@ package dtls
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"testing"
+	"time"
 
 	"github.com/pion/dtls/v3/internal/ciphersuite"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	dtlsnet "github.com/pion/dtls/v3/pkg/net"
 	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/transport/v4/dpipe"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,4 +68,62 @@ func TestStatePreservesReturnRoutabilityCheck(t *testing.T) {
 	var restored State
 	restored.deserialize(*serialized)
 	require.True(t, restored.rrcNegotiated)
+}
+
+// TestConnectionStateRoleAndVersion negotiates a real connection and checks that
+// both peers report the role they actually took and the version they agreed on.
+func TestConnectionStateRoleAndVersion(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version protocol.Version
+	}{
+		{"DTLS1.2", protocol.Version1_2},
+		{"DTLS1.3", protocol.Version1_3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			ca, cb := dpipe.Pipe()
+			type result struct {
+				c   *Conn
+				err error
+			}
+			resultCh := make(chan result, 1)
+
+			go func() {
+				client, err := testClient(ctx, dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
+					[]ClientOption{
+						WithMinVersion(test.version),
+						WithMaxVersion(test.version),
+					}, true)
+				resultCh <- result{client, err}
+			}()
+
+			server, err := testServer(ctx, dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(),
+				[]ServerOption{
+					WithMinVersion(test.version),
+					WithMaxVersion(test.version),
+				}, true)
+			require.NoError(t, err)
+
+			res := <-resultCh
+			require.NoError(t, res.err)
+
+			defer func() {
+				require.NoError(t, res.c.Close())
+				require.NoError(t, server.Close())
+			}()
+
+			clientState, ok := res.c.ConnectionState()
+			require.True(t, ok)
+			serverState, ok := server.ConnectionState()
+			require.True(t, ok)
+
+			require.Equal(t, RoleClient, clientState.Role())
+			require.Equal(t, RoleServer, serverState.Role())
+			require.True(t, clientState.NegotiatedVersion().Equal(test.version))
+			require.True(t, serverState.NegotiatedVersion().Equal(test.version))
+		})
+	}
 }


### PR DESCRIPTION
useful for stats and SPED

(note https://github.com/w3c/webrtc-stats/issues/820 - I'd rather not expose "unknown")