### PR TITLE
Optimize buffer used by PacketConn

### DIFF
--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -36,6 +36,15 @@ type AddrPacket struct {
 	data bytes.Buffer
 }
 
+type readNotification struct {
+	ch      chan struct{}
+	waiters atomic.Int64
+}
+
+func newReadNotification() *readNotification {
+	return &readNotification{ch: make(chan struct{})}
+}
+
 // PacketBuffer is a circular buffer for network packets. Each slot in the
 // buffer contains the remote address from which the packet was received, as
 // well as the packet data.
@@ -46,7 +55,7 @@ type PacketBuffer struct {
 	write, read         atomic.Uint64
 	readLock, writeLock sync.Mutex
 
-	notify   chan struct{}
+	notify   atomic.Pointer[readNotification]
 	closedCh chan struct{}
 	closed   atomic.Bool
 
@@ -61,13 +70,15 @@ func NewPacketBufferWithSize(bufSize int) *PacketBuffer {
 		bufSize = 1
 	}
 
-	return &PacketBuffer{
+	buffer := &PacketBuffer{
 		readDeadline: deadline.New(),
 		packets:      make([]AddrPacket, bufSize),
-		notify:       make(chan struct{}, 1),
 		closedCh:     make(chan struct{}),
 		growable:     growable,
 	}
+	buffer.notify.Store(newReadNotification())
+
+	return buffer
 }
 
 // NewPacketBuffer creates a new PacketBuffer with default buffer size.
@@ -120,10 +131,7 @@ func (b *PacketBuffer) WriteTo(pkt []byte, addr net.Addr) (int, error) {
 
 	b.write.Add(1)
 
-	select {
-	case b.notify <- struct{}{}:
-	default:
-	}
+	b.notifyReaders()
 
 	return n, nil
 }
@@ -184,13 +192,36 @@ func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error)
 }
 
 func (b *PacketBuffer) waitForRead() error {
+	notify := b.notify.Load()
+	notify.waiters.Add(1)
+
+	if b.notify.Load() != notify || b.read.Load() < b.write.Load() || b.closed.Load() {
+		notify.waiters.Add(-1)
+
+		return nil
+	}
+
+	var err error
 	select {
 	case <-b.readDeadline.Done():
-		return ErrTimeout
-	case <-b.notify:
-		return nil
+		err = ErrTimeout
+	case <-notify.ch:
 	case <-b.closedCh:
-		return nil
+	}
+
+	notify.waiters.Add(-1)
+
+	return err
+}
+
+func (b *PacketBuffer) notifyReaders() {
+	notify := b.notify.Load()
+	if notify.waiters.Load() == 0 {
+		return
+	}
+
+	if b.notify.CompareAndSwap(notify, newReadNotification()) {
+		close(notify.ch)
 	}
 }
 
@@ -218,10 +249,7 @@ func (b *PacketBuffer) SetReadDeadline(t time.Time) error {
 	defer b.readLock.Unlock()
 	b.readDeadline.Set(t)
 
-	select {
-	case b.notify <- struct{}{}:
-	default:
-	}
+	b.notifyReaders()
 
 	return nil
 }

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
@@ -31,115 +32,86 @@ var ErrTimeout = dtlserrors.ErrNetBufferTimeout
 // it was received.
 type AddrPacket struct {
 	addr net.Addr
-	data bytes.Buffer
+	data *bytes.Buffer
 }
 
 // PacketBuffer is a circular buffer for network packets. Each slot in the
 // buffer contains the remote address from which the packet was received, as
 // well as the packet data.
 type PacketBuffer struct {
-	mutex sync.Mutex
+	packets []AddrPacket
 
-	packets     []AddrPacket
-	write, read int
-
-	// full indicates whether the buffer is full, which is needed to distinguish
-	// when the write pointer and read pointer are at the same index.
-	full bool
+	write, read         atomic.Uint64
+	readLock, writeLock sync.Mutex
 
 	notify chan struct{}
-	closed bool
+	closed atomic.Bool
 
 	readDeadline *deadline.Deadline
 }
 
-// NewPacketBuffer creates a new PacketBuffer.
-func NewPacketBuffer() *PacketBuffer {
+const defaultPacketSize = 128
+
+// NewPacketBufferWithSize creates a new PacketBuffer with a given buffer size.
+func NewPacketBufferWithSize(bufSize int) *PacketBuffer {
+	if bufSize == 0 {
+		bufSize = defaultPacketSize
+	}
+
 	return &PacketBuffer{
 		readDeadline: deadline.New(),
-		// In the narrow context in which this package is currently used, there
-		// will always be at least one packet written to the buffer. Therefore,
-		// we opt to allocate with size of 1 during construction, rather than
-		// waiting until that first packet is written.
-		packets: make([]AddrPacket, 1),
-		full:    false,
+		packets:      make([]AddrPacket, bufSize),
+		notify:       make(chan struct{}, 1),
 	}
+}
+
+// NewPacketBuffer creates a new PacketBuffer with default buffer size.
+func NewPacketBuffer() *PacketBuffer {
+	return NewPacketBufferWithSize(defaultPacketSize)
+}
+
+//nolint:gochecknoglobals
+var bufferPool = sync.Pool{
+	New: func() any {
+		return &bytes.Buffer{}
+	},
 }
 
 // WriteTo writes a single packet to the buffer. The supplied address will
 // remain associated with the packet.
 func (b *PacketBuffer) WriteTo(pkt []byte, addr net.Addr) (int, error) {
-	b.mutex.Lock()
+	b.writeLock.Lock()
+	defer b.writeLock.Unlock()
 
-	if b.closed {
-		b.mutex.Unlock()
-
+	if b.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 
-	var notify chan struct{}
-	if b.notify != nil {
-		notify = b.notify
-		b.notify = nil
+	write := b.write.Load()
+	read := b.read.Load()
+
+	if write-read >= uint64(len(b.packets)) {
+		return 0, dtlserrors.ErrBufferTooSmall
 	}
 
-	// Check to see if we are full.
-	if b.full {
-		// If so, grow AddrPacket buffer.
-		var newSize int
-		if len(b.packets) < 128 {
-			// Double the number of packets.
-			newSize = len(b.packets) * 2
-		} else {
-			// Increase the number of packets by 25%.
-			newSize = 5 * len(b.packets) / 4
-		}
-		newBuf := make([]AddrPacket, newSize)
-		var n int
-		if b.read < b.write {
-			n = copy(newBuf, b.packets[b.read:b.write])
-		} else {
-			n = copy(newBuf, b.packets[b.read:])
-			n += copy(newBuf[n:], b.packets[:b.write])
-		}
+	slot := &b.packets[write%uint64(len(b.packets))]
 
-		b.packets = newBuf
+	buf := bufferPool.Get()
+	slot.data, _ = buf.(*bytes.Buffer)
+	slot.data.Reset()
 
-		// Update read/write pointers and mark buffer as not full.
-		b.read = 0
-		b.write = n
-		b.full = false
-	}
-
-	// Store the packet at the write pointer.
-	packet := &b.packets[b.write]
-	packet.data.Reset()
-	n, err := packet.data.Write(pkt)
+	n, err := slot.data.Write(pkt)
 	if err != nil {
-		b.mutex.Unlock()
-
 		return n, err
 	}
-	packet.addr = addr
 
-	// Increment write pointer.
-	b.write++
+	slot.addr = addr
 
-	// If the write pointer is equal to the length of the buffer, wrap around.
-	if len(b.packets) == b.write {
-		b.write = 0
-	}
+	b.write.Add(1)
 
-	// If a write resulted in making write and read pointers equivalent, then we
-	// are full.
-	if b.write == b.read {
-		b.full = true
-	}
-
-	b.mutex.Unlock()
-
-	if notify != nil {
-		close(notify)
+	select {
+	case b.notify <- struct{}{}:
+	default:
 	}
 
 	return n, nil
@@ -147,88 +119,80 @@ func (b *PacketBuffer) WriteTo(pkt []byte, addr net.Addr) (int, error) {
 
 // ReadFrom reads a single packet from the buffer, or blocks until one is
 // available.
-func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error) { //nolint:cyclop
+func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error) {
+	b.readLock.Lock()
+
 	select {
 	case <-b.readDeadline.Done():
+		b.readLock.Unlock()
+
 		return 0, nil, ErrTimeout
 	default:
 	}
 
 	for {
-		b.mutex.Lock()
+		read := b.read.Load()
+		write := b.write.Load()
 
-		if b.read != b.write || b.full {
-			ap := b.packets[b.read]
-			if len(packet) < ap.data.Len() {
-				b.mutex.Unlock()
+		if read < write {
+			slot := &b.packets[read%uint64(len(b.packets))]
+
+			if len(packet) < slot.data.Len() {
+				b.readLock.Unlock()
 
 				return 0, nil, io.ErrShortBuffer
 			}
 
-			// Copy packet data from buffer.
-			n, err := ap.data.Read(packet)
+			n, err := slot.data.Read(packet)
 			if err != nil {
-				b.mutex.Unlock()
+				b.readLock.Unlock()
 
 				return n, nil, err
 			}
 
-			// Advance read pointer.
-			b.read++
-			if len(b.packets) == b.read {
-				b.read = 0
-			}
+			addr = slot.addr
 
-			// If we were full before reading and have successfully read, we are
-			// no longer full.
-			if b.full {
-				b.full = false
-			}
+			bufferPool.Put(slot.data)
+			slot.data = nil
 
-			b.mutex.Unlock()
+			b.read.Add(1)
+			b.readLock.Unlock()
 
-			return n, ap.addr, nil
+			return n, addr, nil
 		}
 
-		if b.closed {
-			b.mutex.Unlock()
+		if b.closed.Load() {
+			b.readLock.Unlock()
 
 			return 0, nil, io.EOF
 		}
 
-		if b.notify == nil {
-			b.notify = make(chan struct{})
-		}
-		notify := b.notify
-		b.mutex.Unlock()
-
+		b.readLock.Unlock()
 		select {
 		case <-b.readDeadline.Done():
 			return 0, nil, ErrTimeout
-		case <-notify:
+		case <-b.notify:
+			b.readLock.Lock()
 		}
 	}
 }
 
 // Close closes the buffer, allowing unread packets to be read, but erroring on
 // any new writes.
-func (b *PacketBuffer) Close() (err error) {
-	b.mutex.Lock()
+func (b *PacketBuffer) Close() error {
+	b.writeLock.Lock()
+	defer b.writeLock.Unlock()
 
-	if b.closed {
-		b.mutex.Unlock()
+	b.readLock.Lock()
+	defer b.readLock.Unlock()
 
+	if !b.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 
-	notify := b.notify
-	b.notify = nil
-	b.closed = true
-
-	b.mutex.Unlock()
-
-	if notify != nil {
-		close(notify)
+	select {
+	case b.notify <- struct{}{}:
+	default:
 	}
 
 	return nil
@@ -236,7 +200,14 @@ func (b *PacketBuffer) Close() (err error) {
 
 // SetReadDeadline sets the read deadline for the buffer.
 func (b *PacketBuffer) SetReadDeadline(t time.Time) error {
+	b.readLock.Lock()
+	defer b.readLock.Unlock()
 	b.readDeadline.Set(t)
+
+	select {
+	case b.notify <- struct{}{}:
+	default:
+	}
 
 	return nil
 }

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -106,15 +106,17 @@ func (b *PacketBuffer) WriteTo(pkt []byte, addr net.Addr) (int, error) {
 		b.readLock.Lock()
 		read = b.read.Load()
 
-		oldLen := len(b.packets)
-		newLen := oldLen * 2
+		if write-read >= uint64(len(b.packets)) {
+			oldLen := len(b.packets)
+			newLen := oldLen * 2
 
-		packets := make([]AddrPacket, newLen)
-		for i := read; i < write; i++ {
-			packets[i%uint64(newLen)] = b.packets[i%uint64(oldLen)]
+			packets := make([]AddrPacket, newLen)
+			for i := read; i < write; i++ {
+				packets[i%uint64(newLen)] = b.packets[i%uint64(oldLen)]
+			}
+
+			b.packets = packets
 		}
-
-		b.packets = packets
 		b.readLock.Unlock()
 	}
 

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsnet "github.com/pion/dtls/v3/pkg/net"
 	"github.com/pion/transport/v4/deadline"
 )
 
@@ -32,14 +33,15 @@ var ErrTimeout = dtlserrors.ErrNetBufferTimeout
 // it was received.
 type AddrPacket struct {
 	addr net.Addr
-	data *bytes.Buffer
+	data bytes.Buffer
 }
 
 // PacketBuffer is a circular buffer for network packets. Each slot in the
 // buffer contains the remote address from which the packet was received, as
 // well as the packet data.
 type PacketBuffer struct {
-	packets []AddrPacket
+	packets  []AddrPacket
+	growable bool
 
 	write, read         atomic.Uint64
 	readLock, writeLock sync.Mutex
@@ -51,12 +53,12 @@ type PacketBuffer struct {
 	readDeadline *deadline.Deadline
 }
 
-const defaultPacketSize = 128
-
 // NewPacketBufferWithSize creates a new PacketBuffer with a given buffer size.
+// If the size is 0 (default), the ring buffer is unbounded and will grow indefinitely.
 func NewPacketBufferWithSize(bufSize int) *PacketBuffer {
-	if bufSize == 0 {
-		bufSize = defaultPacketSize
+	growable := bufSize == 0
+	if growable {
+		bufSize = 1
 	}
 
 	return &PacketBuffer{
@@ -64,19 +66,13 @@ func NewPacketBufferWithSize(bufSize int) *PacketBuffer {
 		packets:      make([]AddrPacket, bufSize),
 		notify:       make(chan struct{}, 1),
 		closedCh:     make(chan struct{}),
+		growable:     growable,
 	}
 }
 
 // NewPacketBuffer creates a new PacketBuffer with default buffer size.
 func NewPacketBuffer() *PacketBuffer {
-	return NewPacketBufferWithSize(defaultPacketSize)
-}
-
-//nolint:gochecknoglobals
-var bufferPool = sync.Pool{
-	New: func() any {
-		return &bytes.Buffer{}
-	},
+	return NewPacketBufferWithSize(dtlsnet.PacketBufferRingbufferSize)
 }
 
 // WriteTo writes a single packet to the buffer. The supplied address will
@@ -93,13 +89,26 @@ func (b *PacketBuffer) WriteTo(pkt []byte, addr net.Addr) (int, error) {
 	read := b.read.Load()
 
 	if write-read >= uint64(len(b.packets)) {
-		return 0, dtlserrors.ErrBufferTooSmall
+		if !b.growable {
+			return 0, dtlserrors.ErrBufferTooSmall
+		}
+		b.readLock.Lock()
+		read = b.read.Load()
+
+		oldLen := len(b.packets)
+		newLen := oldLen * 2
+
+		packets := make([]AddrPacket, newLen)
+		for i := read; i < write; i++ {
+			packets[i%uint64(newLen)] = b.packets[i%uint64(oldLen)]
+		}
+
+		b.packets = packets
+		b.readLock.Unlock()
 	}
 
 	slot := &b.packets[write%uint64(len(b.packets))]
 
-	buf := bufferPool.Get()
-	slot.data, _ = buf.(*bytes.Buffer)
 	slot.data.Reset()
 
 	n, err := slot.data.Write(pkt)
@@ -153,9 +162,6 @@ func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error)
 			}
 
 			addr = slot.addr
-
-			bufferPool.Put(slot.data)
-			slot.data = nil
 
 			b.read.Add(1)
 			b.readLock.Unlock()

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -44,8 +44,9 @@ type PacketBuffer struct {
 	write, read         atomic.Uint64
 	readLock, writeLock sync.Mutex
 
-	notify chan struct{}
-	closed atomic.Bool
+	notify   chan struct{}
+	closedCh chan struct{}
+	closed   atomic.Bool
 
 	readDeadline *deadline.Deadline
 }
@@ -62,6 +63,7 @@ func NewPacketBufferWithSize(bufSize int) *PacketBuffer {
 		readDeadline: deadline.New(),
 		packets:      make([]AddrPacket, bufSize),
 		notify:       make(chan struct{}, 1),
+		closedCh:     make(chan struct{}),
 	}
 }
 
@@ -143,7 +145,7 @@ func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error)
 				return 0, nil, io.ErrShortBuffer
 			}
 
-			n, err := slot.data.Read(packet)
+			n, err = slot.data.Read(packet)
 			if err != nil {
 				b.readLock.Unlock()
 
@@ -168,12 +170,21 @@ func (b *PacketBuffer) ReadFrom(packet []byte) (n int, addr net.Addr, err error)
 		}
 
 		b.readLock.Unlock()
-		select {
-		case <-b.readDeadline.Done():
+		if err = b.waitForRead(); err != nil {
 			return 0, nil, ErrTimeout
-		case <-b.notify:
-			b.readLock.Lock()
 		}
+		b.readLock.Lock()
+	}
+}
+
+func (b *PacketBuffer) waitForRead() error {
+	select {
+	case <-b.readDeadline.Done():
+		return ErrTimeout
+	case <-b.notify:
+		return nil
+	case <-b.closedCh:
+		return nil
 	}
 }
 
@@ -190,10 +201,7 @@ func (b *PacketBuffer) Close() error {
 		return nil
 	}
 
-	select {
-	case b.notify <- struct{}{}:
-	default:
-	}
+	close(b.closedCh)
 
 	return nil
 }

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -38,6 +38,16 @@ func equalBytes(t *testing.T, expected, actual []byte) {
 	assert.Equal(t, expected, actual)
 }
 
+func waitForBlockedReaders(t *testing.T, buffer *PacketBuffer, count int) {
+	t.Helper()
+
+	if !assert.Eventually(t, func() bool {
+		return buffer.notify.Load().waiters.Load() == int64(count)
+	}, time.Second, time.Millisecond) {
+		assert.Fail(t, "timed out waiting for blocked readers")
+	}
+}
+
 func TestBuffer(t *testing.T) {
 	buffer := NewPacketBuffer()
 	packet := make([]byte, 4)
@@ -354,6 +364,72 @@ func TestBufferCloseUnblocksAllReaders(t *testing.T) {
 			assert.ErrorIs(t, err, io.EOF)
 		case <-time.After(time.Second):
 			assert.Fail(t, "timed out waiting for blocked reader to return")
+
+			return
+		}
+	}
+}
+
+func TestBufferWritesUnblockAllReaders(t *testing.T) {
+	const readerCount = 4
+
+	buffer := NewPacketBuffer()
+	defer func() { assert.NoError(t, buffer.Close()) }()
+
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5684}
+	results := make(chan error, readerCount)
+
+	for range readerCount {
+		go func() {
+			_, _, err := buffer.ReadFrom(make([]byte, 1))
+			results <- err
+		}()
+	}
+
+	waitForBlockedReaders(t, buffer, readerCount)
+	for i := range readerCount {
+		_, err := buffer.WriteTo([]byte{byte(i)}, addr)
+		assert.NoError(t, err)
+	}
+
+	for range readerCount {
+		select {
+		case err := <-results:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			assert.Fail(t, "timed out waiting for blocked reader to return")
+
+			return
+		}
+	}
+}
+
+func TestBufferWriteUnblocksAllShortBufferReaders(t *testing.T) {
+	const readerCount = 4
+
+	buffer := NewPacketBuffer()
+	defer func() { assert.NoError(t, buffer.Close()) }()
+
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5684}
+	results := make(chan error, readerCount)
+
+	for range readerCount {
+		go func() {
+			_, _, err := buffer.ReadFrom(make([]byte, 1))
+			results <- err
+		}()
+	}
+
+	waitForBlockedReaders(t, buffer, readerCount)
+	_, err := buffer.WriteTo([]byte{1, 2}, addr)
+	assert.NoError(t, err)
+
+	for range readerCount {
+		select {
+		case err = <-results:
+			assert.ErrorIs(t, err, io.ErrShortBuffer)
+		case <-time.After(time.Second):
+			assert.Fail(t, "timed out waiting for blocked short-buffer reader to return")
 
 			return
 		}

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -213,14 +213,67 @@ func TestWraparound(t *testing.T) {
 	assert.NoError(t, err)
 	equalInt(t, 3, n)
 
-	// Write again and verify buffer grew.
+	// Write again and verify buffer did not grew.
 	n, err = buffer.WriteTo([]byte{12, 13, 14, 15, 16, 17, 18, 19}, addr)
 	assert.NoError(t, err)
 	equalInt(t, 8, n)
+	equalInt(t, 4, len(buffer.packets))
 
 	// Write again and verify packet dropped.
 	_, err = buffer.WriteTo([]byte{12, 13, 14, 15, 16, 17, 18, 19}, addr)
 	assert.Error(t, err)
+	equalInt(t, 4, len(buffer.packets))
+
+	// Close.
+	assert.NoError(t, buffer.Close())
+}
+
+func TestWraparoundUnbounded(t *testing.T) {
+	buffer := NewPacketBuffer()
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:5684")
+	assert.NoError(t, err)
+
+	// Write multiple.
+	n, err := buffer.WriteTo([]byte{0, 1, 2, 3}, addr)
+	assert.NoError(t, err)
+	equalInt(t, 4, n)
+
+	n, err = buffer.WriteTo([]byte{4, 5}, addr)
+	assert.NoError(t, err)
+	equalInt(t, 2, n)
+
+	n, err = buffer.WriteTo([]byte{6, 7, 8}, addr)
+	assert.NoError(t, err)
+	equalInt(t, 3, n)
+
+	// Verify underlying buffer length.
+	// Packet 1: buffer does not grow.
+	// Packet 2: buffer doubles from 1 to 2.
+	// Packet 3: buffer doubles from 2 to 4.
+	equalInt(t, 4, len(buffer.packets))
+	// Read once.
+	packet := make([]byte, 4)
+	var raddr net.Addr
+	n, raddr, err = buffer.ReadFrom(packet)
+	assert.NoError(t, err)
+	equalInt(t, 4, n)
+	equalBytes(t, []byte{0, 1, 2, 3}, packet[:n])
+	equalUDPAddr(t, addr, raddr)
+
+	// Write again.
+	n, err = buffer.WriteTo([]byte{9, 10, 11}, addr)
+	assert.NoError(t, err)
+	equalInt(t, 3, n)
+
+	// Verify underlying buffer length.
+	// No change in buffer size.
+	equalInt(t, 4, len(buffer.packets))
+
+	// Write again and verify buffer grew.
+	n, err = buffer.WriteTo([]byte{12, 13, 14, 15, 16, 17, 18, 19}, addr)
+	assert.NoError(t, err)
+	equalInt(t, 8, n)
+	equalInt(t, 4, len(buffer.packets))
 
 	// Close.
 	assert.NoError(t, buffer.Close())

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -191,6 +191,54 @@ func TestResizeWraparound(t *testing.T) {
 	}
 }
 
+func TestResizeRechecksCapacityAfterAcquiringReadLock(t *testing.T) {
+	buffer := NewPacketBuffer()
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5684}
+
+	_, err := buffer.WriteTo([]byte{1}, addr)
+	assert.NoError(t, err)
+
+	buffer.readLock.Lock()
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := buffer.WriteTo([]byte{2}, addr)
+		writeDone <- writeErr
+	}()
+
+	if !assert.Eventually(t, func() bool {
+		if !buffer.writeLock.TryLock() {
+			return true
+		}
+		buffer.writeLock.Unlock()
+
+		return false
+	}, time.Second, time.Millisecond) {
+		buffer.readLock.Unlock()
+
+		return
+	}
+
+	buffer.read.Add(1)
+	buffer.readLock.Unlock()
+
+	select {
+	case err = <-writeDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "timed out waiting for writer to return")
+
+		return
+	}
+
+	equalInt(t, 1, len(buffer.packets))
+
+	packet := make([]byte, 1)
+	n, _, err := buffer.ReadFrom(packet)
+	assert.NoError(t, err)
+	equalInt(t, 1, n)
+	equalBytes(t, []byte{2}, packet[:n])
+}
+
 func TestWraparound(t *testing.T) {
 	buffer := NewPacketBufferWithSize(4)
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:5684")

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -273,6 +273,40 @@ func TestBufferAsync(t *testing.T) {
 	assert.False(t, ok, routineFail)
 }
 
+func TestBufferCloseUnblocksAllReaders(t *testing.T) {
+	const readerCount = 4
+
+	buffer := NewPacketBuffer()
+	started := make(chan struct{}, readerCount)
+	results := make(chan error, readerCount)
+
+	for range readerCount {
+		go func() {
+			started <- struct{}{}
+			_, _, err := buffer.ReadFrom(make([]byte, 1))
+			results <- err
+		}()
+	}
+
+	for range readerCount {
+		<-started
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	assert.NoError(t, buffer.Close())
+
+	for range readerCount {
+		select {
+		case err := <-results:
+			assert.ErrorIs(t, err, io.EOF)
+		case <-time.After(time.Second):
+			assert.Fail(t, "timed out waiting for blocked reader to return")
+
+			return
+		}
+	}
+}
+
 func benchmarkBufferWR(b *testing.B, size int64, write bool, grow int) { // nolint:unparam
 	b.Helper()
 

--- a/internal/net/buffer_test.go
+++ b/internal/net/buffer_test.go
@@ -182,7 +182,7 @@ func TestResizeWraparound(t *testing.T) {
 }
 
 func TestWraparound(t *testing.T) {
-	buffer := NewPacketBuffer()
+	buffer := NewPacketBufferWithSize(4)
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:5684")
 	assert.NoError(t, err)
 
@@ -199,12 +199,6 @@ func TestWraparound(t *testing.T) {
 	assert.NoError(t, err)
 	equalInt(t, 3, n)
 
-	// Verify underlying buffer length.
-	// Packet 1: buffer does not grow.
-	// Packet 2: buffer doubles from 1 to 2.
-	// Packet 3: buffer doubles from 2 to 4.
-	equalInt(t, 4, len(buffer.packets))
-
 	// Read once.
 	packet := make([]byte, 4)
 	var raddr net.Addr
@@ -219,15 +213,14 @@ func TestWraparound(t *testing.T) {
 	assert.NoError(t, err)
 	equalInt(t, 3, n)
 
-	// Verify underlying buffer length.
-	// No change in buffer size.
-	equalInt(t, 4, len(buffer.packets))
-
 	// Write again and verify buffer grew.
 	n, err = buffer.WriteTo([]byte{12, 13, 14, 15, 16, 17, 18, 19}, addr)
 	assert.NoError(t, err)
 	equalInt(t, 8, n)
-	equalInt(t, 4, len(buffer.packets))
+
+	// Write again and verify packet dropped.
+	_, err = buffer.WriteTo([]byte{12, 13, 14, 15, 16, 17, 18, 19}, addr)
+	assert.Error(t, err)
 
 	// Close.
 	assert.NoError(t, buffer.Close())
@@ -355,7 +348,7 @@ func benchmarkBuffer(b *testing.B, size int64) {
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:5684")
 	assert.NoError(b, err)
 
-	buffer := NewPacketBuffer()
+	buffer := NewPacketBufferWithSize(b.N)
 	b.SetBytes(size)
 
 	done := make(chan struct{})

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -109,3 +109,8 @@ func (p *packetConnWrapper) SetReadDeadline(t time.Time) error {
 func (p *packetConnWrapper) SetWriteDeadline(t time.Time) error {
 	return p.conn.SetWriteDeadline(t)
 }
+
+// PacketBufferRingbufferSize allows for setting the ring buffer size.
+// A size of 0 (default), means the ring buffer will grow when full.
+// If a size if provided, the packets will be dropped when the ring buffer is full.
+var PacketBufferRingbufferSize = 0 //nolint:gochecknoglobals


### PR DESCRIPTION
Optimize `PacketConn` by:
- Avoiding unbound buffer growth of buffers
- Removing locks between reads and writes

On top of that:
- Add option to set the listener backlog size
- Add option to set the `PacketConn` ringbuf size

Also add a quick function to quickly drain packets at the `Conn` layer.