### PR TITLE
Fix panic unmarshaling ECDHE_PSK ClientKeyExchange

### DIFF
--- a/pkg/protocol/handshake/message_client_key_exchange.go
+++ b/pkg/protocol/handshake/message_client_key_exchange.go
@@ -74,12 +74,15 @@ func (m *MessageClientKeyExchange) Unmarshal(data []byte) error {
 	}
 
 	if m.KeyExchangeAlgorithm.Has(types.KeyExchangeAlgorithmEcdhe) {
+		if offset >= len(data) {
+			return dtlserrors.ErrBufferTooSmall
+		}
 		publicKeyLength := int(data[offset])
 		if publicKeyLength > len(data)-1-offset {
 			return dtlserrors.ErrBufferTooSmall
 		}
 
-		m.PublicKey = bytes.Clone(data[offset+1:])
+		m.PublicKey = bytes.Clone(data[offset+1 : offset+1+publicKeyLength])
 	}
 
 	return nil

--- a/pkg/protocol/handshake/message_client_key_exchange_test.go
+++ b/pkg/protocol/handshake/message_client_key_exchange_test.go
@@ -42,3 +42,70 @@ func TestHandshakeMessageClientKeyExchange_PublicKeyTooLong(t *testing.T) {
 	_, err := c.Marshal()
 	assert.ErrorIs(t, err, dtlserrors.ErrPublicKeyTooLong)
 }
+
+func TestHandshakeMessageClientKeyExchangeECDHEPSK(t *testing.T) {
+	raw := []byte{
+		0x00, 0x04, 0x69, 0x64, 0x65, 0x6e, // identity hint: "iden"
+		0x03, 0xaa, 0xbb, 0xcc, // public key: 3 bytes
+	}
+	c := &MessageClientKeyExchange{
+		KeyExchangeAlgorithm: types.KeyExchangeAlgorithmPsk | types.KeyExchangeAlgorithmEcdhe,
+	}
+	assert.NoError(t, c.Unmarshal(raw))
+	assert.Equal(t, []byte("iden"), c.IdentityHint)
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc}, c.PublicKey)
+
+	marshaled, err := c.Marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, raw, marshaled)
+}
+
+func TestHandshakeMessageClientKeyExchangeUnmarshalErrors(t *testing.T) {
+	for _, test := range []struct {
+		name                 string
+		keyExchangeAlgorithm types.KeyExchangeAlgorithm
+		data                 []byte
+		expectedErr          error
+	}{
+		{
+			name:                 "BufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x00},
+			expectedErr:          dtlserrors.ErrBufferTooSmall,
+		},
+		{
+			name:                 "CipherSuiteUnset",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmNone,
+			data:                 []byte{0x00, 0x00},
+			expectedErr:          dtlserrors.ErrCipherSuiteUnset,
+		},
+		{
+			// ECDHE_PSK where the (empty) identity hint consumes the whole body,
+			// leaving nothing for the ECDHE public key. Previously panicked.
+			name:                 "EcdhePskEmptyHintConsumesBody",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmPsk | types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x00, 0x00},
+			expectedErr:          dtlserrors.ErrBufferTooSmall,
+		},
+		{
+			// ECDHE_PSK where a non-empty identity hint consumes the whole body,
+			// leaving nothing for the ECDHE public key. Previously panicked.
+			name:                 "EcdhePskIdentityConsumesBody",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmPsk | types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x00, 0x04, 0x69, 0x64, 0x65, 0x6e},
+			expectedErr:          dtlserrors.ErrBufferTooSmall,
+		},
+		{
+			// ECDHE with a public key length exceeding the remaining body.
+			name:                 "PublicKeyBufferTooSmall",
+			keyExchangeAlgorithm: types.KeyExchangeAlgorithmEcdhe,
+			data:                 []byte{0x05, 0x01},
+			expectedErr:          dtlserrors.ErrBufferTooSmall,
+		},
+	} {
+		c := &MessageClientKeyExchange{
+			KeyExchangeAlgorithm: test.keyExchangeAlgorithm,
+		}
+		assert.ErrorIs(t, c.Unmarshal(test.data), test.expectedErr, test.name)
+	}
+}


### PR DESCRIPTION
## Summary

`MessageClientKeyExchange.Unmarshal` panics when the negotiated key exchange
algorithm is ECDHE_PSK and the PSK identity hint length field covers the entire
message body. The PSK branch advances `offset` to the end of the data, and the
ECDHE branch then reads `data[offset]` without checking that
`offset < len(data)`.

This is the ClientKeyExchange counterpart of the panic fixed in #839 for
ServerKeyExchange.

## Changes

- Add a bounds check before reading the ECDHE public key length.
- Bound the `PublicKey` clone by the declared public key length instead of
  cloning the entire remaining body, matching the ServerKeyExchange handling.

## Tests

- `TestHandshakeMessageClientKeyExchangeUnmarshalErrors` covers the two
  previously panicking ECDHE_PSK inputs plus buffer-too-small cases.
- `TestHandshakeMessageClientKeyExchangeECDHEPSK` verifies a valid ECDHE_PSK
  message round-trips through Marshal/Unmarshal.
