### PR TITLE
crypto: refuse non-approved algorithms in FIPS mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -154,6 +154,26 @@ func filterFIPSCurves(curves []elliptic.Curve) []elliptic.Curve {
 	return filtered
 }
 
+// cipherSuiteFIPSApproved reports whether a suite's cipher comes from the Go FIPS
+// module. ChaCha20-Poly1305 and AES-CCM don't, so they're not approved in FIPS
+// mode; AES-GCM and AES-CBC are fine.
+func cipherSuiteFIPSApproved(id cryptosuite.ID) bool {
+	switch id {
+	case cryptosuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		cryptosuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		cryptosuite.TLS_PSK_WITH_CHACHA20_POLY1305_SHA256,
+		cryptosuite.TLS_CHACHA20_POLY1305_SHA256,
+		cryptosuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
+		cryptosuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
+		cryptosuite.TLS_PSK_WITH_AES_128_CCM,
+		cryptosuite.TLS_PSK_WITH_AES_128_CCM_8,
+		cryptosuite.TLS_PSK_WITH_AES_256_CCM_8:
+		return false
+	default:
+		return true
+	}
+}
+
 func adaptVerifyConnection(verifyConnection func(*State) error) func(dtlsstate.Active) error {
 	if verifyConnection == nil {
 		return nil
@@ -402,6 +422,14 @@ func selectCipherSuites(selectedIDs []cryptosuite.ID, customCipherSuites func() 
 	cipherSuites = slices.DeleteFunc(cipherSuites, func(suite cryptosuite.Suite) bool {
 		return !slices.ContainsFunc(versions, suite.Capabilities().SupportsVersion)
 	})
+
+	// Drop ciphers the Go FIPS module can't provide when FIPS mode is on,
+	// mirroring effectiveEllipticCurves/filterFIPSCurves above.
+	if fips140.Enabled() {
+		cipherSuites = slices.DeleteFunc(cipherSuites, func(suite cryptosuite.Suite) bool {
+			return !cipherSuiteFIPSApproved(suite.ID())
+		})
+	}
 
 	var foundCertificateSuite, foundPSKSuite, foundTrafficSuite bool
 	i := 0

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -52,6 +52,9 @@ var (
 	ErrNoAvailableCipherSuites = stderrors.New(
 		"connection can not be created, no CipherSuites satisfy this Config",
 	)
+	// ErrCipherSuiteNotFIPSApproved is returned when a cipher the Go FIPS module
+	// doesn't provide (ChaCha20-Poly1305 or AES-CCM) would be used in FIPS mode.
+	ErrCipherSuiteNotFIPSApproved        = stderrors.New("cipher suite not approved in FIPS mode")
 	ErrNoAvailablePSKCipherSuite         = stderrors.New("connection can not be created, pre-shared key present but no compatible CipherSuite")
 	ErrNoAvailableCertificateCipherSuite = stderrors.New("connection can not be created, certificate present but no compatible CipherSuite")
 	ErrNoAvailableSignatureSchemes       = stderrors.New(

--- a/resume.go
+++ b/resume.go
@@ -4,6 +4,7 @@
 package dtls
 
 import (
+	"crypto/fips140"
 	"errors"
 	"net"
 
@@ -37,6 +38,12 @@ func resumeWithConfig(state *State, conn net.PacketConn, rAddr net.Addr, config 
 }
 
 func resolveResumeCipherSuite(state *State, config *dtlsConfig) (cryptosuite.Suite, error) {
+	// Resuming rebuilds the cipher from the stored suite ID, skipping the
+	// negotiation-time FIPS filter, so refuse a non-approved suite here.
+	if fips140.Enabled() && !cipherSuiteFIPSApproved(state.CipherSuiteID) {
+		return nil, dtlserrors.ErrCipherSuiteNotFIPSApproved
+	}
+
 	selected, err := state.cipherSuite()
 	if err == nil {
 		return selected, nil


### PR DESCRIPTION
#### Description

PR #817 made the default curve FIPS-safe. This does the same for the symmetric cipher, so a build that must stay inside the Go FIPS module (`crypto/fips140.Enabled()`) doesn't route through a cipher the module doesn't provide.

Under `GODEBUG=fips140=on` the module doesn't reject a non-approved algorithm on its own — it just isn't a validated implementation — so the algorithm has to be kept out of the handshake. This drops ChaCha20-Poly1305 (`golang.org/x/crypto`) and AES-CCM (pure-Go CCM) from negotiation, mirroring the existing `filterFIPSCurves` in `config.go`. AES-GCM and AES-CBC are unaffected.

Kept deliberately narrow — two sites:

- **Negotiation** (`config.go`) — drop the non-approved suites from the negotiated list when FIPS is on, right after the existing version filter and alongside the existing `filterFIPSCurves` curve filter.
- **Resume** (`resume.go`) — `resolveResumeCipherSuite` rebuilds the cipher from the stored `CipherSuiteID` and never re-negotiates, so it bypasses that filter. Refuse a non-approved suite at that resume boundary so a stored suite can't route around it.

Both are no-ops when FIPS mode is off, so existing behavior is unchanged. `GOEXPERIMENT=boringcrypto` builds don't set `fips140.Enabled()` and are unaffected.

#### Changes

1. **`config.go`** — `cipherSuiteFIPSApproved` (predicate, beside `filterFIPSCurves`), applied via `slices.DeleteFunc` during cipher-suite assembly when `fips140.Enabled()`.
2. **`resume.go`** — refuse a non-approved suite at the resume boundary (`resolveResumeCipherSuite`). Cipher implementations themselves are unchanged.
3. **`internal/errors/errors.go`** — adds `ErrCipherSuiteNotFIPSApproved`, returned by the resume guard. Internal-only, matching the existing `ErrNoAvailableCipherSuites` and friends.

No tests, no exported-API changes, and no `go.mod`/`go.sum` changes (`crypto/fips140` is stdlib).

#### Testing

One caveat on testing: this repo's CI runs with FIPS **off**, so `fips140.Enabled()` is false and both guards are inert there — CI confirms the change doesn't regress the non-FIPS path, nothing more. There's no test that asserts a non-approved suite is actually dropped.
