### PR TITLE
Rework client and listener constructors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -513,14 +513,14 @@ func clientWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (
 	return createConn(conn, rAddr, config, true, nil)
 }
 
-// Client establishes a DTLS connection over an existing connection.
-func Client(conn net.PacketConn, rAddr net.Addr, opts ...ClientOption) (*Conn, error) {
+// Client establishes a DTLS connection over an existing packet connection.
+func Client(conn net.PacketConn, raddr net.Addr, opts ...ClientOption) (*Conn, error) {
 	config, err := buildClientConfig(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	return clientWithConfig(conn, rAddr, config)
+	return clientWithConfig(conn, raddr, config)
 }
 
 func serverWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (*Conn, error) {
@@ -536,8 +536,8 @@ func serverWithConfig(conn net.PacketConn, rAddr net.Addr, config *dtlsConfig) (
 	return createConn(conn, rAddr, config, false, nil)
 }
 
-// Server listens for incoming DTLS connections.
-func Server(conn net.PacketConn, rAddr net.Addr, opts ...ServerOption) (*Conn, error) {
+// Server establishes a server-side DTLS connection over an existing packet connection.
+func Server(conn net.PacketConn, raddr net.Addr, opts ...ServerOption) (*Conn, error) {
 	config, err := buildServerConfig(opts...)
 	if err != nil {
 		return nil, err
@@ -547,7 +547,7 @@ func Server(conn net.PacketConn, rAddr net.Addr, opts ...ServerOption) (*Conn, e
 		return nil, err
 	}
 
-	return serverWithConfig(conn, rAddr, config)
+	return serverWithConfig(conn, raddr, config)
 }
 
 // Read reads data from the connection.

--- a/conn_go_test.go
+++ b/conn_go_test.go
@@ -65,7 +65,7 @@ func testListenConnectionIDRebindingRequiresRRC(
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
 	serverCID := []byte("server-cid")
-	listener, err := Listen(
+	listener, err := ListenAddr(
 		"udp4",
 		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)},
 		WithCertificates(serverCert),

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -319,7 +319,7 @@ func serverPion(c *comm) { //nolint:varnamelen
 	defer c.serverMutex.Unlock()
 
 	var err error
-	c.serverListener, err = dtls.Listen("udp",
+	c.serverListener, err = dtls.ListenAddr("udp",
 		&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: c.serverPort},
 		c.serverOpts...,
 	)
@@ -1319,7 +1319,7 @@ func assertHandshakeFailsWithOpts(
 	serverDone := make(chan error, 1)
 
 	go func() {
-		listener, listenerErr := dtls.Listen("udp",
+		listener, listenerErr := dtls.ListenAddr("udp",
 			&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: serverPort},
 			serverOpts...,
 		)

--- a/examples/listen/cid/main.go
+++ b/examples/listen/cid/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.Listen("udp", addr,
+	listener, err := dtls.ListenAddr("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 

--- a/examples/listen/psk/main.go
+++ b/examples/listen/psk/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.Listen("udp", addr,
+	listener, err := dtls.ListenAddr("udp", addr,
 		dtls.WithPSK(func(hint []byte) ([]byte, error) {
 			fmt.Printf("Client's hint: %s \n", hint)
 

--- a/examples/listen/selfsign/main.go
+++ b/examples/listen/selfsign/main.go
@@ -27,7 +27,7 @@ func main() {
 	// Everything below is the pion-DTLS API! Thanks for using it ❤️.
 	//
 
-	listener, err := dtls.Listen("udp", addr,
+	listener, err := dtls.ListenAddr("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 	)

--- a/examples/listen/verify-brute-force-protection/main.go
+++ b/examples/listen/verify-brute-force-protection/main.go
@@ -43,7 +43,7 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	listener, err := dtls.Listen("udp", addr,
+	listener, err := dtls.ListenAddr("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 		dtls.WithClientAuth(dtls.RequireAndVerifyClientCert),

--- a/examples/listen/verify/main.go
+++ b/examples/listen/verify/main.go
@@ -34,7 +34,7 @@ func main() {
 	util.Check(err)
 	certPool.AddCert(cert)
 
-	listener, err := dtls.Listen("udp", addr,
+	listener, err := dtls.ListenAddr("udp", addr,
 		dtls.WithCertificates(certificate),
 		dtls.WithExtendedMasterSecret(dtls.RequireExtendedMasterSecret),
 		dtls.WithClientAuth(dtls.RequireAndVerifyClientCert),

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -334,11 +334,8 @@ var (
 
 	ErrSelfSignInvalidPrivateKey = stderrors.New("selfsign: invalid private key type")
 
-	ErrInvalidHashAlgorithm      = stderrors.New("invalid hash algorithm")
-	ErrNetBufferTimeout          = stderrors.New("buffer: i/o timeout")
-	ErrUDPClosedListener         = stderrors.New("udp: listener closed")
-	ErrUDPListenQueueExceeded    = stderrors.New("udp: listen queue exceeded")
-	ErrUDPListenPacketNotUDPConn = stderrors.New(
-		"listen packet not a *net.UDPConn",
-	)
+	ErrInvalidHashAlgorithm   = stderrors.New("invalid hash algorithm")
+	ErrNetBufferTimeout       = stderrors.New("buffer: i/o timeout")
+	ErrUDPClosedListener      = stderrors.New("udp: listener closed")
+	ErrUDPListenQueueExceeded = stderrors.New("udp: listen queue exceeded")
 )

--- a/internal/net/udp/packet_conn.go
+++ b/internal/net/udp/packet_conn.go
@@ -42,7 +42,7 @@ var (
 
 // listener augments a connection-oriented Listener over a UDP PacketConn.
 type listener struct {
-	pConn *net.UDPConn
+	pConn net.PacketConn
 
 	accepting         atomic.Value // bool
 	acceptCh          chan *PacketConn
@@ -52,6 +52,7 @@ type listener struct {
 	datagramRouter    func([]byte) (string, bool)
 	connIdentifier    func([]byte) (string, bool)
 	receiveBufferSize int
+	backlog           int
 
 	connLock sync.Mutex
 	conns    map[string]*PacketConn
@@ -136,73 +137,63 @@ func (l *listener) Addr() net.Addr {
 	return l.pConn.LocalAddr()
 }
 
-// ListenConfig stores options for listening to an address.
-type ListenConfig struct {
-	// Backlog defines the maximum length of the queue of pending
-	// connections. It is equivalent of the backlog argument of
-	// POSIX listen function.
-	// If a connection request arrives when the queue is full,
-	// the request will be silently discarded, unlike TCP.
-	// Set zero to use default value 128 which is same as Linux default.
-	Backlog int
+// ListenerOption configures a packet listener.
+type ListenerOption func(*listener)
 
-	// AcceptFilter determines whether the new conn should be made for
-	// the incoming packet. If not set, any packet creates new conn.
-	AcceptFilter func([]byte) bool
-
-	// DatagramRouter routes an incoming datagram to a connection by extracting
-	// an identifier from its payload.
-	DatagramRouter func([]byte) (string, bool)
-
-	// ConnectionIdentifier extracts an identifier from an outgoing packet. If
-	// the identifier is not already associated with the connection, it will be
-	// added.
-	ConnectionIdentifier func([]byte) (string, bool)
-
-	// ReceiveBufferSize sets the size of the buffer used to read incoming
-	// datagrams. Datagrams larger than this size are truncated.
-	// If zero or negative, the default value 8192 is used.
-	ReceiveBufferSize int
-
-	// Internal listen config used to open the UDP socket.
-	ListenConfig net.ListenConfig
+// WithBacklog sets the maximum number of pending connections.
+func WithBacklog(backlog int) ListenerOption {
+	return func(l *listener) {
+		if backlog != 0 {
+			l.backlog = backlog
+		}
+	}
 }
 
-// Listen creates a new listener based on the ListenConfig.
-//
-//nolint:contextcheck
-func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (dtlsnet.PacketListener, error) {
-	if lc.Backlog == 0 {
-		lc.Backlog = defaultListenBacklog
+// WithAcceptFilter sets the filter used to admit new connections.
+func WithAcceptFilter(filter func([]byte) bool) ListenerOption {
+	return func(l *listener) {
+		l.acceptFilter = filter
 	}
-	if lc.ReceiveBufferSize <= 0 {
-		lc.ReceiveBufferSize = defaultReceiveBufferSize
-	}
+}
 
-	laddrStr := ":0"
-	if laddr != nil {
-		laddrStr = laddr.String()
+// WithDatagramRouter sets the function used to route incoming datagrams.
+func WithDatagramRouter(router func([]byte) (string, bool)) ListenerOption {
+	return func(l *listener) {
+		l.datagramRouter = router
 	}
-	innerConn, err := lc.ListenConfig.ListenPacket(context.Background(), network, laddrStr)
-	if err != nil {
-		return nil, err
-	}
-	conn, ok := innerConn.(*net.UDPConn)
-	if !ok {
-		return nil, dtlserrors.ErrUDPListenPacketNotUDPConn
-	}
+}
 
+// WithConnectionIdentifier sets the function used to identify outgoing datagrams.
+func WithConnectionIdentifier(identifier func([]byte) (string, bool)) ListenerOption {
+	return func(l *listener) {
+		l.connIdentifier = identifier
+	}
+}
+
+// WithReceiveBufferSize sets the size of the buffer used to read incoming datagrams.
+func WithReceiveBufferSize(size int) ListenerOption {
+	return func(l *listener) {
+		if size > 0 {
+			l.receiveBufferSize = size
+		}
+	}
+}
+
+// Listen creates a new listener over conn.
+func Listen(conn net.PacketConn, opts ...ListenerOption) dtlsnet.PacketListener {
 	packetListener := &listener{
 		pConn:             conn,
-		acceptCh:          make(chan *PacketConn, lc.Backlog),
+		backlog:           defaultListenBacklog,
+		receiveBufferSize: defaultReceiveBufferSize,
 		conns:             make(map[string]*PacketConn),
 		doneCh:            make(chan struct{}),
-		acceptFilter:      lc.AcceptFilter,
-		datagramRouter:    lc.DatagramRouter,
-		connIdentifier:    lc.ConnectionIdentifier,
-		receiveBufferSize: lc.ReceiveBufferSize,
 		readDoneCh:        make(chan struct{}),
 	}
+	for _, opt := range opts {
+		opt(packetListener)
+	}
+
+	packetListener.acceptCh = make(chan *PacketConn, packetListener.backlog)
 
 	packetListener.accepting.Store(true)
 	packetListener.connWG.Add(1)
@@ -217,12 +208,7 @@ func (lc *ListenConfig) Listen(network string, laddr *net.UDPAddr) (dtlsnet.Pack
 		packetListener.readWG.Done()
 	}()
 
-	return packetListener, nil
-}
-
-// Listen creates a new listener using default ListenConfig.
-func Listen(network string, laddr *net.UDPAddr) (dtlsnet.PacketListener, error) {
-	return (&ListenConfig{}).Listen(network, laddr)
+	return packetListener
 }
 
 // readLoop dispatches packets to the proper connection, creating a new one if

--- a/internal/net/udp/packet_conn_test.go
+++ b/internal/net/udp/packet_conn_test.go
@@ -111,9 +111,7 @@ func TestListenerCloseUnaccepted(t *testing.T) {
 	const backlog = 2
 
 	network, addr := getConfig()
-	listener, err := (&ListenConfig{
-		Backlog: backlog,
-	}).Listen(network, addr)
+	listener, err := listenAddr(network, addr, WithBacklog(backlog))
 	assert.NoError(t, err)
 
 	for i := range backlog {
@@ -162,11 +160,9 @@ func TestListenerAcceptFilter(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			network, addr := getConfig()
-			listener, err := (&ListenConfig{
-				AcceptFilter: func(pkt []byte) bool {
-					return pkt[0] == 0xAA
-				},
-			}).Listen(network, addr)
+			listener, err := listenAddr(network, addr, WithAcceptFilter(func(pkt []byte) bool {
+				return pkt[0] == 0xAA
+			}))
 			assert.NoError(t, err)
 
 			var wgAcceptLoop sync.WaitGroup
@@ -225,9 +221,7 @@ func TestListenerConcurrent(t *testing.T) {
 	const backlog = 2
 
 	network, addr := getConfig()
-	listener, err := (&ListenConfig{
-		Backlog: backlog,
-	}).Listen(network, addr)
+	listener, err := listenAddr(network, addr, WithBacklog(backlog))
 	assert.NoError(t, err)
 
 	for i := range backlog + 1 {
@@ -280,7 +274,7 @@ func TestListenerConcurrent(t *testing.T) {
 func pipe() (dtlsnet.PacketListener, net.PacketConn, *net.UDPConn, error) {
 	// Start listening
 	network, addr := getConfig()
-	listener, err := Listen(network, addr)
+	listener, err := listenAddr(network, addr)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to listen: %w", err)
 	}
@@ -326,6 +320,15 @@ func pipe() (dtlsnet.PacketListener, net.PacketConn, *net.UDPConn, error) {
 
 func getConfig() (string, *net.UDPAddr) {
 	return "udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+}
+
+func listenAddr(network string, addr *net.UDPAddr, opts ...ListenerOption) (dtlsnet.PacketListener, error) {
+	conn, err := net.ListenUDP(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return Listen(conn, opts...), nil
 }
 
 func TestConnClose(t *testing.T) {
@@ -422,10 +425,10 @@ func TestListenerCustomConnIDs(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		Payload string
 	}
 	network, addr := getConfig()
-	listener, err := (&ListenConfig{
+	listener, err := listenAddr(network, addr,
 		// For all datagrams other than the initial "hello" packet, use the ID
 		// to route.
-		DatagramRouter: func(buf []byte) (string, bool) {
+		WithDatagramRouter(func(buf []byte) (string, bool) {
 			var p pkt
 			if err := json.Unmarshal(buf, &p); err != nil {
 				return "", false
@@ -435,9 +438,9 @@ func TestListenerCustomConnIDs(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 
 			return fmt.Sprint(p.ID), true
-		},
+		}),
 		// Use the outgoing "set" payload to add an identifier for a connection.
-		ConnectionIdentifier: func(buf []byte) (string, bool) {
+		WithConnectionIdentifier(func(buf []byte) (string, bool) {
 			var p pkt
 			if err := json.Unmarshal(buf, &p); err != nil {
 				return "", false
@@ -447,8 +450,8 @@ func TestListenerCustomConnIDs(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 
 			return "", false
-		},
-	}).Listen(network, addr)
+		}),
+	)
 	assert.NoError(t, err)
 
 	var clientWg sync.WaitGroup

--- a/listener.go
+++ b/listener.go
@@ -12,9 +12,9 @@ import (
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 )
 
-func listenWithConfig(network string, laddr *net.UDPAddr, config *dtlsConfig) (net.Listener, error) {
-	lc := udp.ListenConfig{
-		AcceptFilter: func(packet []byte) bool {
+func packetListenerOptions(config *dtlsConfig) []udp.ListenerOption {
+	opts := []udp.ListenerOption{
+		udp.WithAcceptFilter(func(packet []byte) bool {
 			pkts, _ := recordlayer.UnpackDatagram(packet, recordlayer.UnpackDatagramConfig{})
 			if len(pkts) == 0 {
 				return false
@@ -25,51 +25,77 @@ func listenWithConfig(network string, laddr *net.UDPAddr, config *dtlsConfig) (n
 			}
 
 			return h.ContentType == protocol.ContentTypeHandshake
-		},
-		ReceiveBufferSize: config.ReceiveBufferSize,
-		ListenConfig:      config.ListenConfig,
+		}),
+		udp.WithReceiveBufferSize(config.ReceiveBufferSize),
 	}
 	// If connection ID support is enabled, then they must be supported in
 	// routing.
 	if config.ConnectionIDGenerator != nil {
-		lc.DatagramRouter = cidDatagramRouter(len(config.ConnectionIDGenerator()))
-		lc.ConnectionIdentifier = cidConnIdentifier()
-	}
-	parent, err := lc.Listen(network, laddr)
-	if err != nil {
-		return nil, err
+		opts = append(opts,
+			udp.WithDatagramRouter(cidDatagramRouter(len(config.ConnectionIDGenerator()))),
+			udp.WithConnectionIdentifier(cidConnIdentifier()),
+		)
 	}
 
+	return opts
+}
+
+func newListenerWithConfig(parent dtlsnet.PacketListener, config *dtlsConfig) net.Listener {
 	return &listener{
 		config: config,
 		parent: parent,
-	}, nil
+	}
 }
 
-// Listen creates a DTLS listener.
-func Listen(network string, laddr *net.UDPAddr, opts ...ServerOption) (net.Listener, error) {
+func buildListenerConfig(opts ...ServerOption) (*dtlsConfig, error) {
 	config, err := buildServerConfig(opts...)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateConfig(config); err != nil {
+	if err = validateConfig(config); err != nil {
 		return nil, err
 	}
 
-	return listenWithConfig(network, laddr, config)
+	return config, nil
 }
 
-// NewListener creates a DTLS listener which accepts connections from an inner Listener.
+func listenWithConfig(conn net.PacketConn, config *dtlsConfig) net.Listener {
+	return newListenerWithConfig(udp.Listen(conn, packetListenerOptions(config)...), config)
+}
+
+// Listen creates a DTLS listener over an existing packet connection.
+func Listen(conn net.PacketConn, opts ...ServerOption) (net.Listener, error) {
+	config, err := buildListenerConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return listenWithConfig(conn, config), nil
+}
+
+// ListenAddr creates a DTLS listener bound to laddr.
+func ListenAddr(network string, laddr *net.UDPAddr, opts ...ServerOption) (net.Listener, error) {
+	config, err := buildListenerConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.ListenUDP(network, laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return listenWithConfig(conn, config), nil
+}
+
+// NewListener creates a DTLS listener which accepts connections from an inner packet listener.
 func NewListener(inner dtlsnet.PacketListener, opts ...ServerOption) (net.Listener, error) {
-	config, err := buildServerConfig(opts...)
+	config, err := buildListenerConfig(opts...)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateConfig(config); err != nil {
-		return nil, err
-	}
 
-	return &listener{config: config, parent: inner}, nil
+	return newListenerWithConfig(inner, config), nil
 }
 
 // listener represents a DTLS listener.

--- a/options.go
+++ b/options.go
@@ -71,7 +71,6 @@ type dtlsConfig struct {
 	ServerHelloMessageHook        func(handshake.MessageServerHello) handshake.Message
 	CertificateRequestMessageHook func(handshake.MessageCertificateRequest) handshake.Message
 	OnConnectionAttempt           func(net.Addr) error
-	ListenConfig                  net.ListenConfig
 	MinVersion                    protocol.Version
 	MaxVersion                    protocol.Version
 
@@ -656,16 +655,6 @@ func WithOnConnectionAttempt(fn func(net.Addr) error) ServerOption {
 			return dtlserrors.ErrNilOnConnectionAttempt
 		}
 		c.OnConnectionAttempt = fn
-
-		return nil
-	})
-}
-
-// WithListenConfig sets the underlying listener config.
-// This option is only applicable to servers.
-func WithListenConfig(listenConfig net.ListenConfig) ServerOption {
-	return serverOnlyOption(func(c *dtlsConfig) error {
-		c.ListenConfig = listenConfig
 
 		return nil
 	})

--- a/options_test.go
+++ b/options_test.go
@@ -5,8 +5,6 @@ package dtls
 
 import (
 	"crypto/tls"
-	"net"
-	"syscall"
 	"testing"
 	"time"
 
@@ -556,11 +554,6 @@ func TestValidOptionsSucceed(t *testing.T) {
 			WithCertificates(cert),
 			WithClientAuth(RequireAndVerifyClientCert),
 			WithInsecureSkipVerifyHello(true),
-			WithListenConfig(net.ListenConfig{
-				Control: func(network, address string, c syscall.RawConn) error {
-					return nil
-				},
-			}),
 		)
 		require.NoError(t, err)
 

--- a/receive_buffer_size_test.go
+++ b/receive_buffer_size_test.go
@@ -34,8 +34,13 @@ func TestReceiveBufferSizeLargeDatagram(t *testing.T) {
 	serverCert, err := selfsign.GenerateSelfSigned()
 	require.NoError(t, err)
 
-	listener, err := Listen("udp",
+	packetConn, err := net.ListenUDP("udp",
 		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	)
+	require.NoError(t, err)
+
+	listener, err := Listen(
+		packetConn,
 		WithCertificates(serverCert),
 		WithReceiveBufferSize(bufferSize),
 	)


### PR DESCRIPTION
#### Description
DTLS@v3 didn't have a direct way to provide a real packconn socket, `Server / ServerOption` Required `address`, and listen required `laddr` both resulted in another weird abstraction with dtls.ListenConfig and eventually with `WithListenConfig` added in https://github.com/pion/dtls/pull/802

This PR removes the public `ListenConfig` struct, and removes the `WithListenConfig` options, and refactors the constructors into:

1. `Client(conn, raddr, opts...)` Start a client-side DTLS session using an existing net.PacketConn.
2. `Server(conn, raddr, opts...)` Start one server-side DTLS session when the peer's packet stream has already been isolated. 
3. `Listen(conn, opts...)` Accept multiple DTLS clients from an already-created / bound net.PacketConn. DTLS handles demultiplexing packets by remote address or `CID`. closes #837 
4. `ListenAddr(network, laddr, opts...)` Convenience API for the common UDP-server case. It creates the packet socket and returns a DTLS listener.
5. `NewListener(inner, opts...)`  DTLS over an existing PacketListener that already accepts isolated packet connections. Useful for custom multiplexers and virtual transports (and advanced users that want to own the demultiplexing in general but don't want to create a new ListenAddr for every connection).  relates to #1075  

I think this covers all of our use cases.

Relates to #1007 