### PR TITLE
Synchronize handshake state access

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -173,6 +173,14 @@ func (c handshakeConn) SessionKey() []byte {
 	return c.conn.sessionKey()
 }
 
+func (c handshakeConn) LockState() {
+	c.conn.stateMu.Lock()
+}
+
+func (c handshakeConn) UnlockState() {
+	c.conn.stateMu.Unlock()
+}
+
 func adaptFlightConn(conn *Conn) dtlsflight.Conn {
 	if conn == nil {
 		return nil
@@ -214,6 +222,11 @@ type Conn struct {
 	connectionClosedByUser bool
 	closeLock              sync.Mutex
 	closed                 *closer.Closer
+
+	// stateMu guards the c.state field replacement and mutations of the
+	// shared connection state performed by the handshake FSM. Readers such
+	// as ConnectionState hold the read side.
+	stateMu sync.RWMutex
 
 	readDeadline  *deadline.Deadline
 	writeDeadline *deadline.Deadline
@@ -410,8 +423,10 @@ func (c *Conn) prepareHandshakeStart(ctx context.Context) (handshakeStart, error
 func (c *Conn) prepareHandshakeStart12() handshakeStart {
 	isClient := dtlsstate.CommonState(c.state).IsClient
 	if c.handshakeConfig.ResumeState != nil {
+		c.stateMu.Lock()
 		c.state = c.handshakeConfig.ResumeState
 		dtlsstate.CommonState(c.state).LocalVersion = protocol.Version1_2
+		c.stateMu.Unlock()
 
 		if isClient {
 			return handshakeStart{flight12: dtlsflight12.Flight5, fsmState: dtlshandshake.StateFinished}
@@ -420,9 +435,11 @@ func (c *Conn) prepareHandshakeStart12() handshakeStart {
 		return handshakeStart{flight12: dtlsflight12.Flight6, fsmState: dtlshandshake.StateFinished}
 	}
 
+	c.stateMu.Lock()
 	state := dtlsstate.Activate12(c.state)
 	c.state = state
 	state.LocalVersion = protocol.Version1_2
+	c.stateMu.Unlock()
 	if isClient {
 		return handshakeStart{flight12: dtlsflight12.Flight1, fsmState: dtlshandshake.StatePreparing}
 	}
@@ -431,9 +448,11 @@ func (c *Conn) prepareHandshakeStart12() handshakeStart {
 }
 
 func (c *Conn) prepareHandshakeStart13() handshakeStart {
+	c.stateMu.Lock()
 	state := dtlsstate.Activate13(c.state)
 	c.state = state
 	state.LocalVersion = protocol.Version1_3
+	c.stateMu.Unlock()
 	if state.IsClient {
 		return handshakeStart{flight13: dtlsflight13.Flight1, fsmState: dtlshandshake.StatePreparing}
 	}
@@ -724,8 +743,8 @@ func (c *Conn) Close() error {
 // ConnectionState returns basic DTLS details about the connection.
 // Note that this replaced the `Export` function of v1.
 func (c *Conn) ConnectionState() (State, bool) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
 	state, err := generateStateForVerifyConnection(c.state)
 	if err != nil {
 		return State{}, false
@@ -736,6 +755,8 @@ func (c *Conn) ConnectionState() (State, bool) {
 
 // SelectedSRTPProtectionProfile returns the selected SRTPProtectionProfile.
 func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
 	profile := dtlsstate.CommonState(c.state).SRTPProtectionProfile()
 	if profile == 0 {
 		return 0, false
@@ -746,6 +767,8 @@ func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
 
 // RemoteSRTPMasterKeyIdentifier returns the MasterKeyIdentifier value from the use_srtp.
 func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
 	common := dtlsstate.CommonState(c.state)
 	if profile := common.SRTPProtectionProfile(); profile == 0 {
 		return nil, false
@@ -945,6 +968,8 @@ func (c *Conn) prepareRecord(outbound *dtlsflight.Outbound) ([]byte, error) {
 }
 
 func (c *Conn) nextLocalSequenceNumber(epoch uint16) (uint64, error) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	common := dtlsstate.CommonState(c.state)
 	for len(common.LocalSequenceNumber) <= int(epoch) {
 		common.LocalSequenceNumber = append(common.LocalSequenceNumber, uint64(0))
@@ -2316,8 +2341,10 @@ func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Outbou
 	if !ok {
 		return nil, dtlserrors.ErrFlightUnimplemented13
 	}
+	c.stateMu.Lock()
 	state13 := dtlsstate.Activate13(c.state)
 	c.state = state13
+	c.stateMu.Unlock()
 	pkts, dtlsAlert, err := gen(adaptFlightConn(c), state13, c.handshakeCache, c.handshakeConfig)
 	if dtlsAlert != nil {
 		if alertErr := c.notify(ctx, dtlsAlert.Level, dtlsAlert.Description); alertErr != nil && err == nil {
@@ -2525,6 +2552,8 @@ func (c *Conn) selectRemoteVersion(remote []protocol.Version) error {
 }
 
 func (c *Conn) setNegotiatedVersion(remote []protocol.Version, chosen protocol.Version) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
 	common := dtlsstate.CommonState(c.state)
 	common.RemoteVersions = remote
 	common.LocalVersion = chosen

--- a/conn_state_race_test.go
+++ b/conn_state_race_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+// JS/WASM runs tests single-threaded and the handshake loop in this test
+// exceeds the CI time limit there. The race it covers is meaningless without
+// parallel goroutines anyway.
+
+package dtls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	dtlsnet "github.com/pion/dtls/v3/pkg/net"
+	"github.com/pion/transport/v4/dpipe"
+	"github.com/stretchr/testify/require"
+)
+
+// slowConn adds latency to reads and writes to widen the race window
+// between the handshake FSM goroutine and the polling goroutine.
+type slowConn struct {
+	net.Conn
+	delay time.Duration
+}
+
+func (c *slowConn) Read(p []byte) (int, error) {
+	time.Sleep(c.delay)
+
+	return c.Conn.Read(p)
+}
+
+func (c *slowConn) Write(p []byte) (int, error) {
+	time.Sleep(c.delay)
+
+	return c.Conn.Write(p)
+}
+
+// TestRaceConnectionStateDuringHandshake polls ConnectionState from the main
+// goroutine while the handshake FSM goroutine mutates the shared state
+// fields (CipherSuite, SessionID, MasterSecret, RemoteRandom). Run with
+// -race to verify the access is synchronized.
+func TestRaceConnectionStateDuringHandshake(t *testing.T) { //nolint:cyclop
+	serverCert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	for range 20 {
+		caRaw, cbRaw := dpipe.Pipe()
+		caSlow := &slowConn{Conn: caRaw, delay: 100 * time.Microsecond}
+		cbSlow := &slowConn{Conn: cbRaw, delay: 100 * time.Microsecond}
+
+		ca, err := ClientWithOptions(
+			dtlsnet.PacketConnFromConn(caSlow), caSlow.RemoteAddr(),
+			WithInsecureSkipVerify(true),
+		)
+		require.NoError(t, err)
+		cb, err := ServerWithOptions(
+			dtlsnet.PacketConnFromConn(cbSlow), cbSlow.RemoteAddr(),
+			WithCertificates(serverCert),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		clientDone := make(chan error, 1)
+		serverDone := make(chan error, 1)
+		go func() { clientDone <- ca.HandshakeContext(ctx) }()
+		go func() { serverDone <- cb.HandshakeContext(ctx) }()
+
+		clientFinished, serverFinished := false, false
+		for {
+			_, _ = ca.ConnectionState()
+			_, _ = cb.ConnectionState()
+
+			select {
+			case <-clientDone:
+				clientFinished = true
+			default:
+			}
+			select {
+			case <-serverDone:
+				serverFinished = true
+			default:
+			}
+			if clientFinished && serverFinished {
+				break
+			}
+		}
+
+		require.NoError(t, ca.Close())
+		require.NoError(t, cb.Close())
+	}
+}

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -407,6 +407,10 @@ func (c *flightTestConn) SetLocalEpoch(epoch uint16) {
 	c.epoch = epoch
 }
 
+func (c *flightTestConn) LockState() {}
+
+func (c *flightTestConn) UnlockState() {}
+
 func (c *flightTestConn) Notify(context.Context, alert.Level, alert.Description) error {
 	return nil
 }

--- a/internal/handshake/conn.go
+++ b/internal/handshake/conn.go
@@ -85,6 +85,12 @@ type Conn interface {
 	WritePackets(context.Context, []*dtlsflight.Outbound) (*WriteResult, error)
 	RecvHandshake() <-chan RecvHandshakeState
 	SetLocalEpoch(epoch uint16)
+	// LockState and UnlockState guard mutations of the connection state.
+	// The FSM acquires the write side while flight handlers mutate the
+	// shared state so that concurrent readers (e.g. ConnectionState) see a
+	// consistent snapshot.
+	LockState()
+	UnlockState()
 }
 
 func sideString(isClient bool) string {

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -123,7 +123,9 @@ func (s *fsm12) prepare(ctx context.Context, conn Conn) (State, error) {
 		err = dtlserrors.ErrInvalidFlight
 		dtlsAlert = &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}
 	} else {
+		conn.LockState()
 		pkts, dtlsAlert, err = gen(conn, s.state, s.cache, s.cfg)
+		conn.UnlockState()
 		s.retransmit = retransmit
 	}
 	if err = notifyAlert(ctx, conn, dtlsAlert, err); err != nil {
@@ -175,6 +177,7 @@ func (s *fsm12) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				s.retransmitInterval = s.cfg.InitialRetransmitInterval
 			}
 
+			conn.LockState()
 			nextFlight, dtlsAlert, err, ok := dtlsflight12.Parse(
 				ctx,
 				s.currentFlight,
@@ -183,6 +186,7 @@ func (s *fsm12) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 				s.cache,
 				s.cfg,
 			)
+			conn.UnlockState()
 			if !ok {
 				if alertErr := conn.Notify(ctx, alert.Fatal, alert.InternalError); alertErr != nil {
 					return StateErrored, alertErr

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -274,7 +274,9 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 		err = dtlserrors.ErrFlightUnimplemented13
 		dtlsAlert = &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}
 	} else {
+		conn.LockState()
 		pkts, dtlsAlert, err = gen(conn, s.state, s.cache, s.cfg)
+		conn.UnlockState()
 		s.retransmit = retransmit
 	}
 	if err = notifyAlert(ctx, conn, dtlsAlert, err); err != nil {
@@ -283,7 +285,10 @@ func (s *fsm13) prepare(ctx context.Context, conn Conn) (nextState State, err er
 
 	s.flights = pkts
 	s.prepareFlightACKTracking(s.flights, s.retransmit)
-	if err := s.commitPreparedFlight(conn, s.currentFlight, s.flights); err != nil {
+	conn.LockState()
+	err = s.commitPreparedFlight(conn, s.currentFlight, s.flights)
+	conn.UnlockState()
+	if err != nil {
 		return StateErrored, err
 	}
 

--- a/internal/handshake/fsm_test.go
+++ b/internal/handshake/fsm_test.go
@@ -14,6 +14,7 @@ import (
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsflight12 "github.com/pion/dtls/v3/internal/flight/flight12"
 	dtlsflight13 "github.com/pion/dtls/v3/internal/flight/flight13"
 	dtlscrypto "github.com/pion/dtls/v3/internal/handshakecrypto"
 	"github.com/pion/dtls/v3/internal/negotiation"
@@ -89,6 +90,10 @@ func (c *flightTestConn) SetLocalEpoch(epoch uint16) {
 	c.localEpoch = epoch
 	c.setLocalEpochCalled = true
 }
+
+func (c *flightTestConn) LockState() {}
+
+func (c *flightTestConn) UnlockState() {}
 
 func (c *flightTestConn) HandleQueuedPackets(ctx context.Context) error {
 	if c.handleQueuedPackets != nil {
@@ -346,7 +351,7 @@ func TestHandshakeFSM13PrepareHelloRetryRequestRequiresSeededTranscript(t *testi
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight2, nil, nil)
 	require.NoError(t, err)
 
-	nextState, err := fsm.prepare(context.Background(), nil)
+	nextState, err := fsm.prepare(context.Background(), &flightTestConn{})
 	require.ErrorIs(t, err, dtlserrors.ErrHandshakeTranscriptHelloRetryRequestInvalid)
 	assert.Equal(t, StateErrored, nextState)
 	require.Len(t, fsm.flights, 1)
@@ -363,7 +368,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundClientHello(t *testing.T) {
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight1, nil, nil)
 	require.NoError(t, err)
 
-	nextState, err := fsm.prepare(context.Background(), nil)
+	nextState, err := fsm.prepare(context.Background(), &flightTestConn{})
 	require.NoError(t, err)
 	assert.Equal(t, StateSending, nextState)
 	require.Len(t, fsm.flights, 1)
@@ -390,7 +395,7 @@ func TestHandshakeFSM13PrepareCommitsOutboundHelloRetryRequestWithSeededTranscri
 	fsm, err := newFSM13(state, cache, cfg, dtlsflight13.Flight2, nil, transcript)
 	require.NoError(t, err)
 
-	nextState, err := fsm.prepare(context.Background(), nil)
+	nextState, err := fsm.prepare(context.Background(), &flightTestConn{})
 	require.NoError(t, err)
 	assert.Equal(t, StateSending, nextState)
 	require.Len(t, fsm.flights, 1)
@@ -1637,6 +1642,68 @@ func testHandshakeConfig13(t *testing.T) *dtlsconfig.HandshakeConfig {
 		LocalCertSignatureSchemes:   nil,
 		LocalSRTPProtectionProfiles: nil,
 	}
+}
+
+func testHandshakeConfig12(t *testing.T) *dtlsconfig.HandshakeConfig {
+	t.Helper()
+
+	cipherSuite := ciphersuite.ForID(ciphersuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil)
+	require.NotNil(t, cipherSuite)
+
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	return &dtlsconfig.HandshakeConfig{
+		LocalCipherSuites:         []dtlsconfig.CipherSuite{cipherSuite},
+		EllipticCurves:            []elliptic.Curve{elliptic.X25519},
+		InitialRetransmitInterval: time.Millisecond,
+		ExtendedMasterSecret:      dtlsconfig.RequestExtendedMasterSecret,
+		Log:                       loggerFactory.NewLogger("dtls"),
+	}
+}
+
+func newTestFSM12(t *testing.T) *fsm12 {
+	t.Helper()
+
+	state := dtlsstate.NewState12(true)
+	fsm := NewFSM12(
+		&state,
+		dtlsflight.NewCache(),
+		testHandshakeConfig12(t),
+		dtlsflight12.Flight1,
+		nil,
+		NewEstablishment(),
+	)
+
+	return fsm.(*fsm12) //nolint:forcetypeassert // NewFSM12 always returns *fsm12.
+}
+
+func TestHandshakeFSM12PrepareLocksState(t *testing.T) {
+	conn := &flightTestConn{}
+	fsm := newTestFSM12(t)
+
+	nextState, err := fsm.prepare(context.Background(), conn)
+	require.NoError(t, err)
+	assert.Equal(t, StateSending, nextState)
+	require.Len(t, fsm.flights, 1)
+	hs, ok := fsm.flights[0].Content.(*handshake.Handshake)
+	require.True(t, ok)
+	assert.Equal(t, handshake.TypeClientHello, hs.Message.Type())
+}
+
+func TestHandshakeFSM12WaitLocksState(t *testing.T) {
+	conn := &flightTestConn{
+		recvHandshake: make(chan RecvHandshakeState, 1),
+	}
+	fsm := newTestFSM12(t)
+
+	conn.recvHandshake <- RecvHandshakeState{
+		Done:         make(chan struct{}),
+		HasHandshake: true,
+	}
+
+	nextState, err := fsm.wait(context.Background(), conn)
+	require.NoError(t, err)
+	assert.Equal(t, StateWaiting, nextState)
 }
 
 func TestAppendOutboundHandshakeFlight13ClientHello(t *testing.T) {

--- a/internal/handshake/handshake_context.go
+++ b/internal/handshake/handshake_context.go
@@ -70,7 +70,9 @@ func (c *handshakeContext) parseReceivedFlight(
 	conn Conn,
 	currentFlight dtlsflight13.Flight,
 ) (dtlsflight13.Flight, error) {
+	conn.LockState()
 	nextFlight, dtlsAlert, err, ok := dtlsflight13.Parse(ctx, currentFlight, conn, c.parseDependencies())
+	conn.UnlockState()
 	if !ok {
 		if alertErr := conn.Notify(ctx, alert.Fatal, alert.InternalError); alertErr != nil {
 			return 0, alertErr
@@ -98,14 +100,20 @@ func (c *handshakeContext) advanceAfterReceivedFlight(
 	receivedRecords []protocol.RecordNumber,
 ) (receivedFlightTransition, error) {
 	if c.state.IsClient && nextFlight.IsLastSendFlight() {
-		if err := DeriveAndStoreApplicationTrafficSecrets(c.state, c.transcript); err != nil {
+		conn.LockState()
+		err := DeriveAndStoreApplicationTrafficSecrets(c.state, c.transcript)
+		conn.UnlockState()
+		if err != nil {
 			return receivedFlightTransition{}, err
 		}
 	}
 	if !c.state.IsClient &&
 		currentFlight == nextFlight &&
 		nextFlight.IsLastRecvFlight() {
-		if err := activateApplicationRecordProtection(ctx, conn, c.state); err != nil {
+		conn.LockState()
+		err := activateApplicationRecordProtection(ctx, conn, c.state)
+		conn.UnlockState()
+		if err != nil {
 			return receivedFlightTransition{}, err
 		}
 		if err := sendACK(ctx, conn, c.state.LocalEpoch(), receivedRecords); err != nil {

--- a/state.go
+++ b/state.go
@@ -75,13 +75,18 @@ func generateState(internalState *dtlsstate.State) (*State, error) {
 		peerMKI = bytes.Clone(internalState.RemoteSRTPMasterKeyIdentifier)
 	}
 
+	var sequenceNumber uint64
+	if int(epoch) < len(internalState.LocalSequenceNumber) {
+		sequenceNumber = atomic.LoadUint64(&internalState.LocalSequenceNumber[epoch])
+	}
+
 	return &State{
 		localEpoch:            internalState.LocalEpoch(),
 		remoteEpoch:           internalState.RemoteEpoch(),
 		localRandom:           internalState.LocalRandom,
 		remoteRandom:          internalState.RemoteRandom,
 		masterSecret:          internalState.MasterSecret,
-		sequenceNumber:        atomic.LoadUint64(&internalState.LocalSequenceNumber[epoch]),
+		sequenceNumber:        sequenceNumber,
 		srtpProtectionProfile: profile,
 		peerSRTPMKI:           peerMKI,
 		localConnectionID:     internalState.LocalConnectionID(),


### PR DESCRIPTION
## Summary

The handshake FSM mutates the shared connection state (`CipherSuite`,
`SessionID`, `MasterSecret`, `RemoteRandom`, `LocalSequenceNumber`) from its
own goroutine while users may call `ConnectionState`,
`SelectedSRTPProtectionProfile` or `RemoteSRTPMasterKeyIdentifier`
concurrently. Running `go test -race` during a handshake reports five data
races and can crash with:

```
panic: runtime error: index out of range [0] with length 0
```

when `LocalSequenceNumber` grows while it is being read.

## Changes

- Add `stateMu sync.RWMutex` to `Conn`. The FSM acquires the write side via
  new `LockState`/`UnlockState` methods on the handshake `Conn` interface
  while flight generators and parsers mutate the state. State-replacing
  helpers (`prepareHandshakeStart12/13`, `negotiateVersionClient`,
  `setNegotiatedVersion`) and `nextLocalSequenceNumber` take the write lock.
- `ConnectionState`, `SelectedSRTPProtectionProfile` and
  `RemoteSRTPMasterKeyIdentifier` take the read lock.
- Locking is kept out of paths that acquire `writeLock` (alerts, packet
  writes) to avoid lock-order inversion.
- Bound the `LocalSequenceNumber` read in `generateState`, matching the
  existing guard in `generateState13`.

## Tests

- `TestRaceConnectionStateDuringHandshake` runs 20 handshakes while polling
  `ConnectionState` from the main goroutine and fails under `-race` before
  this change.
- `TestHandshakeFSM12PrepareLocksState` and `TestHandshakeFSM12WaitLocksState`
  cover the DTLS 1.2 FSM lock paths.

## Verification

- `go test -race ./...` passes.
- `go test ./...` passes.
