### PR TITLE
Close rejected listeners at Accept

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -412,8 +412,6 @@ func serverWithConfig(conn net.PacketConn, rAddr net.Addr, config *Config) (*Con
 	}
 	if config.OnConnectionAttempt != nil {
 		if err := config.OnConnectionAttempt(rAddr); err != nil {
-			_ = conn.Close()
-
 			return nil, err
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -3398,6 +3398,70 @@ func TestOnConnectionAttempt(t *testing.T) {
 	assert.Equal(t, int32(0), clientOnConnectionAttempt.Load(), "OnConnectionAttempt fired for client")
 }
 
+func TestOnConnectionAttemptConnectionOwnership(t *testing.T) {
+	expectedErr := errors.New("connection rejected") //nolint:err113
+	config := &Config{
+		OnConnectionAttempt: func(net.Addr) error { return expectedErr },
+	}
+
+	t.Run("Server retains caller PacketConn", func(t *testing.T) {
+		ca, cb := dpipe.Pipe()
+		defer func() {
+			assert.NoError(t, ca.Close())
+		}()
+
+		conn := &closeTrackingPacketConn{PacketConn: dtlsnet.PacketConnFromConn(cb)}
+		defer func() {
+			assert.NoError(t, conn.Close())
+		}()
+
+		_, err := Server(conn, cb.RemoteAddr(), config)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.False(t, conn.closed.Load())
+	})
+
+	t.Run("Listener closes rejected accepted PacketConn", func(t *testing.T) {
+		ca, cb := dpipe.Pipe()
+		defer func() {
+			assert.NoError(t, ca.Close())
+		}()
+
+		conn := &closeTrackingPacketConn{PacketConn: dtlsnet.PacketConnFromConn(cb)}
+		l := &listener{
+			config: config,
+			parent: &singlePacketListener{conn: conn, raddr: cb.RemoteAddr()},
+		}
+
+		_, err := l.Accept()
+		assert.ErrorIs(t, err, expectedErr)
+		assert.True(t, conn.closed.Load())
+	})
+}
+
+type closeTrackingPacketConn struct {
+	net.PacketConn
+	closed atomic.Bool
+}
+
+func (c *closeTrackingPacketConn) Close() error {
+	c.closed.Store(true)
+
+	return c.PacketConn.Close()
+}
+
+type singlePacketListener struct {
+	conn  net.PacketConn
+	raddr net.Addr
+}
+
+func (l *singlePacketListener) Accept() (net.PacketConn, net.Addr, error) {
+	return l.conn, l.raddr, nil
+}
+
+func (*singlePacketListener) Close() error { return nil }
+
+func (*singlePacketListener) Addr() net.Addr { return nil }
+
 func TestFragmentBuffer_Retransmission(t *testing.T) {
 	fragmentBuffer := newFragmentBuffer()
 	frag := []byte{

--- a/listener.go
+++ b/listener.go
@@ -100,7 +100,14 @@ func (l *listener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	return serverWithConfig(c, raddr, l.config)
+	conn, err := serverWithConfig(c, raddr, l.config)
+	if err != nil {
+		_ = c.Close()
+
+		return nil, err
+	}
+
+	return conn, nil
 }
 
 // Close closes the listener.


### PR DESCRIPTION
#### Description
https://github.com/pion/dtls/pull/1081 closed the connection at the incorrect layer:
1. it missed createConn errors.
2. it closed user supplied packetConns from `func Server(conn net.PacketConn, rAddr net.Addr, config *Config)` calls.