### PR TITLE
Fix unpack error missmatch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1399,7 +1399,7 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 		return datagramProcessingSummary{}, netError(err)
 	}
 
-	pkts, unpackErr := c.unpackDatagram(b[:i])
+	pkts, err := c.unpackDatagram(b[:i])
 	if len(pkts) == 0 {
 		// discard missing negotiated CID without terminating the handshake.
 		if errors.Is(err, dtlserrors.ErrInvalidCiphertextHeader) {
@@ -1408,14 +1408,15 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 			return datagramProcessingSummary{}, nil
 		}
 
-		return datagramProcessingSummary{}, unpackErr
+		return datagramProcessingSummary{}, err
 	}
 	datagramContainsCID := recordsContainCID(pkts)
 	bufferLease.datagramContainsCID = datagramContainsCID
 
 	var summary datagramProcessingSummary
 	for _, p := range pkts {
-		outcome, err := c.processIncomingPacket(ctx, p, rAddr, &bufferLease, datagramContainsCID)
+		var outcome packetOutcome
+		outcome, err = c.processIncomingPacket(ctx, p, rAddr, &bufferLease, datagramContainsCID)
 		if err != nil {
 			return datagramProcessingSummary{}, err
 		}
@@ -1426,8 +1427,8 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 		}
 	}
 
-	if unpackErr != nil {
-		c.log.Debugf("discarded malformed datagram suffix: %v", unpackErr)
+	if err != nil {
+		c.log.Debugf("discarded malformed datagram suffix: %v", err)
 	}
 
 	return summary, nil

--- a/conn_test.go
+++ b/conn_test.go
@@ -535,6 +535,139 @@ func TestHandshakeWithInvalidRecord(t *testing.T) {
 	assert.NoError(t, errClient.err)
 }
 
+func TestHandshakeDiscardsProtectedRecordWithoutRequiredCID(t *testing.T) {
+	lim := test.TimeOut(20 * time.Second)
+	defer lim.Stop()
+
+	report := test.CheckRoutines(t)
+	defer report()
+
+	tests := []struct {
+		name    string
+		version protocol.Version
+	}{
+		{name: "DTLS12", version: protocol.Version1_2},
+		{name: "DTLS13", version: protocol.Version1_3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			clientCID := []byte("client-cid")
+			serverCID := []byte("server-cid")
+
+			type result struct {
+				c   *Conn
+				err error
+			}
+			clientResult := make(chan result, 1)
+			injectionResult := make(chan error, 1)
+			ca, cb := dpipe.Pipe()
+			clientTransport := &connWithCallback{Conn: ca}
+
+			var injected atomic.Bool
+			clientTransport.onWrite = func(datagram []byte) {
+				records, _ := recordlayer.UnpackDatagram(datagram, recordlayer.UnpackDatagramConfig{
+					TargetVersion: tt.version,
+					CIDLength:     len(serverCID),
+				})
+				for _, record := range records {
+					if !recordsContainCID([][]byte{record}) || !injected.CompareAndSwap(false, true) {
+						continue
+					}
+
+					var invalidRecord []byte
+					if tt.version.Equal(protocol.Version1_3) {
+						invalidRecord = append(invalidRecord, record[0]&^recordlayer.UnifiedHeaderCIDBit)
+						invalidRecord = append(invalidRecord, record[1+len(serverCID):]...)
+					} else {
+						invalidRecord = append(invalidRecord, byte(protocol.ContentTypeHandshake))
+						invalidRecord = append(invalidRecord, record[1:11]...)
+						invalidRecord = append(invalidRecord, record[11+len(serverCID):]...)
+					}
+
+					strictRecords, strictErr := recordlayer.UnpackDatagram(
+						invalidRecord,
+						recordlayer.UnpackDatagramConfig{
+							TargetVersion: tt.version,
+							CIDLength:     len(serverCID),
+							CIDRequired:   true,
+						},
+					)
+					if len(strictRecords) != 0 || !errors.Is(strictErr, dtlserrors.ErrInvalidCiphertextHeader) {
+						injectionResult <- fmt.Errorf(
+							"CID-less clone was not rejected by strict scanner: records=%d, err=%w",
+							len(strictRecords),
+							strictErr,
+						)
+
+						return
+					}
+
+					_, err := ca.Write(invalidRecord)
+					injectionResult <- err
+
+					return
+				}
+			}
+
+			go func() {
+				client, err := testClient(
+					ctx,
+					dtlsnet.PacketConnFromConn(clientTransport),
+					clientTransport.RemoteAddr(),
+					[]ClientOption{
+						WithMinVersion(tt.version),
+						WithMaxVersion(tt.version),
+						WithConnectionID(func() []byte { return bytes.Clone(clientCID) }, CIDPathMigrationReject),
+					},
+					true,
+				)
+				clientResult <- result{client, err}
+			}()
+
+			server, serverErr := testServer(
+				ctx,
+				dtlsnet.PacketConnFromConn(cb),
+				cb.RemoteAddr(),
+				[]ServerOption{
+					WithMinVersion(tt.version),
+					WithMaxVersion(tt.version),
+					WithConnectionID(func() []byte { return bytes.Clone(serverCID) }, CIDPathMigrationReject),
+				},
+				true,
+			)
+			client := <-clientResult
+
+			defer func() {
+				if server != nil {
+					assert.NoError(t, server.Close())
+				}
+				if client.c != nil {
+					assert.NoError(t, client.c.Close())
+				}
+			}()
+
+			require.NoError(t, serverErr)
+			require.NoError(t, client.err)
+			require.True(t, injected.Load(), "handshake did not send a CID-bearing protected record")
+			require.NoError(t, <-injectionResult)
+
+			payload := []byte("connection survived CID-less protected record")
+			n, err := client.c.Write(payload)
+			require.NoError(t, err)
+			require.Equal(t, len(payload), n)
+			require.NoError(t, server.SetReadDeadline(time.Now().Add(time.Second)))
+			readBuffer := make([]byte, len(payload))
+			n, err = server.Read(readBuffer)
+			require.NoError(t, err)
+			require.Equal(t, payload, readBuffer[:n])
+		})
+	}
+}
+
 func TestExportKeyingMaterial(t *testing.T) {
 	// Check for leaking routines
 	report := test.CheckRoutines(t)


### PR DESCRIPTION
#### Description
When i was working on #1056  govet was complaining about err shadow so I renamed the error returned from unpackDatagram to unpackErrr and didn't update the cid discard condition which prevented the condition from ever being met, my local interop for different CID issues was failing because of this and other issues in #1053 and I didn't pay attention because I thought it was an old issue.


This was was reported by @fippo 

