### PR TITLE
Replace Packet with outbound record intent

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -130,7 +130,7 @@ type handshakeStart struct {
 	flight12  dtlsflight12.Flight
 	flight13  dtlsflight13.Flight
 	fsmState  dtlshandshake.State
-	flights   []*dtlsflight.Packet
+	flights   []*dtlsflight.Outbound
 	postSetup func(context.Context)
 }
 
@@ -144,7 +144,7 @@ func (c handshakeConn) Notify(ctx context.Context, level alert.Level, desc alert
 
 func (c handshakeConn) WritePackets(
 	ctx context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*dtlshandshake.WriteResult, error) {
 	return c.conn.writePacketsWithResult(ctx, pkts)
 }
@@ -601,7 +601,7 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	ctx, cancel := c.contextWithClose(c.writeDeadline)
 	defer cancel()
 
-	err := c.writeApplicationData(ctx, []*dtlsflight.Packet{
+	err := c.writeApplicationData(ctx, []*dtlsflight.Outbound{
 		c.newApplicationDataPacket(payload),
 	})
 	if errors.Is(err, context.Canceled) && errors.Is(context.Cause(ctx), context.DeadlineExceeded) {
@@ -614,20 +614,14 @@ func (c *Conn) Write(payload []byte) (int, error) {
 	return len(payload), nil
 }
 
-func (c *Conn) newApplicationDataPacket(payload []byte) *dtlsflight.Packet {
-	return &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &protocol.ApplicationData{
-				// The DTLS 1.3 FSM may retain this packet after Write returns on
-				// cancellation, so take ownership before queueing it.
-				Data: bytes.Clone(payload),
-			},
+func (c *Conn) newApplicationDataPacket(payload []byte) *dtlsflight.Outbound {
+	return &dtlsflight.Outbound{
+		Content: &protocol.ApplicationData{
+			// The DTLS 1.3 FSM may retain this packet after Write returns on
+			// cancellation, so take ownership before queueing it.
+			Data: bytes.Clone(payload),
 		},
-		ShouldWrapCID: c.state.ShouldWrapConnectionID(),
-		ShouldEncrypt: true,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 }
 
@@ -695,7 +689,7 @@ func (c *Conn) normalizeKeyUpdateError(ctx, operationCtx context.Context, err er
 	return err
 }
 
-func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Packet) error {
+func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Outbound) error {
 	if dtlsstate.CommonState(c.state).LocalVersion.Equal(protocol.Version1_3) {
 		writer, ok := c.fsm.(dtlshandshake.ApplicationDataWriter)
 		if !ok {
@@ -707,7 +701,7 @@ func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Pack
 
 	epoch := dtlsstate.CommonState(c.state).LocalEpoch()
 	for _, pkt := range pkts {
-		pkt.Record.Header.Epoch = epoch
+		pkt.Epoch = epoch
 	}
 	_, err := c.writePacketsWithResult(ctx, pkts)
 
@@ -760,7 +754,7 @@ func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
 	return bytes.Clone(common.RemoteSRTPMasterKeyIdentifier), true
 }
 
-func (c *Conn) writePackets(ctx context.Context, pkts []*dtlsflight.Packet) error {
+func (c *Conn) writePackets(ctx context.Context, pkts []*dtlsflight.Outbound) error {
 	_, err := c.writePacketsWithResult(ctx, pkts)
 
 	return err
@@ -768,7 +762,7 @@ func (c *Conn) writePackets(ctx context.Context, pkts []*dtlsflight.Packet) erro
 
 func (c *Conn) writePacketsWithResult(
 	ctx context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*dtlshandshake.WriteResult, error) {
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()
@@ -778,7 +772,7 @@ func (c *Conn) writePacketsWithResult(
 
 func (c *Conn) writePacketsWithResultLocked(
 	ctx context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*dtlshandshake.WriteResult, error) {
 	datagrams, rAddr, err := c.prepareRawPacketsTracked(pkts)
 	if err != nil {
@@ -805,7 +799,7 @@ type preparedDatagram struct {
 	tracked []dtlshandshake.SentHandshakeRecord
 }
 
-func (c *Conn) prepareRawPacketsTracked(pkts []*dtlsflight.Packet) ([]preparedDatagram, net.Addr, error) {
+func (c *Conn) prepareRawPacketsTracked(pkts []*dtlsflight.Outbound) ([]preparedDatagram, net.Addr, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -820,10 +814,10 @@ func (c *Conn) prepareRawPacketsTracked(pkts []*dtlsflight.Packet) ([]preparedDa
 	return c.compactPreparedRecords(records), c.rAddr, nil
 }
 
-func (c *Conn) prepareRecordsTracked(pkts []*dtlsflight.Packet) ([]preparedRecord, error) {
+func (c *Conn) prepareRecordsTracked(pkts []*dtlsflight.Outbound) ([]preparedRecord, error) {
 	var records []preparedRecord
 	for _, pkt := range pkts {
-		prepared, err := c.prepareRecordsFromPacket(pkt)
+		prepared, err := c.prepareOutbound(pkt)
 		if err != nil {
 			return nil, err
 		}
@@ -833,59 +827,39 @@ func (c *Conn) prepareRecordsTracked(pkts []*dtlsflight.Packet) ([]preparedRecor
 	return records, nil
 }
 
-func (c *Conn) prepareRecordsFromPacket(pkt *dtlsflight.Packet) ([]preparedRecord, error) {
-	handshakeRecord, ok := pkt.Record.Content.(*handshake.Handshake)
-	if ok && dtlsstate.CommonState(c.state).LocalVersion.Equal(protocol.Version1_3) && pkt.ShouldEncrypt {
-		if err := c.cacheHandshakePacket(pkt, handshakeRecord); err != nil {
+func (c *Conn) prepareOutbound(outbound *dtlsflight.Outbound) ([]preparedRecord, error) {
+	if outbound == nil || outbound.Content == nil || !validProtection(outbound.Protection) {
+		return nil, dtlserrors.ErrInvalidPacket
+	}
+	if dtlsHandshake, ok := outbound.Content.(*handshake.Handshake); ok {
+		if err := c.cacheHandshake(outbound, dtlsHandshake); err != nil {
 			return nil, err
 		}
 
-		return c.processProtectedHandshakePacketTracked(pkt, handshakeRecord)
+		return c.prepareHandshakeRecords(outbound, dtlsHandshake)
 	}
 
-	rawPackets, err := c.prepareRawPacket(pkt)
-	if err != nil {
-		return nil, err
-	}
-	records := make([]preparedRecord, 0, len(rawPackets))
-	for _, raw := range rawPackets {
-		records = append(records, preparedRecord{raw: raw})
-	}
-
-	return records, nil
-}
-
-func (c *Conn) prepareRawPacket(pkt *dtlsflight.Packet) ([][]byte, error) {
-	dtlsHandshake, ok := pkt.Record.Content.(*handshake.Handshake)
-	if ok {
-		if err := c.cacheHandshakePacket(pkt, dtlsHandshake); err != nil {
-			return nil, err
-		}
-
-		return c.processHandshakePacket(pkt, dtlsHandshake)
-	}
-
-	rawPacket, err := c.processPacket(pkt)
+	raw, err := c.prepareRecord(outbound)
 	if err != nil {
 		return nil, err
 	}
 
-	return [][]byte{rawPacket}, nil
+	return []preparedRecord{{raw: raw}}, nil
 }
 
-func (c *Conn) cacheHandshakePacket(pkt *dtlsflight.Packet, dtlsHandshake *handshake.Handshake) error {
-	handshakeRaw, err := pkt.Record.Marshal()
+func (c *Conn) cacheHandshake(outbound *dtlsflight.Outbound, dtlsHandshake *handshake.Handshake) error {
+	handshakeRaw, err := dtlsHandshake.Marshal()
 	if err != nil {
 		return err
 	}
 
 	c.log.Tracef("[handshake:%v] -> %s (epoch: %d, seq: %d)",
 		srvCliStr(dtlsstate.CommonState(c.state).IsClient), dtlsHandshake.Header.Type.String(),
-		pkt.Record.Header.Epoch, dtlsHandshake.Header.MessageSequence)
+		outbound.Epoch, dtlsHandshake.Header.MessageSequence)
 
 	c.handshakeCache.Push(
-		handshakeRaw[recordlayer.FixedHeaderSize:],
-		pkt.Record.Header.Epoch,
+		handshakeRaw,
+		outbound.Epoch,
 		dtlsHandshake.Header.MessageSequence,
 		dtlsHandshake.Header.Type,
 		dtlsstate.CommonState(c.state).IsClient,
@@ -952,68 +926,22 @@ func (c *Conn) compactPreparedRecords(records []preparedRecord) []preparedDatagr
 	return datagrams
 }
 
-func (c *Conn) processPacket(pkt *dtlsflight.Packet) ([]byte, error) { //nolint:cyclop
-	epoch := pkt.Record.Header.Epoch
+func (c *Conn) prepareRecord(outbound *dtlsflight.Outbound) ([]byte, error) {
+	if outbound == nil || outbound.Content == nil || !validProtection(outbound.Protection) {
+		return nil, dtlserrors.ErrInvalidPacket
+	}
+	contentType, plaintext, err := marshalRecordContent(outbound.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	epoch := outbound.Epoch
 	seq, err := c.nextLocalSequenceNumber(epoch)
 	if err != nil {
 		return nil, err
 	}
-	pkt.Record.Header.SequenceNumber = seq
 
-	common := dtlsstate.CommonState(c.state)
-	if common.LocalVersion.Equal(protocol.Version1_3) && pkt.ShouldEncrypt {
-		return c.processProtectedPacket(pkt, seq)
-	}
-
-	var rawPacket []byte
-	if pkt.ShouldWrapCID { //nolint:nestif
-		// Record must be marshaled to populate fields used in inner plaintext.
-		if _, err := pkt.Record.Marshal(); err != nil {
-			return nil, err
-		}
-		content, err := pkt.Record.Content.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		inner := &recordlayer.InnerPlaintext{
-			Content:  content,
-			RealType: pkt.Record.Header.ContentType,
-		}
-		rawInner, err := inner.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		cidHeader := &recordlayer.Header{
-			Version:        pkt.Record.Header.Version,
-			ContentType:    protocol.ContentTypeConnectionID,
-			Epoch:          pkt.Record.Header.Epoch,
-			ContentLen:     uint16(len(rawInner)), //nolint:gosec //G115
-			ConnectionID:   common.RemoteConnectionID,
-			SequenceNumber: pkt.Record.Header.SequenceNumber,
-		}
-		rawPacket, err = cidHeader.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		pkt.Record.Header = *cidHeader
-		rawPacket = append(rawPacket, rawInner...)
-	} else {
-		var err error
-		rawPacket, err = pkt.Record.Marshal()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if pkt.ShouldEncrypt {
-		var err error
-		rawPacket, err = common.CipherSuite.Encrypt(pkt.Record, rawPacket)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return rawPacket, nil
+	return c.encodeRecord(epoch, seq, contentType, plaintext, outbound.Protection)
 }
 
 func (c *Conn) nextLocalSequenceNumber(epoch uint16) (uint64, error) {
@@ -1032,29 +960,10 @@ func (c *Conn) nextLocalSequenceNumber(epoch uint16) (uint64, error) {
 	return seq, nil
 }
 
-// processProtectedPacket writes a DTLS 1.3 protected record. The helpers below
-// keep the AEAD plaintext at the DTLSInnerPlaintext content level: handshake
-// header plus body for handshake records, and alert bytes for alert records.
-// They intentionally do not pass a marshaled record-layer header as plaintext;
-// application data, ACK, and CID protected writes are left for their own
-// integrations.
-func (c *Conn) processProtectedPacket(pkt *dtlsflight.Packet, seq uint64) ([]byte, error) {
-	if pkt.ShouldWrapCID {
-		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	epoch := pkt.Record.Header.Epoch
-	contentType, plaintext, err := marshalRecordContent(pkt.Record.Content)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.sealRecordContent(epoch, seq, contentType, plaintext)
-}
-
 func marshalRecordContent(content protocol.Content) (protocol.ContentType, []byte, error) {
 	switch content.(type) {
 	case *handshake.Handshake, *alert.Alert, *protocol.ApplicationData, *protocol.ACK,
+		*protocol.ChangeCipherSpec,
 		*protocol.ReturnRoutabilityCheck:
 	default:
 		return 0, nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
@@ -1066,6 +975,62 @@ func marshalRecordContent(content protocol.Content) (protocol.ContentType, []byt
 	}
 
 	return content.ContentType(), plaintext, nil
+}
+
+func validProtection(protection dtlsflight.Protection) bool {
+	return protection == dtlsflight.ProtectionPlaintext || protection == dtlsflight.ProtectionCiphertext
+}
+
+func (c *Conn) encodeRecord( //nolint:cyclop
+	epoch uint16,
+	seq uint64,
+	contentType protocol.ContentType,
+	plaintext []byte,
+	protection dtlsflight.Protection,
+) ([]byte, error) {
+	if !validProtection(protection) {
+		return nil, dtlserrors.ErrInvalidPacket
+	}
+	common := dtlsstate.CommonState(c.state)
+	if protection == dtlsflight.ProtectionCiphertext && common.LocalVersion.Equal(protocol.Version1_3) {
+		return c.sealRecordContent(epoch, seq, contentType, plaintext)
+	}
+
+	header := recordlayer.Header{
+		Version:        protocol.Version1_2,
+		ContentType:    contentType,
+		Epoch:          epoch,
+		SequenceNumber: seq,
+	}
+	payload := plaintext
+	if protection == dtlsflight.ProtectionCiphertext &&
+		common.LocalVersion.Equal(protocol.Version1_2) && c.state.ShouldWrapConnectionID() {
+		inner := recordlayer.InnerPlaintext{
+			Content:  plaintext,
+			RealType: contentType,
+			Zeros:    c.paddingLengthGenerator(uint(len(plaintext))),
+		}
+		var err error
+		payload, err = inner.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		header.ContentType = protocol.ContentTypeConnectionID
+		header.ConnectionID = bytes.Clone(common.RemoteConnectionID)
+	}
+	raw, err := recordlayer.MarshalRecord(header, header.ContentType, payload)
+	if err != nil {
+		return nil, err
+	}
+	header.ContentLen = uint16(len(payload)) //nolint:gosec
+	if protection != dtlsflight.ProtectionCiphertext {
+		return raw, nil
+	}
+	if common.CipherSuite == nil {
+		return nil, dtlserrors.ErrCipherSuiteNotInit
+	}
+
+	return common.CipherSuite.Encrypt(&recordlayer.RecordLayer{Header: header}, raw)
 }
 
 func (c *Conn) sealRecordContent(
@@ -1116,131 +1081,24 @@ func (c *Conn) writeTrafficGeneration(epoch uint16) (*dtlsstate.TrafficGeneratio
 	return generation, nil
 }
 
-//nolint:cyclop
-func (c *Conn) processHandshakePacket(pkt *dtlsflight.Packet, dtlsHandshake *handshake.Handshake) ([][]byte, error) {
-	common := dtlsstate.CommonState(c.state)
-	if common.LocalVersion.Equal(protocol.Version1_3) && pkt.ShouldEncrypt {
-		return c.processProtectedHandshakePacket(pkt, dtlsHandshake)
-	}
-
-	rawPackets := make([][]byte, 0)
-
-	handshakeFragments, err := c.fragmentHandshake(dtlsHandshake)
-	if err != nil {
-		return nil, err
-	}
-	epoch := pkt.Record.Header.Epoch
-
-	for _, handshakeFragment := range handshakeFragments {
-		seq, err := c.nextLocalSequenceNumber(epoch)
-		if err != nil {
-			return nil, err
-		}
-
-		var rawPacket []byte
-		if pkt.ShouldWrapCID {
-			inner := &recordlayer.InnerPlaintext{
-				Content:  handshakeFragment,
-				RealType: protocol.ContentTypeHandshake,
-				Zeros:    c.paddingLengthGenerator(uint(len(handshakeFragment))),
-			}
-			rawInner, err := inner.Marshal() //nolint:govet
-			if err != nil {
-				return nil, err
-			}
-			cidHeader := &recordlayer.Header{
-				Version:        pkt.Record.Header.Version,
-				ContentType:    protocol.ContentTypeConnectionID,
-				Epoch:          pkt.Record.Header.Epoch,
-				ContentLen:     uint16(len(rawInner)), //nolint:gosec //G115
-				ConnectionID:   common.RemoteConnectionID,
-				SequenceNumber: seq,
-			}
-			rawPacket, err = cidHeader.Marshal()
-			if err != nil {
-				return nil, err
-			}
-			pkt.Record.Header = *cidHeader
-			rawPacket = append(rawPacket, rawInner...)
-		} else {
-			recordlayerHeader := &recordlayer.Header{
-				Version:        pkt.Record.Header.Version,
-				ContentType:    pkt.Record.Header.ContentType,
-				ContentLen:     uint16(len(handshakeFragment)), //nolint:gosec // G115
-				Epoch:          pkt.Record.Header.Epoch,
-				SequenceNumber: seq,
-			}
-
-			rawPacket, err = recordlayerHeader.Marshal()
-			if err != nil {
-				return nil, err
-			}
-
-			pkt.Record.Header = *recordlayerHeader
-			rawPacket = append(rawPacket, handshakeFragment...)
-		}
-
-		if pkt.ShouldEncrypt {
-			var err error
-			rawPacket, err = common.CipherSuite.Encrypt(pkt.Record, rawPacket)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		rawPackets = append(rawPackets, rawPacket)
-	}
-
-	return rawPackets, nil
-}
-
-func (c *Conn) processProtectedHandshakePacket(
-	pkt *dtlsflight.Packet,
-	dtlsHandshake *handshake.Handshake,
-) ([][]byte, error) {
-	if pkt == nil || pkt.Record == nil || dtlsHandshake == nil {
-		// TODO: Replace this temporary error when CID protection is implemented.
-		// nolint:godox
-		return nil, dtlserrors.ErrInvalidPacket
-	}
-	if pkt.ShouldWrapCID {
-		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
-	prepared, err := c.processProtectedHandshakePacketTracked(pkt, dtlsHandshake)
-	if err != nil {
-		return nil, err
-	}
-	rawPackets := make([][]byte, 0, len(prepared))
-	for _, record := range prepared {
-		rawPackets = append(rawPackets, record.raw)
-	}
-
-	return rawPackets, nil
-}
-
 type preparedRecord struct {
 	raw     []byte
 	tracked *dtlshandshake.SentHandshakeRecord
 }
 
-func (c *Conn) processProtectedHandshakePacketTracked(
-	pkt *dtlsflight.Packet,
+func (c *Conn) prepareHandshakeRecords(
+	outbound *dtlsflight.Outbound,
 	dtlsHandshake *handshake.Handshake,
 ) ([]preparedRecord, error) {
-	if pkt.ShouldWrapCID {
-		return nil, dtlserrors.ErrCipherSuiteRecordProtectionNotImplemented
-	}
-
 	handshakeFragments, err := c.fragmentHandshake(dtlsHandshake)
 	if err != nil {
 		return nil, err
 	}
 
 	rawPackets := make([]preparedRecord, 0, len(handshakeFragments))
-	epoch := pkt.Record.Header.Epoch
+	epoch := outbound.Epoch
 	for _, handshakeFragment := range handshakeFragments {
-		selected, err := selectHandshakeFragment(pkt.HandshakeFragmentOffsets, handshakeFragment)
+		selected, err := selectHandshakeFragment(outbound.HandshakeFragmentOffsets, handshakeFragment)
 		if err != nil {
 			return nil, err
 		}
@@ -1251,22 +1109,19 @@ func (c *Conn) processProtectedHandshakePacketTracked(
 		if err != nil {
 			return nil, err
 		}
-		pkt.Record.Header.ContentType = protocol.ContentTypeHandshake
-		pkt.Record.Header.ContentLen = uint16(len(handshakeFragment)) //nolint:gosec // G115
-		pkt.Record.Header.SequenceNumber = seq
-
-		rawPacket, err := c.sealRecordContent(
+		rawPacket, err := c.encodeRecord(
 			epoch,
 			seq,
 			protocol.ContentTypeHandshake,
 			handshakeFragment,
+			outbound.Protection,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		prepared := preparedRecord{raw: rawPacket}
-		if pkt.ShouldTrackACK {
+		if outbound.TrackACK {
 			fragmentHeader := &handshake.Header{}
 			if err = fragmentHeader.Unmarshal(handshakeFragment); err != nil {
 				return nil, err
@@ -2399,22 +2254,18 @@ func (c *Conn) notify(ctx context.Context, level alert.Level, desc alert.Descrip
 		}
 	}
 
-	return c.writePackets(ctx, []*dtlsflight.Packet{
-		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Epoch:   common.LocalEpoch(),
-					Version: protocol.Version1_2,
-				},
-				Content: &alert.Alert{
-					Level:       level,
-					Description: desc,
-				},
-			},
-			ShouldWrapCID: c.state.ShouldWrapConnectionID(),
-			ShouldEncrypt: c.isHandshakeCompletedSuccessfully(),
+	outbound := &dtlsflight.Outbound{
+		Epoch: common.LocalEpoch(),
+		Content: &alert.Alert{
+			Level:       level,
+			Description: desc,
 		},
-	})
+	}
+	if c.isHandshakeCompletedSuccessfully() {
+		outbound.Protection = dtlsflight.ProtectionCiphertext
+	}
+
+	return c.writePackets(ctx, []*dtlsflight.Outbound{outbound})
 }
 
 func (c *Conn) isHandshakeCompletedSuccessfully() bool {
@@ -2442,7 +2293,7 @@ func (c *Conn) negotiateVersionServer(ctx context.Context) error {
 }
 
 //nolint:cyclop
-func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Packet, error) {
+func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Outbound, error) {
 	gen, _, ok := dtlsflight13.GetGenerator(dtlsflight13.Flight1)
 	if !ok {
 		return nil, dtlserrors.ErrFlightUnimplemented13
@@ -2671,11 +2522,11 @@ func (c *Conn) setNegotiatedVersion(remote []protocol.Version, chosen protocol.V
 // stampHandshakeSequence assigns the DTLS message_sequence to each handshake
 // record in pkts. This is the subset of handshakeFSM.prepare()'s bookkeeping
 // that generated dual-stack packets need before being passed to writePackets.
-func (c *Conn) stampHandshakeSequence(pkts []*dtlsflight.Packet) {
+func (c *Conn) stampHandshakeSequence(pkts []*dtlsflight.Outbound) {
 	epoch := c.handshakeConfig.InitialEpoch
 	for _, p := range pkts {
-		p.Record.Header.Epoch += epoch
-		if h, ok := p.Record.Content.(*handshake.Handshake); ok {
+		p.Epoch += epoch
+		if h, ok := p.Content.(*handshake.Handshake); ok {
 			h.Header.MessageSequence = dtlsstate.NextHandshakeSendSequence(c.state)
 		}
 	}

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	dtlsnet "github.com/pion/dtls/v3/pkg/net"
 	"github.com/pion/dtls/v3/pkg/protocol"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/transport/v4/dpipe"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
@@ -137,8 +136,8 @@ func testListenConnectionIDRebindingRequiresRRC(
 	}()
 
 	reboundPacket := client.newApplicationDataPacket([]byte("rebound"))
-	reboundPacket.Record.Header.Epoch = dtlsstate.CommonState(client.state).LocalEpoch()
-	datagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Packet{reboundPacket})
+	reboundPacket.Epoch = dtlsstate.CommonState(client.state).LocalEpoch()
+	datagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Outbound{reboundPacket})
 	require.NoError(t, err)
 	require.Len(t, datagrams, 1)
 	_, err = reboundSocket.WriteTo(datagrams[0].raw, listener.Addr())
@@ -179,29 +178,23 @@ func testListenConnectionIDRebindingRequiresRRC(
 	}
 	assert.Equal(t, protocol.ReturnRoutabilityCheckPathChallenge, challenge.MessageType)
 
-	responsePacket := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   dtlsstate.CommonState(client.state).LocalEpoch(),
-			},
-			Content: &protocol.ReturnRoutabilityCheck{
-				MessageType: protocol.ReturnRoutabilityCheckPathResponse,
-				Cookie:      challenge.Cookie,
-			},
+	responsePacket := &dtlsflight.Outbound{
+		Epoch: dtlsstate.CommonState(client.state).LocalEpoch(),
+		Content: &protocol.ReturnRoutabilityCheck{
+			MessageType: protocol.ReturnRoutabilityCheckPathResponse,
+			Cookie:      challenge.Cookie,
 		},
-		ShouldWrapCID: negotiatedVersion.Equal(protocol.Version1_2) && client.state.ShouldWrapConnectionID(),
-		ShouldEncrypt: true,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
-	responseDatagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Packet{responsePacket})
+	responseDatagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Outbound{responsePacket})
 	require.NoError(t, err)
 	require.Len(t, responseDatagrams, 1)
 	_, err = reboundSocket.WriteTo(responseDatagrams[0].raw, listener.Addr())
 	require.NoError(t, err)
 
 	secondReboundPacket := client.newApplicationDataPacket([]byte("validated"))
-	secondReboundPacket.Record.Header.Epoch = dtlsstate.CommonState(client.state).LocalEpoch()
-	secondDatagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Packet{secondReboundPacket})
+	secondReboundPacket.Epoch = dtlsstate.CommonState(client.state).LocalEpoch()
+	secondDatagrams, _, err := client.prepareRawPacketsTracked([]*dtlsflight.Outbound{secondReboundPacket})
 	require.NoError(t, err)
 	require.Len(t, secondDatagrams, 1)
 	_, err = reboundSocket.WriteTo(secondDatagrams[0].raw, listener.Addr())

--- a/conn_test.go
+++ b/conn_test.go
@@ -68,6 +68,24 @@ var (
 
 const renegotiationInfoSCSV uint16 = 0x00ff
 
+func marshalTestRecord(header recordlayer.Header, content protocol.Content) ([]byte, error) {
+	payload, err := content.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return recordlayer.MarshalRecord(header, content.ContentType(), payload)
+}
+
+type testRecord struct {
+	Header  recordlayer.Header
+	Content protocol.Content
+}
+
+func (r *testRecord) Marshal() ([]byte, error) {
+	return marshalTestRecord(r.Header, r.Content)
+}
+
 func TestStressDuplex(t *testing.T) {
 	// Limit runtime in case of deadlocks
 	lim := test.TimeOut(time.Second * 20)
@@ -219,7 +237,7 @@ func TestApplicationDataPacketOwnsPayload(t *testing.T) {
 	packet := conn.newApplicationDataPacket(payload)
 	payload[0] = 'X'
 
-	applicationData, ok := packet.Record.Content.(*protocol.ApplicationData)
+	applicationData, ok := packet.Content.(*protocol.ApplicationData)
 	require.True(t, ok)
 	assert.Equal(t, []byte("application data"), applicationData.Data)
 }
@@ -258,19 +276,14 @@ func TestSequenceNumberOverflow(t *testing.T) {
 		atomic.StoreUint64(&dtlsstate.CommonState(ca.state).LocalSequenceNumber[0], recordlayer.MaxSequenceNumber+1)
 
 		// Try to send handshake packet.
-		werr := ca.writePackets(ctx, []*dtlsflight.Packet{
+		werr := ca.writePackets(ctx, []*dtlsflight.Outbound{
 			{
-				Record: &recordlayer.RecordLayer{
-					Header: recordlayer.Header{
-						Version: protocol.Version1_2,
-					},
-					Content: &handshake.Handshake{
-						Message: &handshake.MessageClientHello{
-							Version:            protocol.Version1_2,
-							Cookie:             make([]byte, 64),
-							CipherSuiteIDs:     cipherSuiteIDs(defaultCipherSuites()),
-							CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-						},
+				Content: &handshake.Handshake{
+					Message: &handshake.MessageClientHello{
+						Version:            protocol.Version1_2,
+						Cookie:             make([]byte, 64),
+						CipherSuiteIDs:     cipherSuiteIDs(defaultCipherSuites()),
+						CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 					},
 				},
 			},
@@ -388,24 +401,21 @@ func sendClientHello(
 		cipherSuites = cipherSuiteIDs(defaultCipherSuites())
 	}
 
-	packet, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Version:        protocol.Version1_2,
-			SequenceNumber: sequenceNumber,
+	packet, err := marshalTestRecord(recordlayer.Header{
+		Version:        protocol.Version1_2,
+		SequenceNumber: sequenceNumber,
+	}, &handshake.Handshake{
+		Header: handshake.Header{
+			MessageSequence: uint16(sequenceNumber), //nolint:gosec // G115
 		},
-		Content: &handshake.Handshake{
-			Header: handshake.Header{
-				MessageSequence: uint16(sequenceNumber), //nolint:gosec // G115
-			},
-			Message: &handshake.MessageClientHello{
-				Version:            protocol.Version1_2,
-				Cookie:             cookie,
-				CipherSuiteIDs:     cipherSuites,
-				CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-				Extensions:         extensions,
-			},
+		Message: &handshake.MessageClientHello{
+			Version:            protocol.Version1_2,
+			Cookie:             cookie,
+			CipherSuiteIDs:     cipherSuites,
+			CompressionMethods: dtlsflight.DefaultCompressionMethods(),
+			Extensions:         extensions,
 		},
-	}).Marshal()
+	})
 	if err != nil {
 		return err
 	}
@@ -2220,7 +2230,7 @@ func TestServerTimeout(t *testing.T) {
 		},
 	}
 
-	record := &recordlayer.RecordLayer{
+	record := &testRecord{
 		Header: recordlayer.Header{
 			SequenceNumber: 0,
 			Version:        protocol.Version1_2,
@@ -2328,10 +2338,10 @@ func TestProtocolVersionValidation(t *testing.T) {
 
 	t.Run("Server", func(t *testing.T) {
 		serverCases := map[string]struct {
-			records []*recordlayer.RecordLayer
+			records []*testRecord
 		}{
 			"ClientHelloVersion": {
-				records: []*recordlayer.RecordLayer{
+				records: []*testRecord{
 					{
 						Header: recordlayer.Header{
 							Version: protocol.Version1_2,
@@ -2349,7 +2359,7 @@ func TestProtocolVersionValidation(t *testing.T) {
 				},
 			},
 			"SecondsClientHelloVersion": {
-				records: []*recordlayer.RecordLayer{
+				records: []*testRecord{
 					{
 						Header: recordlayer.Header{
 							Version: protocol.Version1_2,
@@ -2435,10 +2445,10 @@ func TestProtocolVersionValidation(t *testing.T) {
 
 	t.Run("Client", func(t *testing.T) {
 		clientCases := map[string]struct {
-			records []*recordlayer.RecordLayer
+			records []*testRecord
 		}{
 			"ServerHelloVersion": {
-				records: []*recordlayer.RecordLayer{
+				records: []*testRecord{
 					{
 						Header: recordlayer.Header{
 							Version: protocol.Version1_2,
@@ -2773,12 +2783,9 @@ func TestDualStackVersionNegotiationSendsClassifiedAlerts(t *testing.T) {
 func marshalVersionNegotiationRecord(t *testing.T, message handshake.Message) []byte {
 	t.Helper()
 
-	raw, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{Version: protocol.Version1_2},
-		Content: &handshake.Handshake{
-			Message: message,
-		},
-	}).Marshal()
+	raw, err := marshalTestRecord(recordlayer.Header{Version: protocol.Version1_2}, &handshake.Handshake{
+		Message: message,
+	})
 	require.NoError(t, err)
 
 	return raw
@@ -2912,7 +2919,7 @@ func TestMultipleHelloVerifyRequest(t *testing.T) {
 
 		cookies = append(cookies, cookie)
 
-		record := &recordlayer.RecordLayer{
+		record := &testRecord{
 			Header: recordlayer.Header{
 				SequenceNumber: uint64(i),
 				Version:        protocol.Version1_2,
@@ -3297,10 +3304,7 @@ func TestALPNExtension(t *testing.T) {
 
 				assert.Equalf(t, test.ExpectedProtocol, negotiatedProtocol, "ALPN %v", test.Name)
 
-				s, err := (&recordlayer.RecordLayer{
-					Header:  recordHeader,
-					Content: handshakeRecord,
-				}).Marshal()
+				s, err := marshalTestRecord(recordHeader, handshakeRecord)
 				assert.NoError(t, err)
 
 				// Forward ServerHello
@@ -3889,16 +3893,13 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 
 	for i := range 1000 {
 		// Send an application data packet
-		packet, err := (&recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version:        protocol.Version1_2,
-				SequenceNumber: uint64(3),
-				Epoch:          1, // use an epoch greater than 0
-			},
-			Content: &protocol.ApplicationData{
-				Data: []byte{1, 2, 3, 4},
-			},
-		}).Marshal()
+		packet, err := marshalTestRecord(recordlayer.Header{
+			Version:        protocol.Version1_2,
+			SequenceNumber: uint64(3),
+			Epoch:          1, // use an epoch greater than 0
+		}, &protocol.ApplicationData{
+			Data: []byte{1, 2, 3, 4},
+		})
 		assert.NoError(t, err)
 		_, err = ca.Write(packet)
 		assert.NoError(t, err)
@@ -3988,17 +3989,14 @@ func TestHandleIncomingPacket13RejectsFixedHandshakeEpoch(t *testing.T) {
 	}
 	conn.setRemoteEpoch(0)
 
-	rawPacket, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Version:        protocol.Version1_2,
-			Epoch:          dtlsflight13.EpochHandshake,
-			SequenceNumber: 0,
-		},
-		Content: &handshake.Handshake{
-			Header:  handshake.Header{MessageSequence: 1},
-			Message: &handshake.MessageEncryptedExtensions{},
-		},
-	}).Marshal()
+	rawPacket, err := marshalTestRecord(recordlayer.Header{
+		Version:        protocol.Version1_2,
+		Epoch:          dtlsflight13.EpochHandshake,
+		SequenceNumber: 0,
+	}, &handshake.Handshake{
+		Header:  handshake.Header{MessageSequence: 1},
+		Message: &handshake.MessageEncryptedExtensions{},
+	})
 	assert.NoError(t, err)
 
 	bufferLease := &readBufferLease{conn: conn, recyclableReadBuffer: &rawPacket}
@@ -4935,15 +4933,10 @@ func TestProcessProtectedPacketWritesDTLS13HandshakeRecord(t *testing.T) {
 	expectedPlaintext, err := dtlsHandshake.Marshal()
 	assert.NoError(t, err)
 
-	rawPacket, err := conn.processPacket(&dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   dtlsflight13.EpochHandshake,
-			},
-			Content: dtlsHandshake,
-		},
-		ShouldEncrypt: true,
+	rawPacket, err := conn.prepareRecord(&dtlsflight.Outbound{
+		Epoch:      dtlsflight13.EpochHandshake,
+		Content:    dtlsHandshake,
+		Protection: dtlsflight.ProtectionCiphertext,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, rawPacket)
@@ -4957,10 +4950,12 @@ func TestProcessProtectedPacketWritesDTLS13HandshakeRecord(t *testing.T) {
 type sequenceRecordingCipherSuite struct {
 	ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256
 	sequences []uint64
+	headers   []recordlayer.Header
 }
 
 func (c *sequenceRecordingCipherSuite) Encrypt(pkt *recordlayer.RecordLayer, raw []byte) ([]byte, error) {
 	c.sequences = append(c.sequences, pkt.Header.SequenceNumber)
+	c.headers = append(c.headers, pkt.Header)
 
 	return bytes.Clone(raw), nil
 }
@@ -4994,29 +4989,23 @@ func TestProcessHandshakePacketCIDFragmentsUseAllocatedSequenceNumbers(t *testin
 	_, err := dtlsHandshake.Marshal()
 	require.NoError(t, err)
 
-	pkt := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version:        protocol.Version1_2,
-				Epoch:          epoch,
-				SequenceNumber: staleSequence,
-			},
-			Content: dtlsHandshake,
-		},
-		ShouldEncrypt: true,
-		ShouldWrapCID: true,
+	pkt := &dtlsflight.Outbound{
+		Epoch:      epoch,
+		Content:    dtlsHandshake,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
-	rawPackets, err := conn.processHandshakePacket(pkt, dtlsHandshake)
+	prepared, err := conn.prepareHandshakeRecords(pkt, dtlsHandshake)
 	require.NoError(t, err)
-	require.Greater(t, len(rawPackets), 1)
+	require.Greater(t, len(prepared), 1)
 
-	expectedSequences := make([]uint64, len(rawPackets))
-	for i, rawPacket := range rawPackets {
+	expectedSequences := make([]uint64, len(prepared))
+	for i, record := range prepared {
 		expectedSequence := firstSequence + uint64(i)
 		expectedSequences[i] = expectedSequence
 
 		header := recordlayer.Header{ConnectionID: make([]byte, len(remoteCID))}
-		require.NoError(t, header.Unmarshal(rawPacket))
+		require.NoError(t, header.Unmarshal(record.raw))
+		assert.Equal(t, header, cipherSuite.headers[i])
 		assert.Equal(t, protocol.ContentTypeConnectionID, header.ContentType)
 		assert.Equal(t, remoteCID, header.ConnectionID)
 		assert.Equal(t, epoch, header.Epoch)
@@ -5025,7 +5014,6 @@ func TestProcessHandshakePacketCIDFragmentsUseAllocatedSequenceNumbers(t *testin
 
 	// Encrypt receives this record metadata for the nonce and MAC calculation.
 	assert.Equal(t, expectedSequences, cipherSuite.sequences)
-	assert.Equal(t, expectedSequences[len(expectedSequences)-1], pkt.Record.Header.SequenceNumber)
 	assert.Equal(t, firstSequence+uint64(len(expectedSequences)), commonState.LocalSequenceNumber[epoch])
 }
 
@@ -5037,21 +5025,16 @@ func TestProcessProtectedHandshakePacketWritesDTLS13Fragments(t *testing.T) {
 	expectedPlaintext, err := dtlsHandshake.Marshal()
 	assert.NoError(t, err)
 
-	rawPackets, err := conn.processHandshakePacket(&dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   dtlsflight13.EpochHandshake,
-			},
-			Content: dtlsHandshake,
-		},
-		ShouldEncrypt: true,
+	prepared, err := conn.prepareHandshakeRecords(&dtlsflight.Outbound{
+		Epoch:      dtlsflight13.EpochHandshake,
+		Content:    dtlsHandshake,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}, dtlsHandshake)
 	assert.NoError(t, err)
-	assert.Len(t, rawPackets, 1)
-	assert.True(t, protocol.IsDTLS13Ciphertext(protocol.ContentType(rawPackets[0][0])))
+	require.Len(t, prepared, 1)
+	assert.True(t, protocol.IsDTLS13Ciphertext(protocol.ContentType(prepared[0].raw[0])))
 
-	innerPlaintext := openTestProtectedRecord(t, peerCipherSuite, rawPackets[0])
+	innerPlaintext := openTestProtectedRecord(t, peerCipherSuite, prepared[0].raw)
 	assert.Equal(t, protocol.ContentTypeHandshake, innerPlaintext.RealType)
 	assert.Equal(t, expectedPlaintext, innerPlaintext.Content)
 }
@@ -5066,13 +5049,11 @@ func TestProcessProtectedHandshakePacketFiltersACKedFragments(t *testing.T) {
 	_, err := dtlsHandshake.Marshal()
 	require.NoError(t, err)
 
-	prepared, err := conn.processProtectedHandshakePacketTracked(&dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: dtlsflight13.EpochHandshake},
-			Content: dtlsHandshake,
-		},
-		ShouldEncrypt:            true,
-		ShouldTrackACK:           true,
+	prepared, err := conn.prepareHandshakeRecords(&dtlsflight.Outbound{
+		Epoch:                    dtlsflight13.EpochHandshake,
+		Content:                  dtlsHandshake,
+		Protection:               dtlsflight.ProtectionCiphertext,
+		TrackACK:                 true,
 		HandshakeFragmentOffsets: map[uint32]uint32{10: 10},
 	}, dtlsHandshake)
 	require.NoError(t, err)
@@ -5084,15 +5065,10 @@ func TestProcessProtectedPacketWritesApplicationData(t *testing.T) {
 	conn, peerCipherSuite := newTestConnWithWriteProtection(t)
 	payload := []byte("application data")
 
-	rawPacket, err := conn.processPacket(&dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   dtlsflight13.EpochApplication,
-			},
-			Content: &protocol.ApplicationData{Data: payload},
-		},
-		ShouldEncrypt: true,
+	rawPacket, err := conn.prepareRecord(&dtlsflight.Outbound{
+		Epoch:      dtlsflight13.EpochApplication,
+		Content:    &protocol.ApplicationData{Data: payload},
+		Protection: dtlsflight.ProtectionCiphertext,
 	})
 	require.NoError(t, err)
 
@@ -5107,12 +5083,10 @@ func TestProcessProtectedPacketWritesACK(t *testing.T) {
 	expected, err := ack.Marshal()
 	require.NoError(t, err)
 
-	rawPacket, err := conn.processPacket(&dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: dtlsflight13.EpochApplication},
-			Content: ack,
-		},
-		ShouldEncrypt: true,
+	rawPacket, err := conn.prepareRecord(&dtlsflight.Outbound{
+		Epoch:      dtlsflight13.EpochApplication,
+		Content:    ack,
+		Protection: dtlsflight.ProtectionCiphertext,
 	})
 	require.NoError(t, err)
 	innerPlaintext := openTestProtectedRecord(t, peerCipherSuite, rawPacket)

--- a/connection_id.go
+++ b/connection_id.go
@@ -62,18 +62,15 @@ func (c returnRoutabilityConn) WriteRRC(
 
 		return dtlserrors.ErrUnexpectedPostHandshakeMessage
 	}
-	packet := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{Version: protocol.Version1_2, Epoch: common.LocalEpoch()},
-			Content: &protocol.ReturnRoutabilityCheck{
-				MessageType: messageType,
-				Cookie:      cookie,
-			},
+	packet := &dtlsflight.Outbound{
+		Epoch: common.LocalEpoch(),
+		Content: &protocol.ReturnRoutabilityCheck{
+			MessageType: messageType,
+			Cookie:      cookie,
 		},
-		ShouldWrapCID: common.LocalVersion.Equal(protocol.Version1_2) && c.conn.state.ShouldWrapConnectionID(),
-		ShouldEncrypt: true,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
-	raw, err := c.conn.processPacket(packet)
+	raw, err := c.conn.prepareRecord(packet)
 	if err == nil {
 		err = c.conn.rrc.Reserve(addr, c.conn.rAddr, len(raw))
 	}

--- a/connection_id_test.go
+++ b/connection_id_test.go
@@ -55,26 +55,20 @@ func TestOnlySendCIDGenerator(t *testing.T) {
 func TestCIDDatagramRouter(t *testing.T) {
 	cid := []byte("abcd1234")
 	cidLen := 8
-	epochZeroRecord, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Epoch:   0,
-			Version: protocol.Version1_2,
-		},
-		Content: &alert.Alert{
-			Level:       alert.Warning,
-			Description: alert.CloseNotify,
-		},
-	}).Marshal()
+	epochZeroRecord, err := marshalTestRecord(recordlayer.Header{
+		Epoch:   0,
+		Version: protocol.Version1_2,
+	}, &alert.Alert{
+		Level:       alert.Warning,
+		Description: alert.CloseNotify,
+	})
 	assert.NoError(t, err)
-	protectedWithoutCIDRecord, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Epoch:   1,
-			Version: protocol.Version1_2,
-		},
-		Content: &protocol.ApplicationData{
-			Data: []byte("application data"),
-		},
-	}).Marshal()
+	protectedWithoutCIDRecord, err := marshalTestRecord(recordlayer.Header{
+		Epoch:   1,
+		Version: protocol.Version1_2,
+	}, &protocol.ApplicationData{
+		Data: []byte("application data"),
+	})
 	assert.NoError(t, err)
 
 	appData, err := (&protocol.ApplicationData{
@@ -204,13 +198,10 @@ func TestCIDDatagramRouter(t *testing.T) {
 
 func TestCIDDatagramRouter13(t *testing.T) {
 	cid := []byte("abcd1234")
-	plaintextPrefix, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{Version: protocol.Version1_2},
-		Content: &alert.Alert{
-			Level:       alert.Warning,
-			Description: alert.CloseNotify,
-		},
-	}).Marshal()
+	plaintextPrefix, err := marshalTestRecord(recordlayer.Header{Version: protocol.Version1_2}, &alert.Alert{
+		Level:       alert.Warning,
+		Description: alert.CloseNotify,
+	})
 	assert.NoError(t, err)
 
 	makeRecord := func(t *testing.T, connectionID []byte, sequenceNumber uint16) []byte {
@@ -293,37 +284,31 @@ func TestCIDDatagramRouter13(t *testing.T) {
 func TestCIDConnIdentifier(t *testing.T) {
 	cid := []byte("abcd1234")
 	cs := uint16(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
-	sh, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Epoch:   0,
-			Version: protocol.Version1_2,
-		},
-		Content: &handshake.Handshake{
-			Message: &handshake.MessageServerHello{
-				Version:           protocol.Version1_2,
-				Random:            handshake.Random{GMTUnixTime: time.Unix(500, 0), RandomBytes: [28]byte{}},
-				SessionID:         []byte("hello"),
-				CipherSuiteID:     &cs,
-				CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-				Extensions: []extension.Value{
-					&extension.ConnectionID{
-						CID: cid,
-					},
+	sh, err := marshalTestRecord(recordlayer.Header{
+		Epoch:   0,
+		Version: protocol.Version1_2,
+	}, &handshake.Handshake{
+		Message: &handshake.MessageServerHello{
+			Version:           protocol.Version1_2,
+			Random:            handshake.Random{GMTUnixTime: time.Unix(500, 0), RandomBytes: [28]byte{}},
+			SessionID:         []byte("hello"),
+			CipherSuiteID:     &cs,
+			CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+			Extensions: []extension.Value{
+				&extension.ConnectionID{
+					CID: cid,
 				},
 			},
 		},
-	}).Marshal()
+	})
 	assert.NoError(t, err)
 
-	appRecord, err := (&recordlayer.RecordLayer{
-		Header: recordlayer.Header{
-			Epoch:   1,
-			Version: protocol.Version1_2,
-		},
-		Content: &protocol.ApplicationData{
-			Data: []byte("application data"),
-		},
-	}).Marshal()
+	appRecord, err := marshalTestRecord(recordlayer.Header{
+		Epoch:   1,
+		Version: protocol.Version1_2,
+	}, &protocol.ApplicationData{
+		Data: []byte("application data"),
+	})
 	assert.NoError(t, err)
 	dtls13Ciphertext, err := (&recordlayer.CiphertextRecord{
 		Header:          recordlayer.UnifiedHeader{SequenceNumber: 1},

--- a/flight_test.go
+++ b/flight_test.go
@@ -173,7 +173,7 @@ func flight13GenerateForTest(
 	testingT require.TestingT,
 	flight dtlsflight13.Flight,
 	flightCtx *handshakeTestContext13,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {
 		helper.Helper()
 	}
@@ -208,10 +208,10 @@ func retryRequestForTest(
 	return request
 }
 
-func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Packet) []byte {
+func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Outbound) []byte {
 	t.Helper()
 
-	content, ok := p.Record.Content.(*handshake.Handshake)
+	content, ok := p.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := content.Marshal()
 	require.NoError(t, err)
@@ -633,14 +633,14 @@ func TestFlight13_5GenerateSelectsClientCertificateBySignatureScheme(t *testing.
 	require.Nil(t, dtlsAlert)
 	require.Len(t, packets, 3)
 
-	certificateHandshake, ok := packets[0].Record.Content.(*handshake.Handshake)
+	certificateHandshake, ok := packets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	certificateMessage, ok := certificateHandshake.Message.(*handshake.MessageCertificate13)
 	require.True(t, ok)
 	require.Len(t, certificateMessage.CertificateList, 1)
 	assert.Equal(t, ecdsaCertificate.Certificate[0], certificateMessage.CertificateList[0].CertificateData)
 
-	verifyHandshake, ok := packets[1].Record.Content.(*handshake.Handshake)
+	verifyHandshake, ok := packets[1].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	verifyMessage, ok := verifyHandshake.Message.(*handshake.MessageCertificateVerify)
 	require.True(t, ok)
@@ -715,7 +715,7 @@ func generateFlight13_1ClientHello(t *testing.T, cfg *dtlsconfig.HandshakeConfig
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -728,7 +728,7 @@ func generateFlight13_1ClientHello(t *testing.T, cfg *dtlsconfig.HandshakeConfig
 	return clientHello
 }
 
-func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) {
+func TestFlight13_1GenerateClientHelloIncludesRequiredExtensions(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := newTestState13(t, false)
 
@@ -741,7 +741,7 @@ func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) 
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -752,15 +752,19 @@ func TestFlight13_1GenerateClientHelloUsesSupportedVersionsVector(t *testing.T) 
 	require.True(t, ok)
 
 	var supportedVersions *extension13.OfferedVersions
+	var supportedGroups *extension.SupportedGroups
 	for _, ext := range clientHello.Extensions {
-		if sv, ok := ext.(*extension13.OfferedVersions); ok {
-			supportedVersions = sv
-
-			break
+		switch typed := ext.(type) {
+		case *extension13.OfferedVersions:
+			supportedVersions = typed
+		case *extension.SupportedGroups:
+			supportedGroups = typed
 		}
 	}
 	require.NotNil(t, supportedVersions)
 	assert.Equal(t, []protocol.Version{protocol.Version1_3}, supportedVersions.Versions)
+	require.NotNil(t, supportedGroups)
+	assert.Equal(t, cfg.EllipticCurves, supportedGroups.Groups)
 }
 
 func TestFlight13_1GenerateClientHelloIncludesSignatureAlgorithms(t *testing.T) {
@@ -786,24 +790,6 @@ func TestFlight13_1GenerateClientHelloIncludesSignatureAlgorithms(t *testing.T) 
 	assert.Equal(t, dtlsflight.SignatureSchemeIDs(cfg.LocalCertSignatureSchemes), signatureAlgorithmsCert.Schemes)
 }
 
-func TestFlight13_1GenerateClientHelloIncludesSupportedGroups(t *testing.T) {
-	cfg := testHandshakeConfig13(t)
-
-	clientHello := generateFlight13_1ClientHello(t, cfg)
-
-	var supportedGroups *extension.SupportedGroups
-	for _, ext := range clientHello.Extensions {
-		if typed, ok := ext.(*extension.SupportedGroups); ok {
-			supportedGroups = typed
-
-			break
-		}
-	}
-
-	require.NotNil(t, supportedGroups)
-	assert.Equal(t, cfg.EllipticCurves, supportedGroups.Groups)
-}
-
 func TestFlight13_1GenerateRetainsPrivateKeysForAdvertisedShares(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 	state := newTestState13(t, false)
@@ -817,7 +803,7 @@ func TestFlight13_1GenerateRetainsPrivateKeysForAdvertisedShares(t *testing.T) {
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -874,7 +860,7 @@ func TestFlight13_1GenerateClientHelloIncludesX25519MLKEM768KeyShare(t *testing.
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -1077,7 +1063,7 @@ func TestFlight13_3GenerateIncludesCookieAndSupportedVersions(t *testing.T) {
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -1140,7 +1126,7 @@ func TestFlight13_3GeneratePrioritizesHelloRetryRequestSelectedGroup(t *testing.
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	hand, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	hand, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -1589,7 +1575,7 @@ func TestFlight13ClientParseAppendsHRRTranscriptOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, dtlsAlert)
 	require.Len(t, clientHello2, 1)
-	clientHello2Handshake, ok := clientHello2[0].Record.Content.(*handshake.Handshake)
+	clientHello2Handshake, ok := clientHello2[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	clientHello2Handshake.Header.MessageSequence = 1
 	require.NoError(t, dtlshandshake.AppendOutboundHandshakeFlight(transcript, true, state.CipherSuite, clientHello2))
@@ -2634,10 +2620,9 @@ func serverHelloFromFlight13_2(
 	require.Nil(t, dtlsAlert)
 	require.Len(t, pkts, 1)
 
-	require.NotNil(t, pkts[0].Record)
-	assert.Equal(t, protocol.Version1_2, pkts[0].Record.Header.Version)
+	require.NotNil(t, pkts[0].Content)
 
-	content, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	content, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 
 	serverHello, ok := content.Message.(*handshake.MessageServerHello)
@@ -2874,7 +2859,7 @@ func TestFlight13_4Generate(t *testing.T) {
 
 				var certificateRequest *handshake.MessageCertificateRequest13
 				for _, pkt := range pkts {
-					handshakePacket, ok := pkt.Record.Content.(*handshake.Handshake)
+					handshakePacket, ok := pkt.Content.(*handshake.Handshake)
 					if !ok {
 						continue
 					}
@@ -2884,8 +2869,8 @@ func TestFlight13_4Generate(t *testing.T) {
 					}
 					require.Nil(t, certificateRequest, "server flight contains multiple CertificateRequest messages")
 					certificateRequest = request
-					assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
-					assert.True(t, pkt.ShouldEncrypt)
+					assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Epoch)
+					assert.True(t, pkt.Protection == dtlsflight.ProtectionCiphertext)
 				}
 
 				if !test.wantRequest {
@@ -2925,10 +2910,10 @@ func TestFlight13_4Generate(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, dtlsAlert)
 		require.Len(t, pkts, 5)
-		assert.Equal(t, uint16(0), pkts[0].Record.Header.Epoch)
-		assert.False(t, pkts[0].ShouldEncrypt)
+		assert.Equal(t, uint16(0), pkts[0].Epoch)
+		assert.False(t, pkts[0].Protection == dtlsflight.ProtectionCiphertext)
 
-		serverHelloHandshake, ok := pkts[0].Record.Content.(*handshake.Handshake)
+		serverHelloHandshake, ok := pkts[0].Content.(*handshake.Handshake)
 		require.True(t, ok)
 		serverHello, ok := serverHelloHandshake.Message.(*handshake.MessageServerHello)
 		require.True(t, ok)
@@ -2946,40 +2931,36 @@ func TestFlight13_4Generate(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, protocol.Version1_3, supportedVersions.Version)
 
-		encryptedExtensionsHandshake, ok := pkts[1].Record.Content.(*handshake.Handshake)
+		encryptedExtensionsHandshake, ok := pkts[1].Content.(*handshake.Handshake)
 		require.True(t, ok)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[1].Record.Header.Epoch)
-		assert.True(t, pkts[1].ShouldEncrypt)
-		assert.True(t, pkts[1].ResetLocalSequenceNumber)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[1].Epoch)
+		assert.True(t, pkts[1].Protection == dtlsflight.ProtectionCiphertext)
 		encryptedExtensions, ok := encryptedExtensionsHandshake.Message.(*handshake.MessageEncryptedExtensions)
 		require.True(t, ok)
 		assert.Empty(t, encryptedExtensions.Extensions)
 
-		certificateHandshake, ok := pkts[2].Record.Content.(*handshake.Handshake)
+		certificateHandshake, ok := pkts[2].Content.(*handshake.Handshake)
 		require.True(t, ok)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[2].Record.Header.Epoch)
-		assert.True(t, pkts[2].ShouldEncrypt)
-		assert.False(t, pkts[2].ResetLocalSequenceNumber)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[2].Epoch)
+		assert.True(t, pkts[2].Protection == dtlsflight.ProtectionCiphertext)
 		certificateMessage, ok := certificateHandshake.Message.(*handshake.MessageCertificate13)
 		require.True(t, ok)
 		assert.Empty(t, certificateMessage.CertificateRequestContext)
 		require.Len(t, certificateMessage.CertificateList, len(certificate.Certificate))
 
-		certificateVerifyHandshake, ok := pkts[3].Record.Content.(*handshake.Handshake)
+		certificateVerifyHandshake, ok := pkts[3].Content.(*handshake.Handshake)
 		require.True(t, ok)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[3].Record.Header.Epoch)
-		assert.True(t, pkts[3].ShouldEncrypt)
-		assert.False(t, pkts[3].ResetLocalSequenceNumber)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[3].Epoch)
+		assert.True(t, pkts[3].Protection == dtlsflight.ProtectionCiphertext)
 		certificateVerify, ok := certificateVerifyHandshake.Message.(*handshake.MessageCertificateVerify)
 		require.True(t, ok)
 		assert.Empty(t, certificateVerify.Signature)
 		assert.NotNil(t, pkts[3].CertificateVerifySigner)
 
-		finishedHandshake, ok := pkts[4].Record.Content.(*handshake.Handshake)
+		finishedHandshake, ok := pkts[4].Content.(*handshake.Handshake)
 		require.True(t, ok)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[4].Record.Header.Epoch)
-		assert.True(t, pkts[4].ShouldEncrypt)
-		assert.False(t, pkts[4].ResetLocalSequenceNumber)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkts[4].Epoch)
+		assert.True(t, pkts[4].Protection == dtlsflight.ProtectionCiphertext)
 		_, ok = finishedHandshake.Message.(*handshake.MessageFinished)
 		require.True(t, ok)
 	})
@@ -3353,10 +3334,10 @@ func assertConnectionIDs(t *testing.T, state *dtlsstate.State13, localCID, remot
 	assertConnectionIDValue(t, remoteCID, state.CID.Send.Active)
 }
 
-func clientHelloFromFlight13Packet(t *testing.T, packet *dtlsflight.Packet) *handshake.MessageClientHello {
+func clientHelloFromFlight13Packet(t *testing.T, packet *dtlsflight.Outbound) *handshake.MessageClientHello {
 	t.Helper()
 
-	hand, ok := packet.Record.Content.(*handshake.Handshake)
+	hand, ok := packet.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := hand.Marshal()
 	require.NoError(t, err)
@@ -3680,7 +3661,7 @@ func TestFlight13_4GenerateNegotiatesConnectionIDs(t *testing.T) { //nolint:cycl
 				require.NoError(t, err)
 				require.Nil(t, dtlsAlert)
 				require.NotEmpty(t, packets)
-				serverHelloHandshake, ok := packets[0].Record.Content.(*handshake.Handshake)
+				serverHelloHandshake, ok := packets[0].Content.(*handshake.Handshake)
 				require.True(t, ok)
 				serverHello, ok := serverHelloHandshake.Message.(*handshake.MessageServerHello)
 				require.True(t, ok)

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/crypto/signaturehash"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
@@ -75,8 +74,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			const helloVerifyDrop = 5
 
 			clientEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -91,8 +90,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 
 			serverEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -124,8 +123,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			)
 
 			clientEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -138,8 +137,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 
 			serverEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -172,8 +171,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			)
 
 			clientEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -195,8 +194,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 
 			serverEndpoint := TestEndpoint{
-				Filter: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Filter: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return true
 					}
@@ -240,8 +239,8 @@ func TestHandshaker(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		"RetransmitFinishedMessageLost": func() (TestEndpoint, TestEndpoint, func(t *testing.T)) { //nolint:unparam
 			serverEndpoint := TestEndpoint{
-				Retransmit: func(p *dtlsflight.Packet) bool {
-					h, ok := p.Record.Content.(*handshake.Handshake)
+				Retransmit: func(p *dtlsflight.Outbound) bool {
+					h, ok := p.Content.(*handshake.Handshake)
 					if !ok {
 						return false
 					}
@@ -341,7 +340,7 @@ func runHandshakeFSM12ForTest(
 	}
 }
 
-type packetFilter func(p *dtlsflight.Packet) bool
+type packetFilter func(p *dtlsflight.Outbound) bool
 
 type TestEndpoint struct {
 	Filter     packetFilter
@@ -414,7 +413,7 @@ func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description)
 
 func (c *flightTestConn) WritePackets( //nolint:cyclop
 	_ context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*dtlshandshake.WriteResult, error) {
 	time.Sleep(c.delay)
 	isRetransmit := false
@@ -425,15 +424,15 @@ func (c *flightTestConn) WritePackets( //nolint:cyclop
 		if c.retransmit != nil && c.retransmit(pkt) {
 			isRetransmit = true
 		}
-		if handshake, ok := pkt.Record.Content.(*handshake.Handshake); ok {
-			handshakeRaw, err := pkt.Record.Marshal()
+		if handshake, ok := pkt.Content.(*handshake.Handshake); ok {
+			handshakeRaw, err := handshake.Marshal()
 			if err != nil {
 				return nil, err
 			}
 
 			c.handshakeCache.Push(
-				handshakeRaw[recordlayer.FixedHeaderSize:],
-				pkt.Record.Header.Epoch,
+				handshakeRaw,
+				pkt.Epoch,
 				handshake.Header.MessageSequence,
 				handshake.Header.Type,
 				c.state.IsClient,
@@ -451,7 +450,7 @@ func (c *flightTestConn) WritePackets( //nolint:cyclop
 			}
 			c.otherEndCache.Push(
 				append(hdr, content...),
-				pkt.Record.Header.Epoch,
+				pkt.Epoch,
 				handshake.Header.MessageSequence,
 				handshake.Header.Type,
 				c.state.IsClient,

--- a/internal/flight/flight12/curves_test.go
+++ b/internal/flight/flight12/curves_test.go
@@ -32,7 +32,7 @@ func TestClientHelloFiltersX25519MLKEM768(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, elliptic.P256, state.NamedCurve)
 
-	content, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	content, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	clientHello, ok := content.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)

--- a/internal/flight/flight12/flight0handler.go
+++ b/internal/flight/flight12/flight0handler.go
@@ -174,7 +174,7 @@ func flight0Generate(
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	// Initialize
 	state.SetSRTPProtectionProfile(0)
 	if !cfg.InsecureSkipHelloVerify {

--- a/internal/flight/flight12/flight1handler.go
+++ b/internal/flight/flight12/flight1handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight1Parse(
@@ -70,7 +69,7 @@ func flight1Generate(
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	state.ResetConnectionIDs()
 	state.SetSRTPProtectionProfile(0)
 	state.LocalClientHelloSnapshots.Reset()
@@ -190,14 +189,9 @@ func flight1Generate(
 	}
 	content := handshake.Handshake{Message: clientHello}
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &content,
-			},
+			Content: &content,
 		},
 	}, nil, nil
 }

--- a/internal/flight/flight12/flight2handler.go
+++ b/internal/flight/flight12/flight2handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight2Parse(
@@ -67,20 +66,15 @@ func flight2Generate(
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	_ *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	state.HandshakeSendSequence = 0
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageHelloVerifyRequest{
 					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageHelloVerifyRequest{
-						Version: protocol.Version1_2,
-						Cookie:  state.Cookie,
-					},
+					Cookie:  state.Cookie,
 				},
 			},
 		},

--- a/internal/flight/flight12/flight3handler.go
+++ b/internal/flight/flight12/flight3handler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 //nolint:gocognit,gocyclo,maintidx,cyclop
@@ -318,7 +317,7 @@ func flight3Generate(
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	var extensions []extension.Value
 	if len(cfg.LocalSignatureSchemes) > 0 {
 		extensions = append(extensions, &extension.SignatureAlgorithms{
@@ -420,14 +419,9 @@ func flight3Generate(
 	}
 	content := handshake.Handshake{Message: clientHello}
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &content,
-			},
+			Content: &content,
 		},
 	}, nil, nil
 }

--- a/internal/flight/flight12/flight3handler_test.go
+++ b/internal/flight/flight12/flight3handler_test.go
@@ -45,7 +45,7 @@ func TestFlight3GenerateReusesHookOnlyConnectionIDAfterVersionDowngrade(t *testi
 			require.NoError(t, err)
 			require.Nil(t, dtlsAlert)
 			require.Len(t, packets, 1)
-			hand, ok := packets[0].Record.Content.(*handshake.Handshake)
+			hand, ok := packets[0].Content.(*handshake.Handshake)
 			require.True(t, ok)
 			clientHello, ok := hand.Message.(*handshake.MessageClientHello)
 			require.True(t, ok)
@@ -73,7 +73,7 @@ func TestFlight3GenerateRestoresCurveExtensionsAfterVersionDowngrade(t *testing.
 	require.Nil(t, dtlsAlert)
 	assert.Equal(t, elliptic.X25519, state.NamedCurve)
 
-	handshakeMessage, ok := packets[0].Record.Content.(*handshake.Handshake)
+	handshakeMessage, ok := packets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	clientHello, ok := handshakeMessage.Message.(*handshake.MessageClientHello)
 	require.True(t, ok)
@@ -244,7 +244,7 @@ func TestFlight4bGenerateCommitsConnectionIDOnce(t *testing.T) {
 				packets, _, err := generateForTest(t, Flight4b, nil, state, dtlsflight.NewCache(), cfg)
 				require.NoError(t, err)
 				require.Len(t, packets, 3)
-				assert.Equal(t, len(test.clientCID) > 0, packets[2].ShouldWrapCID)
+				assert.Equal(t, len(test.clientCID) > 0, state.ShouldWrapConnectionID())
 			}
 			assert.Equal(t, 1, calls)
 			assert.True(t, state.LocalCIDOffered && state.RemoteCIDOffered)
@@ -291,7 +291,7 @@ func TestFlight5bFinishedUsesCommittedServerConnectionID(t *testing.T) {
 			packets, _, err := generateForTest(t, Flight5b, nil, state, nil, &dtlsconfig.HandshakeConfig{})
 			require.NoError(t, err)
 			require.Len(t, packets, 2)
-			assert.Equal(t, decision != nil && len(decision.ServerCID) > 0, packets[1].ShouldWrapCID)
+			assert.Equal(t, decision != nil && len(decision.ServerCID) > 0, state.ShouldWrapConnectionID())
 		})
 	}
 }

--- a/internal/flight/flight12/flight4bhandler.go
+++ b/internal/flight/flight12/flight4bhandler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight4bParse(
@@ -68,8 +67,8 @@ func flight4bGenerate(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	var pkts []*dtlsflight.Packet
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
+	var pkts []*dtlsflight.Outbound
 	offer := state.RemoteClientHelloSnapshots.Current()
 	srtpSelection, err := negotiation.NegotiateSRTP(
 		offer, cfg.LocalSRTPProtectionProfiles, cfg.LocalSRTPMasterKeyIdentifier,
@@ -147,37 +146,20 @@ func flight4bGenerate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &serverHello,
-			},
+		&dtlsflight.Outbound{
+			Content: &serverHello,
 		},
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &protocol.ChangeCipherSpec{},
-			},
+		&dtlsflight.Outbound{
+			Content: &protocol.ChangeCipherSpec{},
 		},
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-					Epoch:   1,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageFinished{
-						VerifyData: state.LocalVerifyData,
-					},
+		&dtlsflight.Outbound{
+			Epoch: 1,
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageFinished{
+					VerifyData: state.LocalVerifyData,
 				},
 			},
-			ShouldEncrypt:            true,
-			ShouldWrapCID:            decision != nil && len(decision.ClientCID) > 0,
-			ResetLocalSequenceNumber: true,
+			Protection: dtlsflight.ProtectionCiphertext,
 		},
 	)
 	state.CommitNegotiatedExtensions(decision)

--- a/internal/flight/flight12/flight4handler.go
+++ b/internal/flight/flight12/flight4handler.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 //nolint:gocognit,gocyclo,lll,cyclop,maintidx
@@ -262,7 +261,7 @@ func flight4Generate(
 	state *dtlsstate.State12,
 	_ *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	offer := state.RemoteClientHelloSnapshots.Current()
 	extensions := []extension.Value{}
 	srtpSelection, err := negotiation.NegotiateSRTP(
@@ -304,7 +303,7 @@ func flight4Generate(
 		)
 	}
 
-	var pkts []*dtlsflight.Packet
+	var pkts []*dtlsflight.Outbound
 	cipherSuiteID := uint16(state.CipherSuite.ID())
 
 	if cfg.HasSessionStore {
@@ -337,13 +336,8 @@ func flight4Generate(
 	decision := negotiation.DecideConnectionID(offer, serverHello.Extensions)
 	content := handshake.Handshake{Message: serverHello}
 
-	pkts = append(pkts, &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &content,
-		},
+	pkts = append(pkts, &dtlsflight.Outbound{
+		Content: &content,
 	})
 
 	switch {
@@ -357,15 +351,10 @@ func flight4Generate(
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, err
 		}
 
-		pkts = append(pkts, &dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageCertificate{
-						Certificate: certificate.Certificate,
-					},
+		pkts = append(pkts, &dtlsflight.Outbound{
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageCertificate{
+					Certificate: certificate.Certificate,
 				},
 			},
 		})
@@ -402,20 +391,15 @@ func flight4Generate(
 		}
 		state.LocalKeySignature = signature
 
-		pkts = append(pkts, &dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageServerKeyExchange{
-						EllipticCurveType:  elliptic.CurveTypeNamedCurve,
-						NamedCurve:         state.NamedCurve,
-						PublicKey:          state.LocalKeypair.PublicKey,
-						HashAlgorithm:      signatureHashAlgo.Hash,
-						SignatureAlgorithm: signatureHashAlgo.Signature,
-						Signature:          state.LocalKeySignature,
-					},
+		pkts = append(pkts, &dtlsflight.Outbound{
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageServerKeyExchange{
+					EllipticCurveType:  elliptic.CurveTypeNamedCurve,
+					NamedCurve:         state.NamedCurve,
+					PublicKey:          state.LocalKeypair.PublicKey,
+					HashAlgorithm:      signatureHashAlgo.Hash,
+					SignatureAlgorithm: signatureHashAlgo.Signature,
+					Signature:          state.LocalKeySignature,
 				},
 			},
 		})
@@ -448,13 +432,8 @@ func flight4Generate(
 				content = handshake.Handshake{Message: certReq}
 			}
 
-			pkts = append(pkts, &dtlsflight.Packet{
-				Record: &recordlayer.RecordLayer{
-					Header: recordlayer.Header{
-						Version: protocol.Version1_2,
-					},
-					Content: &content,
-				},
+			pkts = append(pkts, &dtlsflight.Outbound{
+				Content: &content,
 			})
 		}
 	case cfg.LocalPSKIdentityHint != nil ||
@@ -473,26 +452,16 @@ func flight4Generate(
 			srvExchange.NamedCurve = state.NamedCurve
 			srvExchange.PublicKey = state.LocalKeypair.PublicKey
 		}
-		pkts = append(pkts, &dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: srvExchange,
-				},
+		pkts = append(pkts, &dtlsflight.Outbound{
+			Content: &handshake.Handshake{
+				Message: srvExchange,
 			},
 		})
 	}
 
-	pkts = append(pkts, &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &handshake.Handshake{
-				Message: &handshake.MessageServerHelloDone{},
-			},
+	pkts = append(pkts, &dtlsflight.Outbound{
+		Content: &handshake.Handshake{
+			Message: &handshake.MessageServerHelloDone{},
 		},
 	})
 	state.CommitNegotiatedExtensions(decision)

--- a/internal/flight/flight12/flight4handler_test.go
+++ b/internal/flight/flight12/flight4handler_test.go
@@ -155,7 +155,7 @@ func TestFlight4_CertificateRequestHook(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, p := range pkts {
-		if h, ok := p.Record.Content.(*handshake.Handshake); ok {
+		if h, ok := p.Content.(*handshake.Handshake); ok {
 			if h.Message.Type() == handshake.TypeCertificateRequest {
 				mcr := &handshake.MessageCertificateRequest{}
 				msg, err := h.Message.Marshal()

--- a/internal/flight/flight12/flight5bhandler.go
+++ b/internal/flight/flight12/flight5bhandler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight5bParse(
@@ -47,17 +46,12 @@ func flight5bGenerate(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	var pkts []*dtlsflight.Packet
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
+	var pkts []*dtlsflight.Outbound
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &protocol.ChangeCipherSpec{},
-			},
+		&dtlsflight.Outbound{
+			Content: &protocol.ChangeCipherSpec{},
 		})
 
 	if len(state.LocalVerifyData) == 0 {
@@ -75,21 +69,14 @@ func flight5bGenerate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-					Epoch:   1,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageFinished{
-						VerifyData: state.LocalVerifyData,
-					},
+		&dtlsflight.Outbound{
+			Epoch: 1,
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageFinished{
+					VerifyData: state.LocalVerifyData,
 				},
 			},
-			ShouldEncrypt:            true,
-			ShouldWrapCID:            state.ShouldWrapConnectionID(),
-			ResetLocalSequenceNumber: true,
+			Protection: dtlsflight.ProtectionCiphertext,
 		})
 
 	return pkts, nil, nil

--- a/internal/flight/flight12/flight5handler.go
+++ b/internal/flight/flight12/flight5handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight5Parse(
@@ -71,9 +70,9 @@ func flight5Generate(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	var signer crypto.Signer
-	var pkts []*dtlsflight.Packet
+	var pkts []*dtlsflight.Outbound
 	if state.RemoteRequestedCertificate { //nolint:nestif
 		pull := cache.FullPullMapItems(state.HandshakeRecvSequence-2, state.CipherSuite,
 			dtlsflight.HandshakeCachePullRule{Typ: handshake.TypeCertificateRequest, Epoch: cfg.InitialEpoch, IsClient: false, Optional: false}) //nolint:lll
@@ -107,15 +106,10 @@ func flight5Generate(
 			}
 		}
 		pkts = append(pkts,
-			&dtlsflight.Packet{
-				Record: &recordlayer.RecordLayer{
-					Header: recordlayer.Header{
-						Version: protocol.Version1_2,
-					},
-					Content: &handshake.Handshake{
-						Message: &handshake.MessageCertificate{
-							Certificate: certificate.Certificate,
-						},
+			&dtlsflight.Outbound{
+				Content: &handshake.Handshake{
+					Message: &handshake.MessageCertificate{
+						Certificate: certificate.Certificate,
 					},
 				},
 			})
@@ -132,14 +126,9 @@ func flight5Generate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: clientKeyExchange,
-				},
+		&dtlsflight.Outbound{
+			Content: &handshake.Handshake{
+				Message: clientKeyExchange,
 			},
 		})
 
@@ -158,7 +147,7 @@ func flight5Generate(
 	merged := []byte{}
 	seqPred := uint16(state.HandshakeSendSequence) //nolint:gosec // G115
 	for _, p := range pkts {
-		h, ok := p.Record.Content.(*handshake.Handshake)
+		h, ok := p.Content.(*handshake.Handshake)
 		if !ok {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, dtlserrors.ErrInvalidContentType
 		}
@@ -206,23 +195,18 @@ func flight5Generate(
 		}
 		state.LocalCertificatesVerify = certVerify
 
-		pkt := &dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageCertificateVerify{
-						HashAlgorithm:      signatureHashAlgo.Hash,
-						SignatureAlgorithm: signatureHashAlgo.Signature,
-						Signature:          state.LocalCertificatesVerify,
-					},
+		pkt := &dtlsflight.Outbound{
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageCertificateVerify{
+					HashAlgorithm:      signatureHashAlgo.Hash,
+					SignatureAlgorithm: signatureHashAlgo.Signature,
+					Signature:          state.LocalCertificatesVerify,
 				},
 			},
 		}
 		pkts = append(pkts, pkt)
 
-		h, ok := pkt.Record.Content.(*handshake.Handshake)
+		h, ok := pkt.Content.(*handshake.Handshake)
 		if !ok {
 			return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}, dtlserrors.ErrInvalidContentType
 		}
@@ -236,13 +220,8 @@ func flight5Generate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &protocol.ChangeCipherSpec{},
-			},
+		&dtlsflight.Outbound{
+			Content: &protocol.ChangeCipherSpec{},
 		})
 
 	if len(state.LocalVerifyData) == 0 {
@@ -260,21 +239,14 @@ func flight5Generate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-					Epoch:   1,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageFinished{
-						VerifyData: state.LocalVerifyData,
-					},
+		&dtlsflight.Outbound{
+			Epoch: 1,
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageFinished{
+					VerifyData: state.LocalVerifyData,
 				},
 			},
-			ShouldWrapCID:            state.ShouldWrapConnectionID(),
-			ShouldEncrypt:            true,
-			ResetLocalSequenceNumber: true,
+			Protection: dtlsflight.ProtectionCiphertext,
 		})
 
 	return pkts, nil, nil

--- a/internal/flight/flight12/flight6handler.go
+++ b/internal/flight/flight12/flight6handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight6Parse(
@@ -47,17 +46,12 @@ func flight6Generate(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
-	var pkts []*dtlsflight.Packet
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
+	var pkts []*dtlsflight.Outbound
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &protocol.ChangeCipherSpec{},
-			},
+		&dtlsflight.Outbound{
+			Content: &protocol.ChangeCipherSpec{},
 		})
 
 	if len(state.LocalVerifyData) == 0 {
@@ -71,21 +65,14 @@ func flight6Generate(
 	}
 
 	pkts = append(pkts,
-		&dtlsflight.Packet{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-					Epoch:   1,
-				},
-				Content: &handshake.Handshake{
-					Message: &handshake.MessageFinished{
-						VerifyData: state.LocalVerifyData,
-					},
+		&dtlsflight.Outbound{
+			Epoch: 1,
+			Content: &handshake.Handshake{
+				Message: &handshake.MessageFinished{
+					VerifyData: state.LocalVerifyData,
 				},
 			},
-			ShouldWrapCID:            state.ShouldWrapConnectionID(),
-			ShouldEncrypt:            true,
-			ResetLocalSequenceNumber: true,
+			Protection: dtlsflight.ProtectionCiphertext,
 		},
 	)
 

--- a/internal/flight/flight12/flight_test_helpers_test.go
+++ b/internal/flight/flight12/flight_test_helpers_test.go
@@ -39,7 +39,7 @@ func generateForTest(
 	state *dtlsstate.State12,
 	cache *dtlsflight.Cache, //nolint:unparam
 	cfg *dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {
 		helper.Helper()
 	}

--- a/internal/flight/flight12/flighthandler.go
+++ b/internal/flight/flight12/flighthandler.go
@@ -34,7 +34,7 @@ type Generator func(
 	*dtlsstate.State12,
 	*dtlsflight.Cache,
 	*dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error)
+) ([]*dtlsflight.Outbound, *alert.Alert, error)
 
 func getFlightParser(f Flight) (flightParser, bool) { //nolint:cyclop
 	switch f {

--- a/internal/flight/flight12/srtp_test.go
+++ b/internal/flight/flight12/srtp_test.go
@@ -180,10 +180,10 @@ func pushHandshake12(t *testing.T, cache *dtlsflight.Cache, sequence uint16, mes
 	cache.Push(raw, 0, sequence, message.Type(), false)
 }
 
-func serverHelloSRTPSelection12(t *testing.T, packets []*dtlsflight.Packet) *extension.SRTPSelection {
+func serverHelloSRTPSelection12(t *testing.T, packets []*dtlsflight.Outbound) *extension.SRTPSelection {
 	t.Helper()
 	require.NotEmpty(t, packets)
-	handshakePacket, ok := packets[0].Record.Content.(*handshake.Handshake)
+	handshakePacket, ok := packets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	serverHello, ok := handshakePacket.Message.(*handshake.MessageServerHello)
 	require.True(t, ok)

--- a/internal/flight/flight13/flight0handler.go
+++ b/internal/flight/flight13/flight0handler.go
@@ -119,7 +119,7 @@ func flight0Parse(
 func flight0Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 	state.SetSRTPProtectionProfile(0)

--- a/internal/flight/flight13/flight1handler.go
+++ b/internal/flight/flight13/flight1handler.go
@@ -18,14 +18,13 @@ import (
 	extension12 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls12"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 //nolint:cyclop
 func flight1Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 	state.ResetConnectionIDs()
@@ -160,14 +159,9 @@ func flight1Generate(
 	}
 	content := handshake.Handshake{Message: clientHello}
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &content,
-			},
+			Content: &content,
 		},
 	}, nil, nil
 }

--- a/internal/flight/flight13/flight2handler.go
+++ b/internal/flight/flight13/flight2handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight2Parse( //nolint:cyclop
@@ -70,7 +69,7 @@ func flight2Parse( //nolint:cyclop
 func flight2Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	flightCtx.state.HandshakeSendSequence = 0
 	if flightCtx.state.CipherSuite == nil {
 		return nil, nil, dtlserrors.ErrCipherSuiteUnset
@@ -119,15 +118,10 @@ func flight2Generate(
 	}
 	flightCtx.state.HelloRetryRequest = request
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &handshake.Handshake{
-					Message: serverHello,
-				},
+			Content: &handshake.Handshake{
+				Message: serverHello,
 			},
 		},
 	}, nil, nil

--- a/internal/flight/flight13/flight3handler.go
+++ b/internal/flight/flight13/flight3handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 func flight3Parse(
@@ -298,7 +297,7 @@ func handleFlight3ProtectedHandshake(
 func flight3Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	if !slices.Contains(flightCtx.state.RemoteVersions, protocol.Version1_3) {
 		return nil, nil, dtlserrors.ErrNoCommonProtocolVersion
 	}
@@ -338,14 +337,9 @@ func flight3Generate(
 	}
 	content := handshake.Handshake{Message: clientHello}
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		{
-			Record: &recordlayer.RecordLayer{
-				Header: recordlayer.Header{
-					Version: protocol.Version1_2,
-				},
-				Content: &content,
-			},
+			Content: &content,
 		},
 	}, nil, nil
 }

--- a/internal/flight/flight13/flight4handler.go
+++ b/internal/flight/flight13/flight4handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 // flight4Parse processes the client's protected final flight. The parser is
@@ -172,7 +171,7 @@ func needsClientKeypair(state *dtlsstate.State13) bool {
 func flight4Generate( //nolint:cyclop
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	state := flightCtx.state
 	cfg := flightCtx.cfg
 
@@ -260,11 +259,8 @@ func flight4Generate( //nolint:cyclop
 	}
 	decision := negotiation.DecideConnectionID(offer, serverHelloExtensions)
 
-	serverHello := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2},
-			Content: &handshake.Handshake{Message: serverHelloMessage},
-		},
+	serverHello := &dtlsflight.Outbound{
+		Content: &handshake.Handshake{Message: serverHelloMessage},
 	}
 
 	encryptedExtensionsList := []extension.Value{}
@@ -277,9 +273,8 @@ func flight4Generate( //nolint:cyclop
 	encryptedExtensions := HandshakePacket(&handshake.MessageEncryptedExtensions{
 		Extensions: encryptedExtensionsList,
 	})
-	encryptedExtensions.ResetLocalSequenceNumber = true
 
-	pkts := []*dtlsflight.Packet{
+	pkts := []*dtlsflight.Outbound{
 		serverHello,
 		encryptedExtensions,
 	}

--- a/internal/flight/flight13/flight5handler.go
+++ b/internal/flight/flight13/flight5handler.go
@@ -22,23 +22,22 @@ import (
 func flight5Generate(
 	_ dtlsflight.Conn,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	pkts, dtlsAlert, err := flight5ClientAuthPackets(flightCtx)
 	if err != nil {
 		return nil, dtlsAlert, err
 	}
 	pkts = append(pkts, HandshakePacket(&handshake.MessageFinished{}))
-	pkts[0].ResetLocalSequenceNumber = true
 
 	return pkts, nil, nil
 }
 
 func flight5ClientAuthPackets(
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	certificateRequest := flightCtx.state.RemoteCertificateRequest
 	if certificateRequest == nil {
-		return []*dtlsflight.Packet{}, nil, nil
+		return []*dtlsflight.Outbound{}, nil, nil
 	}
 
 	certificate, err := flight5ClientCertificate(flightCtx.cfg, certificateRequest)
@@ -46,7 +45,7 @@ func flight5ClientAuthPackets(
 		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.HandshakeFailure}, err
 	}
 	if len(certificate.Certificate) == 0 {
-		return []*dtlsflight.Packet{
+		return []*dtlsflight.Outbound{
 			HandshakePacket(&handshake.MessageCertificate13{
 				CertificateRequestContext: append(
 					[]byte(nil),
@@ -71,7 +70,7 @@ func flight5ClientAuthPackets(
 		return nil, &alert.Alert{Level: alert.Fatal, Description: alert.InsufficientSecurity}, err
 	}
 
-	return []*dtlsflight.Packet{
+	return []*dtlsflight.Outbound{
 		HandshakePacket(&handshake.MessageCertificate13{
 			CertificateRequestContext: append(
 				[]byte(nil),

--- a/internal/flight/flight13/flighthandler.go
+++ b/internal/flight/flight13/flighthandler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 const (
@@ -42,14 +41,14 @@ type flightParser func(
 	*handshakeContext,
 ) (Flight, *alert.Alert, error)
 
-type contextFlightGenerator func(dtlsflight.Conn, *handshakeContext) ([]*dtlsflight.Packet, *alert.Alert, error)
+type contextFlightGenerator func(dtlsflight.Conn, *handshakeContext) ([]*dtlsflight.Outbound, *alert.Alert, error)
 
 type Generator func(
 	dtlsflight.Conn,
 	*dtlsstate.State13,
 	*dtlsflight.Cache,
 	*dtlsconfig.HandshakeConfig,
-) ([]*dtlsflight.Packet, *alert.Alert, error)
+) ([]*dtlsflight.Outbound, *alert.Alert, error)
 
 type InboundHandshakeHandler func(dtlsconfig.CipherSuite, []dtlsflight.DecodedHandshakeCacheItem) error
 
@@ -245,7 +244,7 @@ func adaptFlightGenerator(gen contextFlightGenerator) Generator {
 		state *dtlsstate.State13,
 		cache *dtlsflight.Cache,
 		cfg *dtlsconfig.HandshakeConfig,
-	) ([]*dtlsflight.Packet, *alert.Alert, error) {
+	) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 		return gen(conn, newHandshakeContext(ParseDependencies{
 			State:  state,
 			Cache:  cache,
@@ -293,23 +292,18 @@ func Parse(
 	return nextFlight, dtlsAlert, err, true
 }
 
-func HandshakePacket(message handshake.Message) *dtlsflight.Packet {
-	return &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   EpochHandshake,
-			},
-			Content: &handshake.Handshake{Message: message},
-		},
-		ShouldEncrypt: true,
+func HandshakePacket(message handshake.Message) *dtlsflight.Outbound {
+	return &dtlsflight.Outbound{
+		Epoch:      EpochHandshake,
+		Content:    &handshake.Handshake{Message: message},
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 }
 
 func CertificateVerifyPacket(
 	message *handshake.MessageCertificateVerify,
 	signer crypto.Signer,
-) *dtlsflight.Packet {
+) *dtlsflight.Outbound {
 	pkt := HandshakePacket(message)
 	pkt.CertificateVerifySigner = signer
 

--- a/internal/flight/flight13/srtp_test.go
+++ b/internal/flight/flight13/srtp_test.go
@@ -56,9 +56,9 @@ func TestFlight4GenerateNegotiatesSRTPInEncryptedExtensions(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(packets), 2)
-			serverHello := packets[0].Record.Content.(*handshake.Handshake).Message.(*handshake.MessageServerHello) //nolint:forcetypeassert,lll
+			serverHello := packets[0].Content.(*handshake.Handshake).Message.(*handshake.MessageServerHello) //nolint:forcetypeassert,lll
 			assert.False(t, hasSRTPSelection13(serverHello.Extensions))
-			encryptedExtensions := packets[1].Record.Content.(*handshake.Handshake).Message.(*handshake.MessageEncryptedExtensions) //nolint:forcetypeassert,lll
+			encryptedExtensions := packets[1].Content.(*handshake.Handshake).Message.(*handshake.MessageEncryptedExtensions) //nolint:forcetypeassert,lll
 			selection := findSRTPSelection13(encryptedExtensions.Extensions)
 			require.NotNil(t, selection)
 			assert.Equal(t, srtpProfile13, selection.ProtectionProfile)

--- a/internal/flight/types.go
+++ b/internal/flight/types.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"crypto"
 
+	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 type Conn interface {
@@ -16,14 +16,23 @@ type Conn interface {
 	SessionKey() []byte
 }
 
-type Packet struct {
-	Record         *recordlayer.RecordLayer
-	ShouldEncrypt  bool
-	ShouldWrapCID  bool
-	ShouldTrackACK bool
+// Protection describes the protection required for an outbound
+// record.
+type Protection uint8
+
+const (
+	ProtectionPlaintext Protection = iota
+	ProtectionCiphertext
+)
+
+// Outbound describes semantic record intent.
+type Outbound struct {
+	Epoch      uint16
+	Content    protocol.Content
+	Protection Protection
+	TrackACK   bool
 	// HandshakeFragmentOffsets limits a retransmission to offset:length pairs.
 	HandshakeFragmentOffsets map[uint32]uint32
-	ResetLocalSequenceNumber bool
 
 	// CertificateVerifySigner is local-only metadata used to populate an
 	// outbound CertificateVerify after the handshake messages have been committed.

--- a/internal/handshake/conn.go
+++ b/internal/handshake/conn.go
@@ -9,7 +9,6 @@ import (
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 // RecvHandshakeState signals that a handshake packet has been received.
@@ -83,7 +82,7 @@ type FSM interface {
 type Conn interface {
 	dtlsflight.Conn
 	Notify(ctx context.Context, level alert.Level, desc alert.Description) error
-	WritePackets(context.Context, []*dtlsflight.Packet) (*WriteResult, error)
+	WritePackets(context.Context, []*dtlsflight.Outbound) (*WriteResult, error)
 	RecvHandshake() <-chan RecvHandshakeState
 	SetLocalEpoch(epoch uint16)
 }
@@ -101,12 +100,10 @@ func sendACK(ctx context.Context, conn Conn, epoch uint16, records []protocol.Re
 		return nil
 	}
 
-	_, err := conn.WritePackets(ctx, []*dtlsflight.Packet{{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2, Epoch: epoch},
-			Content: &protocol.ACK{Records: records},
-		},
-		ShouldEncrypt: true,
+	_, err := conn.WritePackets(ctx, []*dtlsflight.Outbound{{
+		Epoch:      epoch,
+		Content:    &protocol.ACK{Records: records},
+		Protection: dtlsflight.ProtectionCiphertext,
 	}})
 
 	return err

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -53,7 +53,7 @@ import (
 
 type fsm12 struct {
 	currentFlight      dtlsflight12.Flight
-	flights            []*dtlsflight.Packet
+	flights            []*dtlsflight.Outbound
 	retransmit         bool
 	retransmitInterval time.Duration
 	state              *dtlsstate.State12
@@ -68,7 +68,7 @@ func NewFSM12(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight12.Flight,
-	initialFlights []*dtlsflight.Packet,
+	initialFlights []*dtlsflight.Outbound,
 	establishment *Establishment,
 ) FSM {
 	return &fsm12{
@@ -116,7 +116,7 @@ func (s *fsm12) prepare(ctx context.Context, conn Conn) (State, error) {
 	var (
 		dtlsAlert *alert.Alert
 		err       error
-		pkts      []*dtlsflight.Packet
+		pkts      []*dtlsflight.Outbound
 	)
 	gen, retransmit, ok := dtlsflight12.GetGenerator(s.currentFlight)
 	if !ok {
@@ -134,11 +134,11 @@ func (s *fsm12) prepare(ctx context.Context, conn Conn) (State, error) {
 	epoch := s.cfg.InitialEpoch
 	nextEpoch := epoch
 	for _, p := range s.flights {
-		p.Record.Header.Epoch += epoch
-		if p.Record.Header.Epoch > nextEpoch {
-			nextEpoch = p.Record.Header.Epoch
+		p.Epoch += epoch
+		if p.Epoch > nextEpoch {
+			nextEpoch = p.Epoch
 		}
-		if h, ok := p.Record.Content.(*handshake.Handshake); ok {
+		if h, ok := p.Content.(*handshake.Handshake); ok {
 			h.Header.MessageSequence = uint16(s.state.HandshakeSendSequence) //nolint:gosec // G115
 			s.state.HandshakeSendSequence++
 		}

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -68,7 +68,7 @@ import (
 
 type fsm13 struct {
 	currentFlight      dtlsflight13.Flight
-	flights            []*dtlsflight.Packet
+	flights            []*dtlsflight.Outbound
 	retransmit         bool
 	retransmitInterval time.Duration
 	flightACK          reliableFlight
@@ -84,7 +84,7 @@ func NewFSM13(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight13.Flight,
-	initialFlights []*dtlsflight.Packet,
+	initialFlights []*dtlsflight.Outbound,
 	establishment *Establishment,
 ) (FSM, error) {
 	return newFSM13WithEstablishment(state, cache, cfg, initialFlight, initialFlights, nil, establishment)
@@ -95,7 +95,7 @@ func newFSM13(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight13.Flight,
-	initialFlights []*dtlsflight.Packet,
+	initialFlights []*dtlsflight.Outbound,
 	initialTranscript *Transcript,
 ) (*fsm13, error) {
 	return newFSM13WithEstablishment(
@@ -108,7 +108,7 @@ func newFSM13WithEstablishment(
 	cache *dtlsflight.Cache,
 	cfg *dtlsconfig.HandshakeConfig,
 	initialFlight dtlsflight13.Flight,
-	initialFlights []*dtlsflight.Packet,
+	initialFlights []*dtlsflight.Outbound,
 	initialTranscript *Transcript,
 	establishment *Establishment,
 ) (*fsm13, error) {
@@ -178,20 +178,20 @@ type KeyUpdater interface {
 // ApplicationDataWriter serializes DTLS 1.3 application data with
 // post-handshake messages.
 type ApplicationDataWriter interface {
-	WriteApplicationData(context.Context, []*dtlsflight.Packet) error
+	WriteApplicationData(context.Context, []*dtlsflight.Outbound) error
 }
 
 // WriteApplicationData queues application records on the post-handshake state
 // machine. In particular, a required KeyUpdate response already in the queue is
 // emitted before these records.
-func (s *fsm13) WriteApplicationData(ctx context.Context, packets []*dtlsflight.Packet) error {
+func (s *fsm13) WriteApplicationData(ctx context.Context, packets []*dtlsflight.Outbound) error {
 	completion, completionCtx := newPostHandshakeCompletion()
 	command := postHandshakeCommand{
 		Kind:       commandSendApplicationData,
 		Canceled:   ctx.Done(),
 		Packets:    packets,
 		Completion: completion,
-		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+		Write: func(conn Conn, packets []*dtlsflight.Outbound) error {
 			_, err := conn.WritePackets(ctx, packets)
 
 			return err
@@ -267,7 +267,7 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 	// Prepare flights
 	var (
 		dtlsAlert *alert.Alert
-		pkts      []*dtlsflight.Packet
+		pkts      []*dtlsflight.Outbound
 	)
 	gen, retransmit, ok := dtlsflight13.GetGenerator(s.currentFlight)
 	if !ok {
@@ -436,11 +436,11 @@ func (s *fsm13) handlePreviousFlightRetransmit(
 	return s.transitionAfterACK(ackResult, true), nil
 }
 
-func (s *fsm13) prepareFlightACKTracking(flights []*dtlsflight.Packet, retransmit bool) {
+func (s *fsm13) prepareFlightACKTracking(flights []*dtlsflight.Outbound, retransmit bool) {
 	s.flightACK.reset()
 	if retransmit {
 		for _, packet := range flights {
-			_, packet.ShouldTrackACK = packet.Record.Content.(*handshake.Handshake)
+			_, packet.TrackACK = packet.Content.(*handshake.Handshake)
 		}
 	}
 }
@@ -449,7 +449,7 @@ func (s *fsm13) applyACKProgress(result ACKResult) {
 	for _, progress := range result.Messages {
 		remaining := s.flights[:0]
 		for _, packet := range s.flights {
-			message, ok := packet.Record.Content.(*handshake.Handshake)
+			message, ok := packet.Content.(*handshake.Handshake)
 			if !ok || message.Header.MessageSequence != progress.MessageSequence {
 				remaining = append(remaining, packet)
 			} else if !progress.Complete {

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +41,7 @@ func flight13GenerateForTest(
 	testingT require.TestingT,
 	flight dtlsflight13.Flight,
 	flightCtx *handshakeContext,
-) ([]*dtlsflight.Packet, *alert.Alert, error) {
+) ([]*dtlsflight.Outbound, *alert.Alert, error) {
 	if helper, ok := testingT.(interface{ Helper() }); ok {
 		helper.Helper()
 	}
@@ -57,9 +56,9 @@ type flightTestConn struct {
 	localEpoch          uint16
 	setLocalEpochCalled bool
 	handleQueuedPackets func(context.Context) error
-	writePackets        func(context.Context, []*dtlsflight.Packet) error
+	writePackets        func(context.Context, []*dtlsflight.Outbound) error
 	recvHandshake       chan RecvHandshakeState
-	writtenPackets      []*dtlsflight.Packet
+	writtenPackets      []*dtlsflight.Outbound
 }
 
 func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description) error {
@@ -68,7 +67,7 @@ func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description)
 
 func (c *flightTestConn) WritePackets(
 	ctx context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*WriteResult, error) {
 	c.writtenPackets = append(c.writtenPackets, pkts...)
 	if c.writePackets != nil {
@@ -208,9 +207,9 @@ func TestHandshakeFSM13SendACKUsesCurrentEpoch(t *testing.T) {
 
 	require.NoError(t, sendACK(context.Background(), conn, fsm.state.LocalEpoch(), records))
 	require.Len(t, conn.writtenPackets, 1)
-	assert.True(t, conn.writtenPackets[0].ShouldEncrypt)
-	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Record.Header.Epoch)
-	ack, ok := conn.writtenPackets[0].Record.Content.(*protocol.ACK)
+	assert.True(t, conn.writtenPackets[0].Protection == dtlsflight.ProtectionCiphertext)
+	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Epoch)
+	ack, ok := conn.writtenPackets[0].Content.(*protocol.ACK)
 	require.True(t, ok)
 	assert.Equal(t, records, ack.Records)
 }
@@ -270,7 +269,7 @@ func TestHandshakeFSM13DualStackClientHelloSeedsTranscript(t *testing.T) {
 	require.Len(t, pkts, 1)
 
 	const messageSequence = 7
-	content, ok := pkts[0].Record.Content.(*handshake.Handshake)
+	content, ok := pkts[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	content.Header.MessageSequence = messageSequence
 
@@ -331,7 +330,7 @@ func TestHandshakeFSM13DualStackClientHelloRequired(t *testing.T) {
 	cfg := testHandshakeConfig13(t)
 
 	fsm, err := newFSM13(
-		state, cache, cfg, dtlsflight13.Flight1, []*dtlsflight.Packet{}, nil,
+		state, cache, cfg, dtlsflight13.Flight1, []*dtlsflight.Outbound{}, nil,
 	)
 	require.Nil(t, fsm)
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMissingClientHello)
@@ -386,7 +385,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscri
 	transcript := NewTranscript()
 	clientHello := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
 	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello)
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{clientHello}))
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{clientHello}))
 
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight2, nil, transcript)
 	require.NoError(t, err)
@@ -422,7 +421,7 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 	transcript := NewTranscript()
 	clientHello := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
 	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello)
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{clientHello}))
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{clientHello}))
 
 	fsm, err := newFSM13(state, dtlsflight.NewCache(), cfg, dtlsflight13.Flight4, nil, transcript)
 	require.NoError(t, err)
@@ -434,10 +433,9 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, StateSending, nextState)
 	require.Len(t, fsm.flights, 5)
-	for i, pkt := range fsm.flights[1:] {
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
-		assert.True(t, pkt.ShouldEncrypt)
-		assert.Equal(t, i == 0, pkt.ResetLocalSequenceNumber)
+	for _, pkt := range fsm.flights[1:] {
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Epoch)
+		assert.True(t, pkt.Protection == dtlsflight.ProtectionCiphertext)
 	}
 
 	serverHelloCanonical := canonicalPacketHandshake13(t, fsm.flights[0])
@@ -454,7 +452,7 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 	require.NoError(t, err)
 	clientVerifyInput, err := CertificateVerifyInputFromTranscript(true, certificateVerifyTranscript)
 	require.NoError(t, err)
-	certificateVerifyHandshake := fsm.flights[3].Record.Content.(*handshake.Handshake)            //nolint:forcetypeassert
+	certificateVerifyHandshake := fsm.flights[3].Content.(*handshake.Handshake)                   //nolint:forcetypeassert
 	certificateVerify := certificateVerifyHandshake.Message.(*handshake.MessageCertificateVerify) //nolint:forcetypeassert
 	require.NoError(t, dtlscrypto.VerifyCertificateVerify(
 		serverVerifyInput,
@@ -471,7 +469,7 @@ func TestCommitPreparedFlightsInitializesProtectionBeforeProtectedPackets(t *tes
 		cfg.LocalCertificates[0].Certificate,
 	))
 
-	finishedHandshake, ok := fsm.flights[4].Record.Content.(*handshake.Handshake)
+	finishedHandshake, ok := fsm.flights[4].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	finished, ok := finishedHandshake.Message.(*handshake.MessageFinished)
 	require.True(t, ok)
@@ -544,12 +542,11 @@ func TestHandshakeFSM13SendsFlight4ProtectedRecords(t *testing.T) {
 	assert.Equal(t, StateWaiting, nextState)
 	require.Len(t, conn.writtenPackets, 5)
 
-	assert.False(t, conn.writtenPackets[0].ShouldEncrypt)
-	assert.Equal(t, dtlsflight13.EpochInitial, conn.writtenPackets[0].Record.Header.Epoch)
-	for i, pkt := range conn.writtenPackets[1:] {
-		assert.True(t, pkt.ShouldEncrypt)
-		assert.Equal(t, i == 0, pkt.ResetLocalSequenceNumber)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
+	assert.False(t, conn.writtenPackets[0].Protection == dtlsflight.ProtectionCiphertext)
+	assert.Equal(t, dtlsflight13.EpochInitial, conn.writtenPackets[0].Epoch)
+	for _, pkt := range conn.writtenPackets[1:] {
+		assert.True(t, pkt.Protection == dtlsflight.ProtectionCiphertext)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Epoch)
 	}
 	assert.True(t, fixture.serverState.CipherSuite.IsInitialized())
 	assert.True(t, conn.setLocalEpochCalled)
@@ -583,7 +580,7 @@ func TestHandshakeFSM13ServerFlight4KeepsReaderPausedThroughQueueDrain(t *testin
 	assertFlight13RecvDoneOpen(t, recvState)
 
 	queueDrains := 0
-	conn.writePackets = func(context.Context, []*dtlsflight.Packet) error {
+	conn.writePackets = func(context.Context, []*dtlsflight.Outbound) error {
 		assertFlight13RecvDoneOpen(t, recvState)
 
 		return nil
@@ -733,7 +730,7 @@ func TestHandshakeFSM13WaitParsesProtectedEncryptedExtensions(t *testing.T) {
 	assertFlight13RecvDoneOpen(t, recvState)
 	assertFlight13ClientTranscriptThroughServerFinished(t, fsm.transcript)
 
-	conn.writePackets = func(context.Context, []*dtlsflight.Packet) error {
+	conn.writePackets = func(context.Context, []*dtlsflight.Outbound) error {
 		assertFlight13RecvDoneOpen(t, recvState)
 
 		return nil
@@ -787,9 +784,9 @@ func TestHandshakeFSM13PartialProtectedServerFlightACKUsesHandshakeEpoch(t *test
 	assert.Equal(t, StateWaiting, transition.state)
 	require.Len(t, conn.writtenPackets, 1)
 	ackPacket := conn.writtenPackets[0]
-	assert.True(t, ackPacket.ShouldEncrypt)
-	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Record.Header.Epoch)
-	ack, ok := ackPacket.Record.Content.(*protocol.ACK)
+	assert.True(t, ackPacket.Protection == dtlsflight.ProtectionCiphertext)
+	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Epoch)
+	ack, ok := ackPacket.Content.(*protocol.ACK)
 	require.True(t, ok)
 	assert.Equal(t, []protocol.RecordNumber{record}, ack.Records)
 	fsm.received.release()
@@ -874,11 +871,10 @@ func TestHandshakeFSM13ClientFlight5GeneratesFinished(t *testing.T) {
 	require.Len(t, fsm.flights, 1)
 
 	pkt := fsm.flights[0]
-	assert.True(t, pkt.ShouldEncrypt)
-	assert.True(t, pkt.ResetLocalSequenceNumber)
-	assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
+	assert.True(t, pkt.Protection == dtlsflight.ProtectionCiphertext)
+	assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Epoch)
 
-	finishedHandshake, ok := pkt.Record.Content.(*handshake.Handshake)
+	finishedHandshake, ok := pkt.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	assert.Equal(t, uint16(1), finishedHandshake.Header.MessageSequence)
 	finished, ok := finishedHandshake.Message.(*handshake.MessageFinished)
@@ -934,9 +930,9 @@ func TestHandshakeFSM13ClientFlight5HandlesPreviousFlightRetransmit(t *testing.T
 	assert.Equal(t, dtlsflight13.Flight5, fsm.currentFlight)
 	require.Len(t, conn.writtenPackets, 1)
 	ackPacket := conn.writtenPackets[0]
-	assert.True(t, ackPacket.ShouldEncrypt)
-	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Record.Header.Epoch)
-	ack, ok := ackPacket.Record.Content.(*protocol.ACK)
+	assert.True(t, ackPacket.Protection == dtlsflight.ProtectionCiphertext)
+	assert.Equal(t, dtlsflight13.EpochHandshake, ackPacket.Epoch)
+	ack, ok := ackPacket.Content.(*protocol.ACK)
 	require.True(t, ok)
 	assert.Equal(t, []protocol.RecordNumber{record}, ack.Records)
 	fsm.received.release()
@@ -957,7 +953,7 @@ func TestHandshakeFSM13SendErrorReleasesReader(t *testing.T) {
 			fsm := clientFSMThroughServerFlight13(t, newNoHRRFlight13Fixture(t))
 			recvState := RecvHandshakeState{Done: fsm.received.done}
 			conn := &flightTestConn{
-				writePackets: func(context.Context, []*dtlsflight.Packet) error {
+				writePackets: func(context.Context, []*dtlsflight.Outbound) error {
 					assertFlight13RecvDoneOpen(t, recvState)
 
 					return test.writeErr
@@ -1006,17 +1002,16 @@ func TestHandshakeFSM13ClientFlight5WithCertificate(t *testing.T) {
 		handshake.TypeFinished,
 	}
 	for i, pkt := range fsm.flights {
-		assert.True(t, pkt.ShouldEncrypt)
-		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Record.Header.Epoch)
-		assert.Equal(t, i == 0, pkt.ResetLocalSequenceNumber)
+		assert.True(t, pkt.Protection == dtlsflight.ProtectionCiphertext)
+		assert.Equal(t, dtlsflight13.EpochHandshake, pkt.Epoch)
 
-		hs, ok := pkt.Record.Content.(*handshake.Handshake)
+		hs, ok := pkt.Content.(*handshake.Handshake)
 		require.True(t, ok)
 		assert.Equal(t, expectedTypes[i], hs.Message.Type())
 		assert.Equal(t, uint16(i+1), hs.Header.MessageSequence)
 	}
 
-	certificateHandshake := fsm.flights[0].Record.Content.(*handshake.Handshake)  //nolint:forcetypeassert
+	certificateHandshake := fsm.flights[0].Content.(*handshake.Handshake)         //nolint:forcetypeassert
 	certificate := certificateHandshake.Message.(*handshake.MessageCertificate13) //nolint:forcetypeassert
 	assert.Equal(t, []byte{0x01, 0x02, 0x03}, certificate.CertificateRequestContext)
 	require.Len(t, certificate.CertificateList, len(clientCertificate.Certificate))
@@ -1035,7 +1030,7 @@ func TestHandshakeFSM13ClientFlight5WithCertificate(t *testing.T) {
 	certificateVerifyInput, err := CertificateVerifyInputFromTranscript(true, expectedTranscript)
 	require.NoError(t, err)
 
-	certificateVerifyHandshake := fsm.flights[1].Record.Content.(*handshake.Handshake)            //nolint:forcetypeassert
+	certificateVerifyHandshake := fsm.flights[1].Content.(*handshake.Handshake)                   //nolint:forcetypeassert
 	certificateVerify := certificateVerifyHandshake.Message.(*handshake.MessageCertificateVerify) //nolint:forcetypeassert
 	require.NotEmpty(t, certificateVerify.Signature)
 	require.NoError(t, dtlscrypto.VerifyCertificateVerify(
@@ -1061,8 +1056,8 @@ func TestHandshakeFSM13ClientFlight5WithCertificate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	finishedHandshake := fsm.flights[2].Record.Content.(*handshake.Handshake) //nolint:forcetypeassert
-	finished := finishedHandshake.Message.(*handshake.MessageFinished)        //nolint:forcetypeassert
+	finishedHandshake := fsm.flights[2].Content.(*handshake.Handshake) //nolint:forcetypeassert
+	finished := finishedHandshake.Message.(*handshake.MessageFinished) //nolint:forcetypeassert
 	assert.Equal(t, expectedVerifyData, finished.VerifyData)
 
 	require.NoError(t, AppendOutboundHandshakeFlight(
@@ -1120,13 +1115,13 @@ func TestHandshakeFSM13ClientFlight5WithoutClientCertificate(t *testing.T) {
 			require.Len(t, fsm.flights, len(test.expectedTypes))
 
 			for i, expectedType := range test.expectedTypes {
-				hs, ok := fsm.flights[i].Record.Content.(*handshake.Handshake)
+				hs, ok := fsm.flights[i].Content.(*handshake.Handshake)
 				require.True(t, ok)
 				assert.Equal(t, expectedType, hs.Message.Type())
 			}
 
 			if test.expectedTypes[0] == handshake.TypeCertificate {
-				hs := fsm.flights[0].Record.Content.(*handshake.Handshake)  //nolint:forcetypeassert
+				hs := fsm.flights[0].Content.(*handshake.Handshake)         //nolint:forcetypeassert
 				certificate := hs.Message.(*handshake.MessageCertificate13) //nolint:forcetypeassert
 				assert.Empty(t, certificate.CertificateRequestContext)
 				assert.Empty(t, certificate.CertificateList)
@@ -1149,8 +1144,8 @@ func TestHandshakeFSM13ClientFlight5WithoutClientCertificate(t *testing.T) {
 					transcriptThroughServerFinished,
 				)
 				require.NoError(t, err)
-				finishedHandshake := fsm.flights[1].Record.Content.(*handshake.Handshake) //nolint:forcetypeassert
-				finished := finishedHandshake.Message.(*handshake.MessageFinished)        //nolint:forcetypeassert
+				finishedHandshake := fsm.flights[1].Content.(*handshake.Handshake) //nolint:forcetypeassert
+				finished := finishedHandshake.Message.(*handshake.MessageFinished) //nolint:forcetypeassert
 				assert.Equal(t, expectedVerifyData, finished.VerifyData)
 			}
 		})
@@ -1196,7 +1191,7 @@ func TestHandshakeFSM13ServerRejectsTamperedClientFinished(t *testing.T) {
 	require.Equal(t, StateSending, nextState)
 	require.Len(t, clientFSM.flights, 1)
 
-	finishedHandshake := clientFSM.flights[0].Record.Content.(*handshake.Handshake) //nolint:forcetypeassert
+	finishedHandshake := clientFSM.flights[0].Content.(*handshake.Handshake) //nolint:forcetypeassert
 	rawFinished, err := finishedHandshake.Marshal()
 	require.NoError(t, err)
 	rawFinished[len(rawFinished)-1] ^= 0xff
@@ -1293,7 +1288,7 @@ func TestHandshakeFSM13RetransmittedFinalFlightDoesNotChangeTranscript(t *testin
 func serverFSMForClientFlight13(
 	t *testing.T,
 	fixture noHRRFlight13Fixture,
-	clientFlight []*dtlsflight.Packet,
+	clientFlight []*dtlsflight.Outbound,
 	cacheCopies int,
 ) *fsm13 {
 	t.Helper()
@@ -1337,10 +1332,10 @@ func serverTranscriptThroughFlight4(t *testing.T, fixture noHRRFlight13Fixture) 
 	return transcript
 }
 
-func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Packet) []byte {
+func canonicalPacketHandshake13(t *testing.T, p *dtlsflight.Outbound) []byte {
 	t.Helper()
 
-	content, ok := p.Record.Content.(*handshake.Handshake)
+	content, ok := p.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	raw, err := content.Marshal()
 	require.NoError(t, err)
@@ -1385,28 +1380,23 @@ func addCertificateRequestToServerFlight13(
 ) noHRRFlight13Fixture {
 	t.Helper()
 
-	request := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   dtlsflight13.EpochHandshake,
-			},
-			Content: &handshake.Handshake{
-				Header: handshake.Header{MessageSequence: 2},
-				Message: &handshake.MessageCertificateRequest13{
-					CertificateRequestContext: requestContext,
-					Extensions: []extension.Value{
-						&extension.SignatureAlgorithms{
-							Schemes: dtlsflight.SignatureSchemeIDs(fixture.cfg.LocalSignatureSchemes),
-						},
+	request := &dtlsflight.Outbound{
+		Epoch: dtlsflight13.EpochHandshake,
+		Content: &handshake.Handshake{
+			Header: handshake.Header{MessageSequence: 2},
+			Message: &handshake.MessageCertificateRequest13{
+				CertificateRequestContext: requestContext,
+				Extensions: []extension.Value{
+					&extension.SignatureAlgorithms{
+						Schemes: dtlsflight.SignatureSchemeIDs(fixture.cfg.LocalSignatureSchemes),
 					},
 				},
 			},
 		},
-		ShouldEncrypt: true,
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 
-	fixture.serverFlight4 = []*dtlsflight.Packet{
+	fixture.serverFlight4 = []*dtlsflight.Outbound{
 		fixture.serverFlight4[0],
 		fixture.serverFlight4[1],
 		request,
@@ -1418,7 +1408,7 @@ func addCertificateRequestToServerFlight13(
 		setFlight13HandshakeSequence(t, pkt, uint16(i))
 	}
 
-	certificateVerifyHandshake := fixture.serverFlight4[4].Record.Content.(*handshake.Handshake)  //nolint:forcetypeassert
+	certificateVerifyHandshake := fixture.serverFlight4[4].Content.(*handshake.Handshake)         //nolint:forcetypeassert
 	certificateVerify := certificateVerifyHandshake.Message.(*handshake.MessageCertificateVerify) //nolint:forcetypeassert
 	signer, ok := fixture.cfg.LocalCertificates[0].PrivateKey.(crypto.Signer)
 	require.True(t, ok)
@@ -1443,8 +1433,8 @@ func addCertificateRequestToServerFlight13(
 	)
 	require.NoError(t, err)
 
-	finishedHandshake := fixture.serverFlight4[5].Record.Content.(*handshake.Handshake) //nolint:forcetypeassert
-	finished := finishedHandshake.Message.(*handshake.MessageFinished)                  //nolint:forcetypeassert
+	finishedHandshake := fixture.serverFlight4[5].Content.(*handshake.Handshake) //nolint:forcetypeassert
+	finished := finishedHandshake.Message.(*handshake.MessageFinished)           //nolint:forcetypeassert
 	finished.VerifyData = nil
 
 	serverTranscript, err := fixture.transcript.clone()
@@ -1472,9 +1462,9 @@ type noHRRFlight13Fixture struct {
 	clientState   *dtlsstate.State13
 	serverState   *dtlsstate.State13
 	cfg           *dtlsconfig.HandshakeConfig
-	clientHello   []*dtlsflight.Packet
+	clientHello   []*dtlsflight.Outbound
 	transcript    *Transcript
-	serverFlight4 []*dtlsflight.Packet
+	serverFlight4 []*dtlsflight.Outbound
 }
 
 func newNoHRRFlight13Fixture(t *testing.T) noHRRFlight13Fixture {
@@ -1537,7 +1527,7 @@ func newNoHRRFlight13Fixture(t *testing.T) noHRRFlight13Fixture {
 func newFlight13ClientHelloFixture(
 	t *testing.T,
 	cfg *dtlsconfig.HandshakeConfig,
-) (*dtlsstate.State13, []*dtlsflight.Packet, *Transcript) {
+) (*dtlsstate.State13, []*dtlsflight.Outbound, *Transcript) {
 	t.Helper()
 
 	clientState := newTestState13(t, true)
@@ -1561,19 +1551,19 @@ func newFlight13ClientHelloFixture(
 func pushFlight13HandshakePacketsToCache(
 	t *testing.T,
 	cache *dtlsflight.Cache,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 	isClient bool,
 ) {
 	t.Helper()
 
 	for _, p := range pkts {
-		content, ok := p.Record.Content.(*handshake.Handshake)
+		content, ok := p.Content.(*handshake.Handshake)
 		require.True(t, ok)
 		raw, err := content.Marshal()
 		require.NoError(t, err)
 		cache.Push(
 			raw,
-			p.Record.Header.Epoch,
+			p.Epoch,
 			content.Header.MessageSequence,
 			content.Message.Type(),
 			isClient,
@@ -1581,10 +1571,10 @@ func pushFlight13HandshakePacketsToCache(
 	}
 }
 
-func setFlight13HandshakeSequence(t *testing.T, p *dtlsflight.Packet, seq uint16) {
+func setFlight13HandshakeSequence(t *testing.T, p *dtlsflight.Outbound, seq uint16) {
 	t.Helper()
 
-	content, ok := p.Record.Content.(*handshake.Handshake)
+	content, ok := p.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	content.Header.MessageSequence = seq
 }
@@ -1654,7 +1644,7 @@ func TestAppendOutboundHandshakeFlight13ClientHello(t *testing.T) {
 	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 3)
 	expected := canonicalPacketHandshake13(t, pkt)
 
-	err := AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt})
+	err := AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{pkt})
 	require.NoError(t, err)
 	require.Len(t, transcript.order, 1)
 	require.Len(t, transcript.pending, 1)
@@ -1669,10 +1659,10 @@ func TestAppendOutboundHandshakeFlight13DuplicateNoop(t *testing.T) {
 	transcript := NewTranscript()
 	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
 
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt}))
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{pkt}))
 	before := append([]byte(nil), transcript.Bytes()...)
 
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt}))
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{pkt}))
 	assert.Equal(t, before, transcript.Bytes())
 	assert.Len(t, transcript.order, 1)
 }
@@ -1682,8 +1672,8 @@ func TestAppendOutboundHandshakeFlight13ChangedSameSequenceFails(t *testing.T) {
 	pkt := transcriptTestClientHelloPacket13([]byte{0x01}, 0)
 	changedPkt := transcriptTestClientHelloPacket13([]byte{0x02}, 0)
 
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{pkt}))
-	err := AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Packet{changedPkt})
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{pkt}))
+	err := AppendOutboundHandshakeFlight(transcript, true, nil, []*dtlsflight.Outbound{changedPkt})
 
 	assert.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptMessageChanged)
 }
@@ -1698,9 +1688,9 @@ func TestAppendOutboundHandshakeFlight13HelloRetryRequest(t *testing.T) {
 	clientHelloCanonical := canonicalPacketHandshake13(t, clientHello)
 	helloRetryRequestCanonical := canonicalPacketHandshake13(t, helloRetryRequest)
 
-	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, cipherSuite, []*dtlsflight.Packet{clientHello}))
+	require.NoError(t, AppendOutboundHandshakeFlight(transcript, true, cipherSuite, []*dtlsflight.Outbound{clientHello}))
 	require.NoError(t, AppendOutboundHandshakeFlight(
-		transcript, false, cipherSuite, []*dtlsflight.Packet{helloRetryRequest},
+		transcript, false, cipherSuite, []*dtlsflight.Outbound{helloRetryRequest},
 	))
 
 	clientHelloHash := hashTranscript13(clientHelloCanonical)
@@ -1717,26 +1707,21 @@ func TestAppendOutboundHandshakeFlight13HelloRetryRequest(t *testing.T) {
 
 	before := append([]byte(nil), transcript.Bytes()...)
 	require.NoError(t, AppendOutboundHandshakeFlight(
-		transcript, false, cipherSuite, []*dtlsflight.Packet{helloRetryRequest},
+		transcript, false, cipherSuite, []*dtlsflight.Outbound{helloRetryRequest},
 	))
 	assert.Equal(t, before, transcript.Bytes())
 	assert.Len(t, transcript.order, 2)
 }
 
-func transcriptTestClientHelloPacket13(sessionID []byte, seq uint16) *dtlsflight.Packet {
-	return &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &handshake.Handshake{
-				Header: handshake.Header{MessageSequence: seq},
-				Message: &handshake.MessageClientHello{
-					Version:            protocol.Version1_2,
-					SessionID:          sessionID,
-					CipherSuiteIDs:     []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
-					CompressionMethods: dtlsflight.DefaultCompressionMethods(),
-				},
+func transcriptTestClientHelloPacket13(sessionID []byte, seq uint16) *dtlsflight.Outbound {
+	return &dtlsflight.Outbound{
+		Content: &handshake.Handshake{
+			Header: handshake.Header{MessageSequence: seq},
+			Message: &handshake.MessageClientHello{
+				Version:            protocol.Version1_2,
+				SessionID:          sessionID,
+				CipherSuiteIDs:     []uint16{uint16(ciphersuite.TLS_AES_128_GCM_SHA256)},
+				CompressionMethods: dtlsflight.DefaultCompressionMethods(),
 			},
 		},
 	}
@@ -1744,29 +1729,24 @@ func transcriptTestClientHelloPacket13(sessionID []byte, seq uint16) *dtlsflight
 
 func transcriptTestHelloRetryRequestPacket13(
 	tb testing.TB, cipherSuite dtlsconfig.CipherSuite, seq uint16,
-) *dtlsflight.Packet {
+) *dtlsflight.Outbound {
 	tb.Helper()
 
 	random := handshake.Random{}
 	random.UnmarshalFixed([32]byte(handshake.HelloRetryRequestRandom()))
 	cipherSuiteID := uint16(cipherSuite.ID())
 
-	return &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-			},
-			Content: &handshake.Handshake{
-				Header: handshake.Header{MessageSequence: seq},
-				Message: &handshake.MessageServerHello{
-					Version:           protocol.Version1_2,
-					Random:            random,
-					CipherSuiteID:     &cipherSuiteID,
-					CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
-					Extensions: []extension.Value{
-						&extension13.SelectedVersion{
-							Version: protocol.Version1_3,
-						},
+	return &dtlsflight.Outbound{
+		Content: &handshake.Handshake{
+			Header: handshake.Header{MessageSequence: seq},
+			Message: &handshake.MessageServerHello{
+				Version:           protocol.Version1_2,
+				Random:            random,
+				CipherSuiteID:     &cipherSuiteID,
+				CompressionMethod: dtlsflight.DefaultCompressionMethods()[0],
+				Extensions: []extension.Value{
+					&extension13.SelectedVersion{
+						Version: protocol.Version1_3,
 					},
 				},
 			},

--- a/internal/handshake/handshake_context.go
+++ b/internal/handshake/handshake_context.go
@@ -24,14 +24,14 @@ type handshakeContext struct {
 	transcript *Transcript
 }
 
-func (c *handshakeContext) seedInitialFlights(flights []*dtlsflight.Packet, retransmit bool) error {
+func (c *handshakeContext) seedInitialFlights(flights []*dtlsflight.Outbound, retransmit bool) error {
 	return seedTranscriptFromInitialFlights(c.state, c.transcript, flights, retransmit)
 }
 
 func (c *handshakeContext) commitPreparedFlight(
 	conn Conn,
 	flight dtlsflight13.Flight,
-	flights []*dtlsflight.Packet,
+	flights []*dtlsflight.Outbound,
 ) error {
 	if err := commitPreparedFlights(conn, c.state, c.transcript, c.cfg, flights); err != nil {
 		return err

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/alert"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
 const (
@@ -99,7 +98,7 @@ type reliablePostHandshakeFlight struct {
 
 	// Constructed once. Retransmissions will reuse these messages and their
 	// message_seq values.
-	Packets []*dtlsflight.Packet
+	Packets []*dtlsflight.Outbound
 
 	// All retransmissions will use this epoch/key generation.
 	Epoch uint16
@@ -138,8 +137,8 @@ type keyUpdateCommand struct {
 type postHandshakeCommand struct {
 	Kind postHandshakeCommandKind
 
-	Packets   []*dtlsflight.Packet
-	Write     func(Conn, []*dtlsflight.Packet) error
+	Packets   []*dtlsflight.Outbound
+	Write     func(Conn, []*dtlsflight.Outbound) error
 	KeyUpdate keyUpdateCommand
 	Canceled  <-chan struct{}
 
@@ -287,7 +286,7 @@ func (p *postHandshake) startPostHandshakeCommand(
 
 func (p *postHandshake) writeApplicationData(conn Conn, command postHandshakeCommand) error {
 	for _, packet := range command.Packets {
-		packet.Record.Header.Epoch = p.state.LocalEpoch()
+		packet.Epoch = p.state.LocalEpoch()
 	}
 	err := command.Write(conn, command.Packets)
 	command.Completion.complete(err)
@@ -595,24 +594,19 @@ func (p *postHandshake) buildKeyUpdateFlight(
 
 	messageSequence := uint16(p.state.HandshakeSendSequence) //nolint:gosec // bounded above
 	p.state.HandshakeSendSequence++
-	packet := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   current.Epoch,
+	packet := &dtlsflight.Outbound{
+		Epoch: current.Epoch,
+		Content: &handshake.Handshake{
+			Header: handshake.Header{
+				Type:            handshake.TypeKeyUpdate,
+				Length:          uint32(len(body)), //nolint:gosec // marshal limits the message size
+				MessageSequence: messageSequence,
+				FragmentLength:  uint32(len(body)), //nolint:gosec // marshal limits the message size
 			},
-			Content: &handshake.Handshake{
-				Header: handshake.Header{
-					Type:            handshake.TypeKeyUpdate,
-					Length:          uint32(len(body)), //nolint:gosec // marshal limits the message size
-					MessageSequence: messageSequence,
-					FragmentLength:  uint32(len(body)), //nolint:gosec // marshal limits the message size
-				},
-				Message: message,
-			},
+			Message: message,
 		},
-		ShouldEncrypt:  true,
-		ShouldTrackACK: true,
+		Protection: dtlsflight.ProtectionCiphertext,
+		TrackACK:   true,
 	}
 	id := postHandshakeFlightID{
 		Category:        postHandshakeKeyUpdate,
@@ -621,7 +615,7 @@ func (p *postHandshake) buildKeyUpdateFlight(
 
 	return &reliablePostHandshakeFlight{
 		ID:                 id,
-		Packets:            []*dtlsflight.Packet{packet},
+		Packets:            []*dtlsflight.Outbound{packet},
 		Epoch:              current.Epoch,
 		PendingFragments:   make(map[postHandshakeFragment]struct{}),
 		SentRecords:        make(map[protocol.RecordNumber]struct{}),
@@ -698,24 +692,19 @@ func (p *postHandshake) makeReliableNewSessionTicket(
 
 	messageSequence := uint16(p.state.HandshakeSendSequence) //nolint:gosec // bounded above
 	p.state.HandshakeSendSequence++
-	packet := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				Version: protocol.Version1_2,
-				Epoch:   p.state.LocalEpoch(),
+	packet := &dtlsflight.Outbound{
+		Epoch: p.state.LocalEpoch(),
+		Content: &handshake.Handshake{
+			Header: handshake.Header{
+				Type:            handshake.TypeNewSessionTicket,
+				Length:          uint32(len(body)), //nolint:gosec // marshal limits the message size
+				MessageSequence: messageSequence,
+				FragmentLength:  uint32(len(body)), //nolint:gosec // marshal limits the message size
 			},
-			Content: &handshake.Handshake{
-				Header: handshake.Header{
-					Type:            handshake.TypeNewSessionTicket,
-					Length:          uint32(len(body)), //nolint:gosec // marshal limits the message size
-					MessageSequence: messageSequence,
-					FragmentLength:  uint32(len(body)), //nolint:gosec // marshal limits the message size
-				},
-				Message: message,
-			},
+			Message: message,
 		},
-		ShouldEncrypt:  true,
-		ShouldTrackACK: true,
+		Protection: dtlsflight.ProtectionCiphertext,
+		TrackACK:   true,
 	}
 	id := postHandshakeFlightID{
 		Category:        postHandshakeNewSessionTicket,
@@ -724,7 +713,7 @@ func (p *postHandshake) makeReliableNewSessionTicket(
 
 	return &reliablePostHandshakeFlight{
 		ID:                 id,
-		Packets:            []*dtlsflight.Packet{packet},
+		Packets:            []*dtlsflight.Outbound{packet},
 		Epoch:              p.state.LocalEpoch(),
 		PendingFragments:   make(map[postHandshakeFragment]struct{}),
 		SentRecords:        make(map[protocol.RecordNumber]struct{}),
@@ -794,7 +783,7 @@ func (p *postHandshake) retransmitPostHandshakeFlight(
 	disableRetransmitBackoff bool,
 ) error {
 	for _, packet := range flight.Packets {
-		message, ok := packet.Record.Content.(*handshake.Handshake)
+		message, ok := packet.Content.(*handshake.Handshake)
 		if !ok {
 			continue
 		}

--- a/internal/handshake/post_handshake_test.go
+++ b/internal/handshake/post_handshake_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/extension"
 	extension13 "github.com/pion/dtls/v3/pkg/protocol/extension/dtls13"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
-	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,7 +63,7 @@ type postHandshakeKeyUpdateConn struct {
 
 func (c *postHandshakeKeyUpdateConn) WritePackets(
 	_ context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*WriteResult, error) {
 	c.writtenPackets = append(c.writtenPackets, pkts...)
 	if c.result == nil {
@@ -114,7 +113,7 @@ func newPostHandshakeKeyUpdateTestState(t *testing.T, isClient bool) *dtlsstate.
 
 func (c *postHandshakeWriteConn) WritePackets(
 	_ context.Context,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) (*WriteResult, error) {
 	c.writtenPackets = append(c.writtenPackets, pkts...)
 
@@ -140,13 +139,13 @@ func TestMakeReliableNewSessionTicket(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, flight.Packets, 1)
 	packet := flight.Packets[0]
-	assert.True(t, packet.ShouldEncrypt)
-	assert.True(t, packet.ShouldTrackACK)
-	assert.Equal(t, uint16(7), packet.Record.Header.Epoch)
+	assert.True(t, packet.Protection == dtlsflight.ProtectionCiphertext)
+	assert.True(t, packet.TrackACK)
+	assert.Equal(t, uint16(7), packet.Epoch)
 	assert.Equal(t, uint16(12), flight.ID.MessageSequence)
 	assert.Equal(t, 13, state.HandshakeSendSequence)
 
-	wireHandshake, ok := packet.Record.Content.(*handshake.Handshake)
+	wireHandshake, ok := packet.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	assert.Equal(t, uint16(12), wireHandshake.Header.MessageSequence)
 	assert.Same(t, message, wireHandshake.Message)
@@ -330,14 +329,14 @@ func TestPostHandshakeReceiveNewSessionTicket(t *testing.T) {
 	require.NoError(t, receive())
 	assert.Equal(t, int(ticketRecvSequence)+1, state.HandshakeRecvSequence)
 	require.Len(t, conn.writtenPackets, 1)
-	firstACK, ok := conn.writtenPackets[0].Record.Content.(*protocol.ACK)
+	firstACK, ok := conn.writtenPackets[0].Content.(*protocol.ACK)
 	require.True(t, ok)
 	assert.Equal(t, []protocol.RecordNumber{record}, firstACK.Records)
 
 	require.NoError(t, receive())
 	assert.Equal(t, int(ticketRecvSequence)+1, state.HandshakeRecvSequence)
 	require.Len(t, conn.writtenPackets, 2)
-	retransmitACK, ok := conn.writtenPackets[1].Record.Content.(*protocol.ACK)
+	retransmitACK, ok := conn.writtenPackets[1].Content.(*protocol.ACK)
 	require.True(t, ok)
 	assert.Equal(t, []protocol.RecordNumber{record}, retransmitACK.Records)
 }
@@ -488,11 +487,11 @@ func TestPrepareNewSessionTicket(t *testing.T) {
 	require.NoError(t, err)
 	second, err := post.prepareNewSessionTicket(false)
 	require.NoError(t, err)
-	firstHandshake, ok := first.Packets[0].Record.Content.(*handshake.Handshake)
+	firstHandshake, ok := first.Packets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	firstMessage, ok := firstHandshake.Message.(*handshake.MessageNewSessionTicket)
 	require.True(t, ok)
-	secondHandshake, ok := second.Packets[0].Record.Content.(*handshake.Handshake)
+	secondHandshake, ok := second.Packets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	secondMessage, ok := secondHandshake.Message.(*handshake.MessageNewSessionTicket)
 	require.True(t, ok)
@@ -527,14 +526,14 @@ func TestKeyUpdateCommitsWriteKeysOnlyAfterACK(t *testing.T) {
 	}))
 	require.Len(t, conn.writtenPackets, 1)
 	packet := conn.writtenPackets[0]
-	assert.Equal(t, dtlsflight13.EpochApplication, packet.Record.Header.Epoch)
-	wireHandshake, ok := packet.Record.Content.(*handshake.Handshake)
+	assert.Equal(t, dtlsflight13.EpochApplication, packet.Epoch)
+	wireHandshake, ok := packet.Content.(*handshake.Handshake)
 	require.True(t, ok)
 	wireKeyUpdate, ok := wireHandshake.Message.(*handshake.MessageKeyUpdate)
 	require.True(t, ok)
 	assert.Equal(t, handshake.KeyUpdateRequested, wireKeyUpdate.RequestUpdate)
 	assert.Equal(t, uint16(9), wireHandshake.Header.MessageSequence)
-	assert.True(t, packet.ShouldTrackACK)
+	assert.True(t, packet.TrackACK)
 	assert.Equal(t, dtlsflight13.EpochApplication, state.LocalEpoch())
 	current, ok := state.TrafficKeys.CurrentWrite()
 	require.True(t, ok)
@@ -598,12 +597,12 @@ func TestRequestedKeyUpdateInstallsReadKeysAndQueuesResponse(t *testing.T) {
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
 	require.Len(t, conn.writtenPackets, 1)
-	responseHandshake, ok := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	responseHandshake, ok := conn.writtenPackets[0].Content.(*handshake.Handshake)
 	require.True(t, ok)
 	response, ok := responseHandshake.Message.(*handshake.MessageKeyUpdate)
 	require.True(t, ok)
 	assert.Equal(t, handshake.KeyUpdateNotRequested, response.RequestUpdate)
-	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Record.Header.Epoch)
+	assert.Equal(t, dtlsflight13.EpochApplication, conn.writtenPackets[0].Epoch)
 	assert.Equal(t, dtlsflight13.EpochApplication, state.LocalEpoch())
 }
 
@@ -654,17 +653,14 @@ func TestApplicationDataChangesEpochOnlyAfterKeyUpdateACK(t *testing.T) {
 			}},
 		}}},
 	}
-	applicationPacket := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2},
-			Content: &protocol.ApplicationData{Data: []byte("after update")},
-		},
-		ShouldEncrypt: true,
+	applicationPacket := &dtlsflight.Outbound{
+		Content:    &protocol.ApplicationData{Data: []byte("after update")},
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 	post.queue = append(post.queue, postHandshakeCommand{
 		Kind:    commandSendApplicationData,
-		Packets: []*dtlsflight.Packet{applicationPacket},
-		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+		Packets: []*dtlsflight.Outbound{applicationPacket},
+		Write: func(conn Conn, packets []*dtlsflight.Outbound) error {
 			_, err := conn.WritePackets(context.Background(), packets)
 
 			return err
@@ -674,27 +670,24 @@ func TestApplicationDataChangesEpochOnlyAfterKeyUpdateACK(t *testing.T) {
 
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
 	require.Len(t, conn.writtenPackets, 2)
-	_, isKeyUpdate := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	_, isKeyUpdate := conn.writtenPackets[0].Content.(*handshake.Handshake)
 	assert.True(t, isKeyUpdate)
-	_, isApplicationData := conn.writtenPackets[1].Record.Content.(*protocol.ApplicationData)
+	_, isApplicationData := conn.writtenPackets[1].Content.(*protocol.ApplicationData)
 	assert.True(t, isApplicationData)
-	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Record.Header.Epoch)
+	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Epoch)
 	assert.Empty(t, post.queue)
 
 	completed := post.applyACK(protocol.ACK{Records: []protocol.RecordNumber{record}})
 	require.Len(t, completed, 1)
 	require.NoError(t, post.completePostHandshakeFlight(conn, completed[0]))
-	afterACKPacket := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2},
-			Content: &protocol.ApplicationData{Data: []byte("after ACK")},
-		},
-		ShouldEncrypt: true,
+	afterACKPacket := &dtlsflight.Outbound{
+		Content:    &protocol.ApplicationData{Data: []byte("after ACK")},
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 	post.queue = append(post.queue, postHandshakeCommand{
 		Kind:    commandSendApplicationData,
-		Packets: []*dtlsflight.Packet{afterACKPacket},
-		Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+		Packets: []*dtlsflight.Outbound{afterACKPacket},
+		Write: func(conn Conn, packets []*dtlsflight.Outbound) error {
 			_, err := conn.WritePackets(context.Background(), packets)
 
 			return err
@@ -702,7 +695,7 @@ func TestApplicationDataChangesEpochOnlyAfterKeyUpdateACK(t *testing.T) {
 	})
 	require.NoError(t, post.startQueuedPostHandshake(context.Background(), conn))
 	require.Len(t, conn.writtenPackets, 3)
-	assert.Equal(t, dtlsflight13.EpochApplication+1, afterACKPacket.Record.Header.Epoch)
+	assert.Equal(t, dtlsflight13.EpochApplication+1, afterACKPacket.Epoch)
 }
 
 func TestApplicationDataDoesNotWaitForNewSessionTicketACK(t *testing.T) {
@@ -712,19 +705,16 @@ func TestApplicationDataDoesNotWaitForNewSessionTicketACK(t *testing.T) {
 		state: &state,
 		cfg:   &dtlsconfig.HandshakeConfig{InitialRetransmitInterval: time.Second},
 	})
-	applicationPacket := &dtlsflight.Packet{
-		Record: &recordlayer.RecordLayer{
-			Header:  recordlayer.Header{Version: protocol.Version1_2},
-			Content: &protocol.ApplicationData{Data: []byte("after ticket")},
-		},
-		ShouldEncrypt: true,
+	applicationPacket := &dtlsflight.Outbound{
+		Content:    &protocol.ApplicationData{Data: []byte("after ticket")},
+		Protection: dtlsflight.ProtectionCiphertext,
 	}
 	post.queue = append(post.queue,
 		postHandshakeCommand{Kind: commandSendNewSessionTicket},
 		postHandshakeCommand{
 			Kind:    commandSendApplicationData,
-			Packets: []*dtlsflight.Packet{applicationPacket},
-			Write: func(conn Conn, packets []*dtlsflight.Packet) error {
+			Packets: []*dtlsflight.Outbound{applicationPacket},
+			Write: func(conn Conn, packets []*dtlsflight.Outbound) error {
 				_, err := conn.WritePackets(context.Background(), packets)
 
 				return err
@@ -737,11 +727,11 @@ func TestApplicationDataDoesNotWaitForNewSessionTicketACK(t *testing.T) {
 	assert.Empty(t, post.queue)
 	require.Len(t, post.flights, 1)
 	require.Len(t, conn.writtenPackets, 2)
-	_, isTicket := conn.writtenPackets[0].Record.Content.(*handshake.Handshake)
+	_, isTicket := conn.writtenPackets[0].Content.(*handshake.Handshake)
 	assert.True(t, isTicket)
-	_, isApplicationData := conn.writtenPackets[1].Record.Content.(*protocol.ApplicationData)
+	_, isApplicationData := conn.writtenPackets[1].Content.(*protocol.ApplicationData)
 	assert.True(t, isApplicationData)
-	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Record.Header.Epoch)
+	assert.Equal(t, dtlsflight13.EpochApplication, applicationPacket.Epoch)
 }
 
 func TestRetransmittedKeyUpdateDoesNotRatchetReadKeysTwice(t *testing.T) {

--- a/internal/handshake/traffic_secrets.go
+++ b/internal/handshake/traffic_secrets.go
@@ -42,7 +42,7 @@ func commitPreparedFlights(
 	state *dtlsstate.State13,
 	transcript *Transcript,
 	cfg *dtlsconfig.HandshakeConfig,
-	flights []*dtlsflight.Packet,
+	flights []*dtlsflight.Outbound,
 ) error {
 	nextEpoch, protectedFlightStart := prepareFlightPackets(state, cfg.InitialEpoch, flights)
 	if err := commitOutboundFlight(state, transcript, flights, protectedFlightStart); err != nil {
@@ -61,19 +61,19 @@ func commitPreparedFlights(
 func prepareFlightPackets(
 	state *dtlsstate.State13,
 	epoch uint16,
-	flights []*dtlsflight.Packet,
+	flights []*dtlsflight.Outbound,
 ) (uint16, int) {
 	nextEpoch := epoch
 	protectedFlightStart := len(flights)
 	for i, packet := range flights {
-		packet.Record.Header.Epoch += epoch
-		if packet.Record.Header.Epoch > nextEpoch {
-			nextEpoch = packet.Record.Header.Epoch
+		packet.Epoch += epoch
+		if packet.Epoch > nextEpoch {
+			nextEpoch = packet.Epoch
 		}
-		if packet.ShouldEncrypt && protectedFlightStart == len(flights) {
+		if packet.Protection == dtlsflight.ProtectionCiphertext && protectedFlightStart == len(flights) {
 			protectedFlightStart = i
 		}
-		if handshakeMessage, ok := packet.Record.Content.(*handshake.Handshake); ok {
+		if handshakeMessage, ok := packet.Content.(*handshake.Handshake); ok {
 			handshakeMessage.Header.MessageSequence = uint16(state.HandshakeSendSequence) //nolint:gosec // G115
 			state.HandshakeSendSequence++
 		}
@@ -85,7 +85,7 @@ func prepareFlightPackets(
 func commitOutboundFlight(
 	state *dtlsstate.State13,
 	transcript *Transcript,
-	flights []*dtlsflight.Packet,
+	flights []*dtlsflight.Outbound,
 	protectedFlightStart int,
 ) error {
 	if err := appendCommittedOutboundHandshakeFlight(state, transcript, flights[:protectedFlightStart]); err != nil {
@@ -116,7 +116,7 @@ func ensureHandshakeTrafficSecrets(state *dtlsstate.State13, transcript *Transcr
 func appendCommittedOutboundHandshakeFlight(
 	state *dtlsstate.State13,
 	transcript *Transcript,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) error {
 	for _, p := range pkts {
 		if err := populateOutboundCertificateVerify(state, transcript, p); err != nil {
@@ -129,7 +129,7 @@ func appendCommittedOutboundHandshakeFlight(
 			transcript,
 			state.IsClient,
 			state.CipherSuite,
-			[]*dtlsflight.Packet{p},
+			[]*dtlsflight.Outbound{p},
 		); err != nil {
 			return err
 		}
@@ -141,12 +141,12 @@ func appendCommittedOutboundHandshakeFlight(
 func populateOutboundCertificateVerify(
 	state *dtlsstate.State13,
 	transcript *Transcript,
-	pkt *dtlsflight.Packet,
+	pkt *dtlsflight.Outbound,
 ) error {
-	if pkt == nil || pkt.Record == nil {
+	if pkt == nil || pkt.Content == nil {
 		return nil
 	}
-	h, ok := pkt.Record.Content.(*handshake.Handshake)
+	h, ok := pkt.Content.(*handshake.Handshake)
 	if !ok {
 		return nil
 	}
@@ -175,12 +175,12 @@ func populateOutboundCertificateVerify(
 func populateOutboundFinished(
 	state *dtlsstate.State13,
 	transcript *Transcript,
-	p *dtlsflight.Packet,
+	p *dtlsflight.Outbound,
 ) error {
-	if p == nil || p.Record == nil {
+	if p == nil || p.Content == nil {
 		return nil
 	}
-	h, ok := p.Record.Content.(*handshake.Handshake)
+	h, ok := p.Content.(*handshake.Handshake)
 	if !ok {
 		return nil
 	}

--- a/internal/handshake/transcript.go
+++ b/internal/handshake/transcript.go
@@ -333,7 +333,7 @@ func (t *Transcript) Bytes() []byte {
 func seedTranscriptFromInitialFlights(
 	state *dtlsstate.State13,
 	transcript *Transcript,
-	flights []*dtlsflight.Packet,
+	flights []*dtlsflight.Outbound,
 	retransmit bool,
 ) error {
 	if !state.IsClient {
@@ -351,7 +351,7 @@ func seedTranscriptFromInitialFlights(
 	return nil
 }
 
-func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflight.Packet) (bool, error) {
+func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflight.Outbound) (bool, error) {
 	if transcript == nil {
 		return false, dtlserrors.ErrHandshakeTranscriptMissingClientHello
 	}
@@ -379,7 +379,7 @@ func AppendClientHelloInitialFlights(transcript *Transcript, flights []*dtlsflig
 
 // ValidateClientHelloInitialFlights verifies that the dual-stack initial flight
 // contains a canonical ClientHello before it is written.
-func ValidateClientHelloInitialFlights(flights []*dtlsflight.Packet) error {
+func ValidateClientHelloInitialFlights(flights []*dtlsflight.Outbound) error {
 	appended, err := AppendClientHelloInitialFlights(NewTranscript(), flights)
 	if err != nil {
 		return err
@@ -391,11 +391,11 @@ func ValidateClientHelloInitialFlights(flights []*dtlsflight.Packet) error {
 	return nil
 }
 
-func canonicalClientHelloInitialFlight(p *dtlsflight.Packet) (uint16, []byte, bool, error) {
-	if p == nil || p.Record == nil {
+func canonicalClientHelloInitialFlight(p *dtlsflight.Outbound) (uint16, []byte, bool, error) {
+	if p == nil || p.Content == nil {
 		return 0, nil, false, nil
 	}
-	hand, ok := p.Record.Content.(*handshake.Handshake)
+	hand, ok := p.Content.(*handshake.Handshake)
 	if !ok {
 		return 0, nil, false, nil
 	}
@@ -427,7 +427,7 @@ func AppendOutboundHandshakeFlight(
 	transcript *Transcript,
 	isClient bool,
 	cipherSuite dtlsconfig.CipherSuite,
-	pkts []*dtlsflight.Packet,
+	pkts []*dtlsflight.Outbound,
 ) error {
 	if transcript == nil {
 		return nil
@@ -458,12 +458,12 @@ func AppendOutboundHandshakeFlight(
 	return nil
 }
 
-func canonicalOutboundHandshake(p *dtlsflight.Packet) (*handshake.Handshake, []byte, bool, error) {
-	if p == nil || p.Record == nil {
+func canonicalOutboundHandshake(p *dtlsflight.Outbound) (*handshake.Handshake, []byte, bool, error) {
+	if p == nil || p.Content == nil {
 		return nil, nil, false, nil
 	}
 
-	hs, ok := p.Record.Content.(*handshake.Handshake)
+	hs, ok := p.Content.(*handshake.Handshake)
 	if !ok || hs.Message == nil {
 		return nil, nil, false, nil
 	}

--- a/pkg/crypto/ciphersuite/ccm_test.go
+++ b/pkg/crypto/ciphersuite/ccm_test.go
@@ -45,21 +45,16 @@ func FuzzCCM_EncryptDecrypt_RoundTrip(f *testing.F) {
 		ccm, err := NewCCM(tag, key, iv, key, iv)
 		assert.NoError(t, err)
 
-		rl := &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				ContentType:    protocol.ContentTypeApplicationData,
-				Version:        protocol.Version1_2,
-				Epoch:          epoch,
-				SequenceNumber: seq,
-			},
-			Content: &protocol.ApplicationData{
-				Data: append([]byte(nil), payload...),
-			},
+		header := recordlayer.Header{
+			ContentType:    protocol.ContentTypeApplicationData,
+			Version:        protocol.Version1_2,
+			Epoch:          epoch,
+			SequenceNumber: seq,
 		}
-		raw, err := rl.Marshal()
+		raw, err := recordlayer.MarshalRecord(header, protocol.ContentTypeApplicationData, payload)
 		assert.NoError(t, err)
 
-		enc, err := ccm.Encrypt(rl, raw)
+		enc, err := ccm.Encrypt(&recordlayer.RecordLayer{Header: header}, raw)
 		assert.NoError(t, err)
 
 		var hdr recordlayer.Header
@@ -80,15 +75,13 @@ func FuzzCCM_Decrypt(f *testing.F) {
 	f.Add([]byte{})
 
 	f.Fuzz(func(t *testing.T, body []byte) {
-		recordLayer := &recordlayer.RecordLayer{
-			Header: recordlayer.Header{
-				ContentType: protocol.ContentTypeChangeCipherSpec,
-				Version:     protocol.Version1_2,
-			},
-			Content: &protocol.ChangeCipherSpec{},
+		header := recordlayer.Header{
+			ContentType: protocol.ContentTypeChangeCipherSpec,
+			Version:     protocol.Version1_2,
 		}
-
-		raw, err := recordLayer.Marshal()
+		content, err := (&protocol.ChangeCipherSpec{}).Marshal()
+		assert.NoError(t, err)
+		raw, err := recordlayer.MarshalRecord(header, protocol.ContentTypeChangeCipherSpec, content)
 		assert.NoError(t, err)
 		raw = append(raw, body...) // arbitrary body after the header for fuzzing
 

--- a/pkg/protocol/recordlayer/recordlayer.go
+++ b/pkg/protocol/recordlayer/recordlayer.go
@@ -5,6 +5,7 @@ package recordlayer
 
 import (
 	"encoding/binary"
+	"math"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -37,8 +38,7 @@ const (
 // RecordLayer describes a mutable outbound fixed-header DTLS record. Inbound
 // datagrams are framed with UnpackDatagram and opened by connection state.
 type RecordLayer struct {
-	Header  Header
-	Content protocol.Content
+	Header Header
 }
 
 // UnpackDatagramConfig configures datagram framing.
@@ -62,22 +62,19 @@ type unpackedDatagramRecord struct {
 	hasCID   bool
 }
 
-// Marshal encodes the RecordLayer to binary.
-func (r *RecordLayer) Marshal() ([]byte, error) {
-	contentRaw, err := r.Content.Marshal()
+// MarshalRecord encodes one fixed-header or DTLS 1.2 CID record.
+func MarshalRecord(header Header, contentType protocol.ContentType, content []byte) ([]byte, error) {
+	if len(content) > math.MaxUint16 {
+		return nil, ErrInvalidPacketLength
+	}
+	header.ContentLen = uint16(len(content)) //nolint:gosec // bounded above
+	header.ContentType = contentType
+	headerRaw, err := header.Marshal()
 	if err != nil {
 		return nil, err
 	}
 
-	r.Header.ContentLen = uint16(len(contentRaw)) //nolint:gosec // G115
-	r.Header.ContentType = r.Content.ContentType()
-
-	headerRaw, err := r.Header.Marshal()
-	if err != nil {
-		return nil, err
-	}
-
-	return append(headerRaw, contentRaw...), nil
+	return append(headerRaw, content...), nil
 }
 
 // UnpackDatagram extracts all records from a single datagram.

--- a/pkg/protocol/recordlayer/recordlayer_test.go
+++ b/pkg/protocol/recordlayer/recordlayer_test.go
@@ -14,6 +14,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func marshalTestRecord(header Header, content protocol.Content) ([]byte, error) {
+	payload, err := content.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return MarshalRecord(header, content.ContentType(), payload)
+}
+
+type testRecord struct {
+	Header  Header
+	Content protocol.Content
+}
+
+func (r *testRecord) Marshal() ([]byte, error) {
+	return marshalTestRecord(r.Header, r.Content)
+}
+
 func TestUDPDecode(t *testing.T) {
 	for _, test := range []struct {
 		Name      string
@@ -110,12 +128,12 @@ func TestRecordLayerMarshalAndScan(t *testing.T) {
 	for _, test := range []struct {
 		Name string
 		Data []byte
-		Want *RecordLayer
+		Want *testRecord
 	}{
 		{
 			Name: "Change Cipher Spec, single packet",
 			Data: []byte{0x14, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x00, 0x01, 0x01},
-			Want: &RecordLayer{
+			Want: &testRecord{
 				Header: Header{
 					ContentType:    protocol.ContentTypeChangeCipherSpec,
 					ContentLen:     1,
@@ -132,7 +150,7 @@ func TestRecordLayerMarshalAndScan(t *testing.T) {
 				0x1b, 0xfe, 0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x00, 0x09,
 				0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 			},
-			Want: &RecordLayer{
+			Want: &testRecord{
 				Header: Header{
 					ContentType:    protocol.ContentTypeReturnRoutabilityCheck,
 					ContentLen:     9,
@@ -205,7 +223,7 @@ func FuzzRecordLayer_MarshalScan_RoundTrip(f *testing.F) {
 			payload = []byte{0}
 		}
 
-		recordLayer := &RecordLayer{
+		recordLayer := &testRecord{
 			Header: Header{
 				ContentType:    protocol.ContentTypeApplicationData,
 				Version:        protocol.Version1_2,
@@ -237,7 +255,7 @@ func FuzzRecordLayer_MarshalScan_RoundTrip(f *testing.F) {
 
 		require.Equal(t, payload, backContent.Data)
 
-		raw2, err := (&RecordLayer{Header: backHeader, Content: &backContent}).Marshal()
+		raw2, err := marshalTestRecord(backHeader, &backContent)
 		require.NoError(t, err)
 		require.Equal(t, raw, raw2)
 	})
@@ -264,7 +282,7 @@ func FuzzRecordLayer_UnpackDatagram_RoundTrip(f *testing.F) {
 		var dat []byte
 		want := make([][]byte, 0, count)
 		for i := range count {
-			rl := &RecordLayer{
+			rl := &testRecord{
 				Header: Header{
 					ContentType:    protocol.ContentTypeApplicationData,
 					Version:        protocol.Version1_2,
@@ -831,7 +849,7 @@ func TestUnpackDatagramDoesNotApplyContentPolicy(t *testing.T) {
 }
 
 func TestUnpackDatagramAllRecordForms(t *testing.T) {
-	plaintext := &RecordLayer{
+	plaintext := &testRecord{
 		Header:  Header{Version: protocol.Version1_2},
 		Content: &alert.Alert{Level: alert.Warning, Description: alert.CloseNotify},
 	}


### PR DESCRIPTION
#### Description
This replaces the explicit `Packet` struct (ShouldEncrypt, ShouldWrapCID, ShouldTrackACK ...) with an implicit `Outbound ` struct.
Consolidated DTLS 1.2 and 1.3 writer and made it own this behavior so flights don't need to know about DTLS write details.
Removed mutable RecordLayer.Marshal and added pure recordlayer.MarshalRecord. The `RecordLayer` type will get removed after all the record-layer reworks.

part of #1053