### PR TITLE
Update recordlayer package documentation

### DIFF
--- a/pkg/protocol/recordlayer/errors.go
+++ b/pkg/protocol/recordlayer/errors.go
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-// Package recordlayer implements the TLS Record Layer https://tools.ietf.org/html/rfc5246#section-6
+// Package recordlayer provides lossless DTLS datagram framing for
+// [DTLS 1.2](https://www.rfc-editor.org/rfc/rfc6347#section-4.1) and
+// [DTLS 1.3](https://www.rfc-editor.org/rfc/rfc9147#section-4), along with the
+// wire header values required by record protection implementations.
 package recordlayer
 
 import (


### PR DESCRIPTION
#### Description
Update recordlayer package document to include DTLS 1.3 and updates the TLS 1.2 link to DTLS 1.2 because recordlayer is DTLS aware. And to describe the lossless API.

#1053