### PR TITLE
Synchronize handshake state access

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -83,6 +83,13 @@ type Conn struct {
 	closeLock              sync.Mutex
 	closed                 *closer.Closer
 
+	// stateMu guards the c.state replacement and mutations of the shared
+	// connection state performed by the handshake FSM. Readers such as
+	// ConnectionState hold the read side. localSequenceNumber remains
+	// guarded by lock, whose writers are all reachable through the write
+	// path already holding it.
+	stateMu sync.RWMutex
+
 	readDeadline  *deadline.Deadline
 	writeDeadline *deadline.Deadline
 
@@ -333,7 +340,9 @@ func (c *Conn) HandshakeContext(ctx context.Context) error {
 		}
 		initialFSMState = handshakeFinished
 
+		c.stateMu.Lock()
 		c.state = *c.handshakeConfig.resumeState
+		c.stateMu.Unlock()
 	} else {
 		if c.state.isClient {
 			initialFlight = flight1
@@ -533,9 +542,15 @@ func (c *Conn) Close() error {
 // ConnectionState returns basic DTLS details about the connection.
 // Note that this replaced the `Export` function of v1.
 func (c *Conn) ConnectionState() (State, bool) {
+	// lock guards localSequenceNumber writes on the send path while
+	// stateMu guards the handshake state mutations performed by the FSM.
+	// Both locks are acquired in the stateMu-then-lock order used by the
+	// FSM when it drains queued packets, avoiding lock-order inversion.
+	c.stateMu.RLock()
 	c.lock.RLock()
-	defer c.lock.RUnlock()
 	stateClone, err := c.state.clone()
+	c.lock.RUnlock()
+	c.stateMu.RUnlock()
 	if err != nil {
 		return State{}, false
 	}
@@ -545,6 +560,8 @@ func (c *Conn) ConnectionState() (State, bool) {
 
 // SelectedSRTPProtectionProfile returns the selected SRTPProtectionProfile.
 func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
 	profile := c.state.getSRTPProtectionProfile()
 	if profile == 0 {
 		return 0, false
@@ -555,6 +572,8 @@ func (c *Conn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
 
 // RemoteSRTPMasterKeyIdentifier returns the MasterKeyIdentifier value from the use_srtp.
 func (c *Conn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
+	c.stateMu.RLock()
+	defer c.stateMu.RUnlock()
 	if profile := c.state.getSRTPProtectionProfile(); profile == 0 {
 		return nil, false
 	}
@@ -1459,6 +1478,14 @@ func (c *Conn) isConnectionClosed() bool {
 
 func (c *Conn) setLocalEpoch(epoch uint16) {
 	c.state.localEpoch.Store(epoch)
+}
+
+func (c *Conn) lockState() {
+	c.stateMu.Lock()
+}
+
+func (c *Conn) unlockState() {
+	c.stateMu.Unlock()
 }
 
 func (c *Conn) setRemoteEpoch(epoch uint16) {

--- a/conn_state_race_test.go
+++ b/conn_state_race_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+// JS/WASM runs tests single-threaded and the handshake loop in this test
+// exceeds the CI time limit there. The race it covers is meaningless without
+// parallel goroutines anyway.
+
+package dtls
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
+	dtlsnet "github.com/pion/dtls/v3/pkg/net"
+	"github.com/pion/transport/v4/dpipe"
+	"github.com/stretchr/testify/require"
+)
+
+// slowConn adds latency to reads and writes to widen the race window
+// between the handshake FSM goroutine and the polling goroutine.
+type slowConn struct {
+	net.Conn
+	delay time.Duration
+}
+
+func (c *slowConn) Read(p []byte) (int, error) {
+	time.Sleep(c.delay)
+
+	return c.Conn.Read(p)
+}
+
+func (c *slowConn) Write(p []byte) (int, error) {
+	time.Sleep(c.delay)
+
+	return c.Conn.Write(p)
+}
+
+// TestRaceConnectionStateDuringHandshake polls ConnectionState from the main
+// goroutine while the handshake FSM goroutine mutates the shared state
+// fields (CipherSuite, SessionID, MasterSecret, RemoteRandom). Run with
+// -race to verify the access is synchronized.
+func TestRaceConnectionStateDuringHandshake(t *testing.T) { //nolint:cyclop
+	serverCert, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+
+	for range 20 {
+		caRaw, cbRaw := dpipe.Pipe()
+		caSlow := &slowConn{Conn: caRaw, delay: 100 * time.Microsecond}
+		cbSlow := &slowConn{Conn: cbRaw, delay: 100 * time.Microsecond}
+
+		ca, err := ClientWithOptions(
+			dtlsnet.PacketConnFromConn(caSlow), caSlow.RemoteAddr(),
+			WithInsecureSkipVerify(true),
+		)
+		require.NoError(t, err)
+		cb, err := ServerWithOptions(
+			dtlsnet.PacketConnFromConn(cbSlow), cbSlow.RemoteAddr(),
+			WithCertificates(serverCert),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		clientDone := make(chan error, 1)
+		serverDone := make(chan error, 1)
+		go func() { clientDone <- ca.HandshakeContext(ctx) }()
+		go func() { serverDone <- cb.HandshakeContext(ctx) }()
+
+		clientFinished, serverFinished := false, false
+		for {
+			_, _ = ca.ConnectionState()
+			_, _ = cb.ConnectionState()
+
+			select {
+			case <-clientDone:
+				clientFinished = true
+			default:
+			}
+			select {
+			case <-serverDone:
+				serverFinished = true
+			default:
+			}
+			if clientFinished && serverFinished {
+				break
+			}
+		}
+
+		require.NoError(t, ca.Close())
+		require.NoError(t, cb.Close())
+	}
+}

--- a/flight1handler_test.go
+++ b/flight1handler_test.go
@@ -26,6 +26,8 @@ func (f *flight1TestMockFlightConn) recvHandshake() <-chan recvHandshakeState   
 func (f *flight1TestMockFlightConn) setLocalEpoch(uint16)                          {}
 func (f *flight1TestMockFlightConn) handleQueuedPackets(context.Context) error     { return nil }
 func (f *flight1TestMockFlightConn) sessionKey() []byte                            { return nil }
+func (f *flight1TestMockFlightConn) lockState()                                    {}
+func (f *flight1TestMockFlightConn) unlockState()                                  {}
 
 type flight1TestMockCipherSuite struct {
 	ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256

--- a/flight4handler_test.go
+++ b/flight4handler_test.go
@@ -29,6 +29,8 @@ func (f *flight4TestMockFlightConn) recvHandshake() <-chan recvHandshakeState   
 func (f *flight4TestMockFlightConn) setLocalEpoch(uint16)                          {}
 func (f *flight4TestMockFlightConn) handleQueuedPackets(context.Context) error     { return nil }
 func (f *flight4TestMockFlightConn) sessionKey() []byte                            { return nil }
+func (f *flight4TestMockFlightConn) lockState()                                    {}
+func (f *flight4TestMockFlightConn) unlockState()                                  {}
 
 type flight4TestMockCipherSuite struct {
 	ciphersuite.TLSEcdheEcdsaWithAes128GcmSha256

--- a/handshaker.go
+++ b/handshaker.go
@@ -149,6 +149,12 @@ type flightConn interface {
 	setLocalEpoch(epoch uint16)
 	handleQueuedPackets(context.Context) error
 	sessionKey() []byte
+	// lockState and unlockState guard mutations of the connection state.
+	// The FSM acquires the write side while flight handlers mutate the
+	// shared state so that concurrent readers (e.g. ConnectionState) see a
+	// consistent snapshot.
+	lockState()
+	unlockState()
 }
 
 func (c *handshakeConfig) writeKeyLog(label string, clientRandom, secret []byte) {
@@ -231,7 +237,9 @@ func (s *handshakeFSM) prepare(ctx context.Context, conn flightConn) (handshakeS
 		err = errFlight
 		dtlsAlert = &alert.Alert{Level: alert.Fatal, Description: alert.InternalError}
 	} else {
+		conn.lockState()
 		pkts, dtlsAlert, err = gen(conn, s.state, s.cache, s.cfg)
+		conn.unlockState()
 		s.retransmit = retransmit
 	}
 	if dtlsAlert != nil {
@@ -299,7 +307,9 @@ func (s *handshakeFSM) wait(ctx context.Context, conn flightConn) (handshakeStat
 				s.retransmitInterval = s.cfg.initialRetransmitInterval
 			}
 
+			conn.lockState()
 			nextFlight, alert, err := parse(ctx, conn, s.state, s.cache, s.cfg)
+			conn.unlockState()
 			close(state.done)
 			if alert != nil {
 				if alertErr := conn.notify(ctx, alert.Level, alert.Description); alertErr != nil {

--- a/handshaker_test.go
+++ b/handshaker_test.go
@@ -407,6 +407,10 @@ func (c *flightTestConn) setLocalEpoch(epoch uint16) {
 	c.epoch = epoch
 }
 
+func (c *flightTestConn) lockState() {}
+
+func (c *flightTestConn) unlockState() {}
+
 func (c *flightTestConn) notify(context.Context, alert.Level, alert.Description) error {
 	return nil
 }

--- a/state.go
+++ b/state.go
@@ -117,12 +117,17 @@ func (s *State) serialize() (*serializedState, error) {
 
 	epoch := s.getLocalEpoch()
 
+	var sequenceNumber uint64
+	if int(epoch) < len(s.localSequenceNumber) {
+		sequenceNumber = atomic.LoadUint64(&s.localSequenceNumber[epoch])
+	}
+
 	return &serializedState{
 		LocalEpoch:            s.getLocalEpoch(),
 		RemoteEpoch:           s.getRemoteEpoch(),
 		CipherSuiteID:         cipherSuiteID,
 		MasterSecret:          s.masterSecret,
-		SequenceNumber:        atomic.LoadUint64(&s.localSequenceNumber[epoch]),
+		SequenceNumber:        sequenceNumber,
 		LocalRandom:           localRnd,
 		RemoteRandom:          remoteRnd,
 		SRTPProtectionProfile: uint16(s.getSRTPProtectionProfile()),


### PR DESCRIPTION
## Summary

Backport of #1080 to the v3 maintenance branch, per maintainer request.

The handshake FSM mutates the shared connection state (`cipherSuite`,
`SessionID`, `masterSecret`, `localSequenceNumber`) from its own goroutine
while users may call `ConnectionState`, `SelectedSRTPProtectionProfile` or
`RemoteSRTPMasterKeyIdentifier` concurrently. Running `go test -race` during
a handshake reports data races and can crash with:

```
panic: runtime error: index out of range [0] with length 0
```

when `localSequenceNumber` grows while it is being read.

## Changes

- Add `stateMu sync.RWMutex` to `Conn`. The FSM acquires the write side via
  new `lockState`/`unlockState` methods on the `flightConn` interface while
  flight generators and parsers mutate the state. The resume-state
  replacement and the sequence-number growth paths take the write lock.
- `ConnectionState`, `SelectedSRTPProtectionProfile` and
  `RemoteSRTPMasterKeyIdentifier` take the read lock.
- Locking is kept out of paths that acquire `writeLock` (alerts, packet
  writes) to avoid lock-order inversion.
- Bound the sequence-number read in `State.serialize`, avoiding the crash
  when called before any packet has been sent.

## Tests

- `TestRaceConnectionStateDuringHandshake` runs 20 handshakes while polling
  `ConnectionState` from the main goroutine and fails under `-race` before
  this change. Excluded from JS/WASM where tests run single-threaded.

## Verification

- `go test -race ./...` passes.
- `go test ./...` passes.
