### PR TITLE
Fix packet connection leak

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -523,6 +523,8 @@ func serverWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (
 	}
 	if config.OnConnectionAttempt != nil {
 		if err := config.OnConnectionAttempt(rAddr); err != nil {
+			_ = conn.Close()
+
 			return nil, err
 		}
 	}


### PR DESCRIPTION
When connection attempt triggers an error we forget to close the packetConn.