### PR TITLE
Drop the transient WithOptions suffix

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -27,7 +27,7 @@ func clientConfigError(t *testing.T, opts ...ClientOption) error {
 		_ = cb.Close()
 	}()
 
-	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
+	client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
 	if client != nil {
 		_ = client.Close()
 	}
@@ -44,7 +44,7 @@ func serverConfigError(t *testing.T, opts ...ServerOption) error {
 		_ = cb.Close()
 	}()
 
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
+	server, err := Server(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
 	if server != nil {
 		_ = server.Close()
 	}

--- a/conn.go
+++ b/conn.go
@@ -482,8 +482,8 @@ func dialWithConfig(network string, rAddr *net.UDPAddr, config *dtlsConfig) (*Co
 	return clientWithConfig(pConn, rAddr, config)
 }
 
-// DialWithOptions connects to the given network address and establishes a DTLS connection on top.
-func DialWithOptions(network string, rAddr *net.UDPAddr, opts ...ClientOption) (*Conn, error) {
+// Dial connects to the given network address and establishes a DTLS connection on top.
+func Dial(network string, rAddr *net.UDPAddr, opts ...ClientOption) (*Conn, error) {
 	config, err := buildClientConfig(opts...)
 	if err != nil {
 		return nil, err
@@ -507,8 +507,8 @@ func clientWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (
 	return createConn(conn, rAddr, config, true, nil)
 }
 
-// ClientWithOptions establishes a DTLS connection over an existing connection.
-func ClientWithOptions(conn net.PacketConn, rAddr net.Addr, opts ...ClientOption) (*Conn, error) {
+// Client establishes a DTLS connection over an existing connection.
+func Client(conn net.PacketConn, rAddr net.Addr, opts ...ClientOption) (*Conn, error) {
 	config, err := buildClientConfig(opts...)
 	if err != nil {
 		return nil, err
@@ -530,8 +530,8 @@ func serverWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (
 	return createConn(conn, rAddr, config, false, nil)
 }
 
-// ServerWithOptions listens for incoming DTLS connections.
-func ServerWithOptions(conn net.PacketConn, rAddr net.Addr, opts ...ServerOption) (*Conn, error) {
+// Server listens for incoming DTLS connections.
+func Server(conn net.PacketConn, rAddr net.Addr, opts ...ServerOption) (*Conn, error) {
 	config, err := buildServerConfig(opts...)
 	if err != nil {
 		return nil, err

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -65,7 +65,7 @@ func testListenConnectionIDRebindingRequiresRRC(
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
 	serverCID := []byte("server-cid")
-	listener, err := ListenWithOptions(
+	listener, err := Listen(
 		"udp4",
 		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)},
 		WithCertificates(serverCert),
@@ -80,7 +80,7 @@ func testListenConnectionIDRebindingRequiresRRC(
 
 	initialSocket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
 	require.NoError(t, err)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		initialSocket,
 		listener.Addr(),
 		WithInsecureSkipVerify(true),
@@ -253,7 +253,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := DialWithOptions("udp", addr, clientOpts...)
+						conn, err := Dial("udp", addr, clientOpts...)
 						if err != nil {
 							return nil, err
 						}
@@ -270,7 +270,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), clientOpts...)
+						conn, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), clientOpts...)
 						if err != nil {
 							return nil, err
 						}
@@ -288,7 +288,7 @@ func TestContextConfig(t *testing.T) { //nolint:cyclop
 				ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
 
 				return func() (net.Conn, error) {
-						conn, err := ServerWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), serverOpts...)
+						conn, err := Server(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), serverOpts...)
 						if err != nil {
 							return nil, err
 						}

--- a/conn_test.go
+++ b/conn_test.go
@@ -359,7 +359,7 @@ func testClient(
 		opts = append(opts, WithCertificates(clientCert))
 	}
 	opts = append(opts, WithInsecureSkipVerify(true))
-	conn, err := ClientWithOptions(pktConn, rAddr, opts...)
+	conn, err := Client(pktConn, rAddr, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func testServer(
 		}
 		opts = append(opts, WithCertificates(serverCert))
 	}
-	conn, err := ServerWithOptions(c, rAddr, opts...)
+	conn, err := Server(c, rAddr, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,7 +1533,7 @@ func TestClientCertificate(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 				clientCh := make(chan result)
 
 				go func() {
-					client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), tt.clientOpts...)
+					client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), tt.clientOpts...)
 					var hsErr error
 					if err == nil {
 						hsErr = client.Handshake()
@@ -1541,7 +1541,7 @@ func TestClientCertificate(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 					clientCh <- result{client, err, hsErr}
 				}()
 
-				server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), tt.serverOpts...)
+				server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), tt.serverOpts...)
 				var hserr error
 				if err == nil {
 					hserr = server.Handshake()
@@ -1879,7 +1879,7 @@ func TestServerCertificate(t *testing.T) {
 				}
 				srvCh := make(chan result)
 				go func() {
-					s, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), tt.serverOpts...)
+					s, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), tt.serverOpts...)
 					var hsErr error
 					if err == nil {
 						hsErr = s.Handshake()
@@ -1887,7 +1887,7 @@ func TestServerCertificate(t *testing.T) {
 					srvCh <- result{s, err, hsErr}
 				}()
 
-				cli, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), tt.clientOpts...)
+				cli, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), tt.clientOpts...)
 				var hserr error
 				if err == nil {
 					hserr = cli.Handshake()
@@ -2742,7 +2742,7 @@ func TestDualStackVersionNegotiationSendsClassifiedAlerts(t *testing.T) {
 
 		certificate, err := selfsign.GenerateSelfSigned()
 		require.NoError(t, err)
-		server, err := ServerWithOptions(
+		server, err := Server(
 			dtlsnet.PacketConnFromConn(cb),
 			cb.RemoteAddr(),
 			WithCertificates(certificate),
@@ -2779,7 +2779,7 @@ func TestDualStackVersionNegotiationSendsClassifiedAlerts(t *testing.T) {
 			_ = cb.Close()
 		}()
 
-		client, err := ClientWithOptions(
+		client, err := Client(
 			dtlsnet.PacketConnFromConn(cb),
 			cb.RemoteAddr(),
 			WithInsecureSkipVerify(true),
@@ -3893,7 +3893,7 @@ func TestApplicationDataQueueLimited(t *testing.T) {
 		serverCert, err := selfsign.GenerateSelfSigned()
 		assert.NoError(t, err)
 
-		dconn, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
+		dconn, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
 		assert.NoError(t, err)
 
 		go func() {
@@ -4143,7 +4143,7 @@ func TestOnConnectionAttemptConnectionOwnership(t *testing.T) {
 			assert.NoError(t, conn.Close())
 		}()
 
-		_, err = ServerWithOptions(conn, cb.RemoteAddr(), WithOnConnectionAttempt(func(net.Addr) error {
+		_, err = Server(conn, cb.RemoteAddr(), WithOnConnectionAttempt(func(net.Addr) error {
 			return expectedErr
 		}))
 		assert.ErrorIs(t, err, expectedErr)
@@ -4218,7 +4218,7 @@ func TestConnectionState(t *testing.T) {
 	clientCert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
 
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(ca),
 		ca.RemoteAddr(),
 		WithCertificates(clientCert),
@@ -4263,7 +4263,7 @@ func TestMultiHandshake(t *testing.T) {
 	serverCert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
 
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
+	server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
 	assert.NoError(t, err)
 
 	go func() {
@@ -4273,7 +4273,7 @@ func TestMultiHandshake(t *testing.T) {
 	clientCert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
 
-	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), WithCertificates(clientCert))
+	client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), WithCertificates(clientCert))
 	assert.NoError(t, err)
 	assert.Error(t, client.Handshake())
 	assert.Error(t, client.Handshake())
@@ -4290,7 +4290,7 @@ func TestCloseDuringHandshake(t *testing.T) {
 
 	for range 100 {
 		_, cb := dpipe.Pipe()
-		server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
+		server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
 		assert.NoError(t, err)
 
 		waitChan := make(chan struct{})
@@ -4312,7 +4312,7 @@ func TestCloseWithoutHandshake(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, cb := dpipe.Pipe()
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
+	server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), WithCertificates(serverCert))
 	assert.NoError(t, err)
 	assert.NoError(t, server.Close())
 }
@@ -4329,7 +4329,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	clientCID := []byte("client-cid")
 	serverCID := []byte("server-cid")
 
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(ca),
 		ca.RemoteAddr(),
 		WithCertificates(clientCert),
@@ -4350,7 +4350,7 @@ func TestDTLS13HandshakeAndApplicationData(t *testing.T) {
 	serverCert, err := selfsign.GenerateSelfSigned()
 	assert.NoError(t, err)
 
-	server, err := ServerWithOptions(
+	server, err := Server(
 		dtlsnet.PacketConnFromConn(cb),
 		cb.RemoteAddr(),
 		WithCertificates(serverCert),
@@ -4478,7 +4478,7 @@ func testDTLS13HelloRetryRequestNetworkRecovery(
 	}
 	clientCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(clientTransport),
 		clientTransport.RemoteAddr(),
 		WithCertificates(clientCert),
@@ -4513,7 +4513,7 @@ func testDTLS13HelloRetryRequestNetworkRecovery(
 
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	server, err := ServerWithOptions(
+	server, err := Server(
 		dtlsnet.PacketConnFromConn(br.GetConn1()),
 		br.GetConn1().RemoteAddr(),
 		WithCertificates(serverCert),
@@ -4678,7 +4678,7 @@ func TestDTLS13RetransmittedClientFinalFlight(t *testing.T) {
 
 	clientCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(caDuplicateFinal),
 		caDuplicateFinal.RemoteAddr(),
 		WithCertificates(clientCert),
@@ -4693,7 +4693,7 @@ func TestDTLS13RetransmittedClientFinalFlight(t *testing.T) {
 
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	server, err := ServerWithOptions(
+	server, err := Server(
 		dtlsnet.PacketConnFromConn(cb),
 		cb.RemoteAddr(),
 		WithCertificates(serverCert),
@@ -4759,7 +4759,7 @@ func TestDTLS13ServerSendsFinalACK(t *testing.T) {
 
 	clientCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
 		WithCertificates(clientCert), WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3), WithMaxVersion(protocol.Version1_3),
@@ -4769,7 +4769,7 @@ func TestDTLS13ServerSendsFinalACK(t *testing.T) {
 
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	server, err := ServerWithOptions(
+	server, err := Server(
 		dtlsnet.PacketConnFromConn(serverTransport), serverTransport.RemoteAddr(),
 		WithCertificates(serverCert), WithInsecureSkipVerify(true),
 		WithMinVersion(protocol.Version1_3), WithMaxVersion(protocol.Version1_3),
@@ -4817,7 +4817,7 @@ func TestHandshakeCancellationWhilePostSetupBlocks(t *testing.T) {
 
 	clientCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(ca),
 		ca.RemoteAddr(),
 		WithCertificates(clientCert),
@@ -4908,7 +4908,7 @@ func TestDTLSDualStackClientRejectsNonClientHelloBeforeWrite(t *testing.T) {
 	}
 
 	cipherSuiteID := uint16(ciphersuite.TLS_AES_128_GCM_SHA256)
-	client, err := ClientWithOptions(
+	client, err := Client(
 		dtlsnet.PacketConnFromConn(caCount),
 		caCount.RemoteAddr(),
 		WithInsecureSkipVerify(true),
@@ -4972,7 +4972,7 @@ func testDTLSDualStack(t *testing.T, clientOpts []ClientOption, serverOpts []Ser
 	t.Helper()
 	ca, cb := dpipe.Pipe()
 
-	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), clientOpts...)
+	client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), clientOpts...)
 	assert.NoError(t, err)
 	defer func() {
 		_ = client.Close()
@@ -4985,7 +4985,7 @@ func testDTLSDualStack(t *testing.T, clientOpts []ClientOption, serverOpts []Ser
 	defer cancelClient()
 	errorChannel := make(chan error, 2)
 
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), serverOpts...)
+	server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(), serverOpts...)
 	assert.NoError(t, err)
 	defer func() {
 		_ = server.Close()

--- a/e2e/e2e_lossy_test.go
+++ b/e2e/e2e_lossy_test.go
@@ -163,7 +163,7 @@ func TestPionE2ELossy(t *testing.T) { //nolint:cyclop
 					clientOpts = append(clientOpts, dtls.WithCertificates(clientCert))
 				}
 
-				client, startupErr := dtls.ClientWithOptions(
+				client, startupErr := dtls.Client(
 					dtlsnet.PacketConnFromConn(br.GetConn0()),
 					br.GetConn0().RemoteAddr(),
 					clientOpts...,
@@ -189,7 +189,7 @@ func TestPionE2ELossy(t *testing.T) { //nolint:cyclop
 					serverOpts = append(serverOpts, dtls.WithFlightInterval(time.Hour))
 				}
 
-				server, startupErr := dtls.ServerWithOptions(
+				server, startupErr := dtls.Server(
 					dtlsnet.PacketConnFromConn(br.GetConn1()),
 					br.GetConn1().RemoteAddr(),
 					serverOpts...,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -285,7 +285,7 @@ func clientPion(c *comm) { //nolint:varnamelen
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
 
-	conn, err := dtls.DialWithOptions("udp",
+	conn, err := dtls.Dial("udp",
 		&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: c.serverPort},
 		c.clientOpts...,
 	)
@@ -318,7 +318,7 @@ func serverPion(c *comm) { //nolint:varnamelen
 	defer c.serverMutex.Unlock()
 
 	var err error
-	c.serverListener, err = dtls.ListenWithOptions("udp",
+	c.serverListener, err = dtls.Listen("udp",
 		&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: c.serverPort},
 		c.serverOpts...,
 	)
@@ -1318,7 +1318,7 @@ func assertHandshakeFailsWithOpts(
 	serverDone := make(chan error, 1)
 
 	go func() {
-		listener, listenerErr := dtls.ListenWithOptions("udp",
+		listener, listenerErr := dtls.Listen("udp",
 			&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: serverPort},
 			serverOpts...,
 		)
@@ -1351,7 +1351,7 @@ func assertHandshakeFailsWithOpts(
 		assert.FailNow(t, "server not ready in time")
 	}
 
-	conn, err := dtls.DialWithOptions("udp",
+	conn, err := dtls.Dial("udp",
 		&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: serverPort},
 		clientOpts...,
 	)

--- a/examples/dial/cid/main.go
+++ b/examples/dial/cid/main.go
@@ -25,7 +25,7 @@ func main() {
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+	dtlsConn, err := dtls.Dial("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Server's hint: %s \n", hint)
 

--- a/examples/dial/psk/main.go
+++ b/examples/dial/psk/main.go
@@ -25,7 +25,7 @@ func main() {
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+	dtlsConn, err := dtls.Dial("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Server's hint: %s \n", hint)
 

--- a/examples/dial/selfsign/main.go
+++ b/examples/dial/selfsign/main.go
@@ -30,7 +30,7 @@ func main() {
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+	dtlsConn, err := dtls.Dial("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithInsecureSkipVerify(true),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),

--- a/examples/dial/verify/main.go
+++ b/examples/dial/verify/main.go
@@ -37,7 +37,7 @@ func main() {
 	// Connect to a DTLS server
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dtlsConn, err := dtls.DialWithOptions("udp", addr,
+	dtlsConn, err := dtls.Dial("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 		dtls.WithRootCAs(certPool),

--- a/examples/listen/cid/main.go
+++ b/examples/listen/cid/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.ListenWithOptions("udp", addr,
+	listener, err := dtls.Listen("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 

--- a/examples/listen/psk/main.go
+++ b/examples/listen/psk/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.ListenWithOptions("udp", addr,
+	listener, err := dtls.Listen("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 

--- a/examples/listen/selfsign/main.go
+++ b/examples/listen/selfsign/main.go
@@ -27,7 +27,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.ListenWithOptions("udp", addr,
+	listener, err := dtls.Listen("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 	)

--- a/examples/listen/verify-brute-force-protection/main.go
+++ b/examples/listen/verify-brute-force-protection/main.go
@@ -43,7 +43,7 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	listener, err := dtls.ListenWithOptions("udp", addr,
+	listener, err := dtls.Listen("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 		dtls.WithClientAuth(dtls.RequireAndVerifyClientCert),

--- a/examples/listen/verify/main.go
+++ b/examples/listen/verify/main.go
@@ -34,7 +34,7 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	listener, err := dtls.ListenWithOptions("udp", addr,
+	listener, err := dtls.Listen("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 		dtls.WithClientAuth(dtls.RequireAndVerifyClientCert),

--- a/listener.go
+++ b/listener.go
@@ -46,8 +46,8 @@ func listenWithConfig(network string, laddr *net.UDPAddr, config *dtlsConfig) (n
 	}, nil
 }
 
-// ListenWithOptions creates a DTLS listener.
-func ListenWithOptions(network string, laddr *net.UDPAddr, opts ...ServerOption) (net.Listener, error) {
+// Listen creates a DTLS listener.
+func Listen(network string, laddr *net.UDPAddr, opts ...ServerOption) (net.Listener, error) {
 	config, err := buildServerConfig(opts...)
 	if err != nil {
 		return nil, err
@@ -59,8 +59,8 @@ func ListenWithOptions(network string, laddr *net.UDPAddr, opts ...ServerOption)
 	return listenWithConfig(network, laddr, config)
 }
 
-// NewListenerWithOptions creates a DTLS listener which accepts connections from an inner Listener.
-func NewListenerWithOptions(inner dtlsnet.PacketListener, opts ...ServerOption) (net.Listener, error) {
+// NewListener creates a DTLS listener which accepts connections from an inner Listener.
+func NewListener(inner dtlsnet.PacketListener, opts ...ServerOption) (net.Listener, error) {
 	config, err := buildServerConfig(opts...)
 	if err != nil {
 		return nil, err

--- a/options_test.go
+++ b/options_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithOptionsCreatesConn(t *testing.T) {
+func TestCreatesConn(t *testing.T) {
 	ca, cb := dpipe.Pipe()
 	defer func() {
 		_ = ca.Close()
@@ -32,13 +32,13 @@ func TestWithOptionsCreatesConn(t *testing.T) {
 	cert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
 
-	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
+	client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(),
 		WithCertificates(cert),
 		WithInsecureSkipVerify(true),
 	)
 	require.NoError(t, err)
 
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(),
+	server, err := Server(dtlsnet.PacketConnFromConn(cb), cb.RemoteAddr(),
 		WithCertificates(cert),
 		WithInsecureSkipVerify(true),
 	)
@@ -57,7 +57,7 @@ func newOptionsClient(t *testing.T, opts ...ClientOption) (*Conn, error) {
 		_ = cb.Close()
 	})
 
-	client, err := ClientWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
+	client, err := Client(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
 	if err == nil {
 		t.Cleanup(func() {
 			_ = client.Close()
@@ -76,7 +76,7 @@ func newOptionsServer(t *testing.T, opts ...ServerOption) (*Conn, error) {
 		_ = cb.Close()
 	})
 
-	server, err := ServerWithOptions(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
+	server, err := Server(dtlsnet.PacketConnFromConn(ca), ca.RemoteAddr(), opts...)
 	if err == nil {
 		t.Cleanup(func() {
 			_ = server.Close()

--- a/receive_buffer_size_test.go
+++ b/receive_buffer_size_test.go
@@ -34,7 +34,7 @@ func TestReceiveBufferSizeLargeDatagram(t *testing.T) {
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
 
-	listener, err := ListenWithOptions("udp",
+	listener, err := Listen("udp",
 		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
 		WithCertificates(serverCert),
 		WithReceiveBufferSize(bufferSize),
@@ -74,7 +74,7 @@ func TestReceiveBufferSizeLargeDatagram(t *testing.T) {
 	serverAddr, ok := listener.Addr().(*net.UDPAddr)
 	require.True(t, ok)
 
-	client, err := DialWithOptions("udp", serverAddr,
+	client, err := Dial("udp", serverAddr,
 		WithInsecureSkipVerify(true),
 		WithReceiveBufferSize(bufferSize),
 	)

--- a/resume.go
+++ b/resume.go
@@ -26,8 +26,8 @@ func resumeWithConfig(state *State, conn net.PacketConn, rAddr net.Addr, config 
 	return createConn(conn, rAddr, config, internalState.IsClient, internalState)
 }
 
-// ResumeWithOptions imports an already established dtls connection using a specific dtls state.
-func ResumeWithOptions(state *State, conn net.PacketConn, rAddr net.Addr, opts ...Option) (*Conn, error) {
+// Resume imports an already established dtls connection using a specific dtls state.
+func Resume(state *State, conn net.PacketConn, rAddr net.Addr, opts ...Option) (*Conn, error) {
 	config, err := buildConfig(opts...)
 	if err != nil {
 		return nil, err

--- a/resume_test.go
+++ b/resume_test.go
@@ -37,7 +37,7 @@ func resumeClient(conn net.PacketConn, rAddr net.Addr, opts []Option) (*Conn, er
 		clientOpts[i] = opt
 	}
 
-	return ClientWithOptions(conn, rAddr, clientOpts...)
+	return Client(conn, rAddr, clientOpts...)
 }
 
 func resumeServer(conn net.PacketConn, rAddr net.Addr, opts []Option) (*Conn, error) {
@@ -46,7 +46,7 @@ func resumeServer(conn net.PacketConn, rAddr net.Addr, opts []Option) (*Conn, er
 		serverOpts[i] = opt
 	}
 
-	return ServerWithOptions(conn, rAddr, serverOpts...)
+	return Server(conn, rAddr, serverOpts...)
 }
 
 func fatal(t *testing.T, errChan chan error, err error) {
@@ -160,7 +160,7 @@ func DoTestResume(
 
 	// Resume dtls connection
 	var resumed net.Conn
-	resumed, err = ResumeWithOptions(
+	resumed, err = Resume(
 		deserialized,
 		dtlsnet.PacketConnFromConn(localConn2),
 		localConn2.RemoteAddr(),


### PR DESCRIPTION
#### Description
This suffix was added when we added options pattern to v3, we didn't remove it when we removed the config API and went options only https://github.com/pion/dtls/pull/863 