### PR TITLE
Implement DetachedConn API

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -224,6 +224,7 @@ type Conn struct {
 
 	reading               chan struct{}
 	handshakeRecv         chan dtlshandshake.RecvHandshakeState
+	detached              *DetachedConn
 	cancelHandshaker      func()
 	cancelHandshakeReader func()
 
@@ -259,9 +260,8 @@ func createConn(nextConn net.PacketConn, rAddr net.Addr, config *dtlsConfig, isC
 }
 
 func newConn(nextConn net.PacketConn, rAddr net.Addr, configValues connConfigValues, handshakeConfig *dtlsconfig.HandshakeConfig, isClient bool) *Conn {
-	return &Conn{
+	conn := &Conn{
 		rAddr:                   rAddr,
-		nextConn:                netctx.NewPacketConn(nextConn),
 		handshakeConfig:         handshakeConfig,
 		fragmentBuffer:          dtlsfragmentbuffer.New(),
 		handshakeCache:          dtlsflight.NewCache(),
@@ -287,6 +287,11 @@ func newConn(nextConn net.PacketConn, rAddr net.Addr, configValues connConfigVal
 
 		state: dtlsstate.NewActive(isClient),
 	}
+	if nextConn != nil {
+		conn.nextConn = netctx.NewPacketConn(nextConn)
+	}
+
+	return conn
 }
 
 // Handshake runs the client or server DTLS handshake
@@ -443,7 +448,12 @@ func (c *Conn) prepareDualStackServerHandshakeStart(ctx context.Context) (handsh
 		return handshakeStart{}, err
 	}
 
-	return handshakeStart{flight12: dtlsflight12.Flight0, flight13: dtlsflight13.Flight0, fsmState: dtlshandshake.StatePreparing}, nil
+	return handshakeStart{
+		flight12:  dtlsflight12.Flight0,
+		flight13:  dtlsflight13.Flight0,
+		fsmState:  dtlshandshake.StatePreparing,
+		postSetup: func(ctx context.Context) { c.primeHandshakeRecv(ctx) },
+	}, nil
 }
 
 func dialWithConfig(network string, rAddr *net.UDPAddr, config *dtlsConfig) (*Conn, error) {
@@ -686,6 +696,9 @@ func (c *Conn) writeApplicationData(ctx context.Context, pkts []*dtlsflight.Outb
 // Close closes the connection.
 func (c *Conn) Close() error {
 	err := c.close(true)
+	if c.detached != nil {
+		c.detached.terminate(ErrConnClosed, false)
+	}
 	c.closeLock.Lock()
 	handshakeDone := c.handshakeDone
 	c.closeLock.Unlock()
@@ -749,6 +762,19 @@ func (c *Conn) writePacketsWithResultLocked(ctx context.Context, pkts []*dtlsfli
 	}
 
 	result := &dtlshandshake.WriteResult{}
+	if c.detached != nil {
+		if len(datagrams) == 0 {
+			return result, nil
+		}
+		raw := make([][]byte, len(datagrams))
+		for i := range datagrams {
+			raw[i] = datagrams[i].raw
+			result.TrackedRecords = append(result.TrackedRecords, datagrams[i].tracked...)
+		}
+		c.detached.publishDatagrams(raw, rAddr)
+
+		return result, nil
+	}
 	for _, datagram := range datagrams {
 		if _, err = c.nextConn.WriteToContext(ctx, datagram.raw, rAddr); err != nil {
 			if errors.Is(err, context.Canceled) && c.isConnectionClosed() {
@@ -1279,6 +1305,8 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 		return err
 	}
 	if !summary.containsHandshake && len(summary.receivedACKs) == 0 {
+		c.signalHandshakeQuiescent()
+
 		return nil
 	}
 
@@ -1303,7 +1331,14 @@ func (c *Conn) readAndProcessDatagram(ctx context.Context) (datagramProcessingSu
 	defer bufferLease.releaseReadBuffer()
 
 	b := *bufptr
-	i, rAddr, err := c.nextConn.ReadFromContext(ctx, b)
+	var i int
+	var rAddr net.Addr
+	var err error
+	if c.detached != nil {
+		i, rAddr, err = c.detached.readDatagram(ctx, b)
+	} else {
+		i, rAddr, err = c.nextConn.ReadFromContext(ctx, b)
+	}
 	if err != nil {
 		return datagramProcessingSummary{}, netError(err)
 	}
@@ -2117,6 +2152,11 @@ func (c *Conn) handleApplicationDataRecord(ctx context.Context, content *protoco
 	}
 
 	isLatestSeqNum := prepared.markPacketAsValid()
+	if c.detached != nil {
+		c.detached.publishApplicationData(content.Data)
+
+		return isLatestSeqNum, packetOutcome{}, nil
+	}
 	select {
 	case c.decrypted <- content.Data:
 	case <-c.closed.Done():
@@ -2245,7 +2285,23 @@ func (c *Conn) syncFragmentBufferHandshakeSequence() {
 }
 
 func (c *Conn) recvHandshake() <-chan dtlshandshake.RecvHandshakeState {
+	if c.detached != nil && !c.detached.quiescentSkip.CompareAndSwap(true, false) {
+		c.detached.markQuiescent()
+	}
+
 	return c.handshakeRecv
+}
+
+func (c *Conn) signalHandshakeQuiescent() {
+	if c.detached != nil {
+		c.detached.markQuiescent()
+	}
+}
+
+func (c *Conn) signalHandshakeTerminated(err error) {
+	if c.detached != nil {
+		c.detached.connectionTerminated(err)
+	}
 }
 
 func (c *Conn) notify(ctx context.Context, level alert.Level, desc alert.Description) error {
@@ -2283,6 +2339,7 @@ func (c *Conn) isHandshakeCompletedSuccessfully() bool {
 
 func (c *Conn) negotiateVersionServer(ctx context.Context) error {
 	for {
+		c.signalHandshakeQuiescent()
 		if err := c.readAndBufferNoFSM(ctx); err != nil {
 			return err
 		}
@@ -2328,6 +2385,7 @@ func (c *Conn) negotiateVersionClient(ctx context.Context) ([]*dtlsflight.Outbou
 	}
 
 	for {
+		c.signalHandshakeQuiescent()
 		if err := c.readAndBufferNoFSM(ctx); err != nil {
 			return nil, err
 		}
@@ -2601,6 +2659,9 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 
 	ctxRead, cancelRead := context.WithCancel(context.Background())
 	ctxHs, cancel := context.WithCancel(context.Background())
+	if c.detached != nil && start.postSetup != nil {
+		c.detached.quiescentSkip.Store(true)
+	}
 
 	c.closeLock.Lock()
 	c.cancelHandshaker = cancel
@@ -2618,6 +2679,7 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 		defer handshakeLoopsFinished.Done()
 		err := c.fsm.Run(ctxHs, handshakeConn{c}, start.fsmState)
 		if !errors.Is(err, context.Canceled) {
+			c.signalHandshakeTerminated(err)
 			select {
 			case firstErr <- err:
 			default:
@@ -2648,10 +2710,13 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 
 			action := c.classifyReadLoopError(err)
 			if action == readLoopContinue {
+				c.signalHandshakeQuiescent()
+
 				continue
 			}
 			if action == readLoopDeliverAndContinue {
 				c.deliverReadError(ctxRead, err)
+				c.signalHandshakeQuiescent()
 
 				continue
 			}
@@ -2661,6 +2726,9 @@ func (c *Conn) handshake(ctx context.Context, start handshakeStart) error {
 			default:
 			}
 
+			if !errors.Is(err, context.Canceled) {
+				c.signalHandshakeTerminated(err)
+			}
 			if action == readLoopCloseAndStop {
 				if errors.Is(err, context.Canceled) {
 					c.log.Trace("handshake timeouts - closing underlying connection")
@@ -2752,6 +2820,10 @@ func (c *Conn) close(byUser bool) error {
 		_ = c.notify(context.Background(), alert.Warning, alert.CloseNotify)
 	}
 
+	if c.detached != nil {
+		return nil
+	}
+
 	return c.nextConn.Close()
 }
 
@@ -2812,6 +2884,10 @@ func validateNextWriteGeneration(
 
 // LocalAddr implements net.Conn.LocalAddr.
 func (c *Conn) LocalAddr() net.Addr {
+	if c.detached != nil {
+		return nil
+	}
+
 	return c.nextConn.LocalAddr()
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -5194,3 +5194,358 @@ func assertTrafficKeyTestRecord(
 	require.NoError(t, err)
 	assert.Equal(t, want, innerPlaintext.Content)
 }
+
+func TestDetachedConnWritesRRCAsAddressedEvent(t *testing.T) {
+	conn, _ := newTestConnWithReadProtection(t)
+	conn.cidPathMigrationPolicy = CIDPathMigrationRRC
+	state, ok := conn.state.(*dtlsstate.State13)
+	require.True(t, ok)
+	state.CommitNegotiatedExtensions(&negotiation.ConnectionID{
+		ClientCID:              []byte("local-cid"),
+		ServerCID:              []byte("remote-cid"),
+		ReturnRoutabilityCheck: true,
+	})
+	conn.setLocalEpoch(dtlsflight13.EpochApplication)
+	addr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 5000}
+	conn.rAddr = addr
+	detached := &DetachedConn{}
+	conn.detached = detached
+
+	require.NoError(t, (returnRoutabilityConn{conn: conn}).WriteRRC(
+		t.Context(), addr, protocol.ReturnRoutabilityCheckPathChallenge,
+		[protocol.ReturnRoutabilityCheckCookieLength]byte{},
+	))
+	event := detached.NextEvent()
+	require.Equal(t, DetachedWriteDatagrams, event.Kind)
+	require.Equal(t, addr.String(), event.Addr.String())
+	require.Len(t, event.Datagrams, 1)
+}
+
+func TestDetachedConnEvents(t *testing.T) {
+	certificate, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+	clientAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 4444}
+	serverAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 5555}
+	for _, testCase := range []struct {
+		name string
+		min  protocol.Version
+		max  protocol.Version
+	}{
+		{name: "DTLS12", min: protocol.Version1_2, max: protocol.Version1_2},
+		{name: "DTLS13", min: protocol.Version1_3, max: protocol.Version1_3},
+		{name: "DualStack", min: protocol.Version1_2, max: protocol.Version1_3},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, err := DetachedClient(serverAddr,
+				WithInsecureSkipVerify(true),
+				WithMinVersion(testCase.min),
+				WithMaxVersion(testCase.max),
+				WithMTU(200),
+			)
+			require.NoError(t, err)
+			server, err := DetachedServer(clientAddr,
+				WithCertificates(certificate),
+				WithMinVersion(testCase.min),
+				WithMaxVersion(testCase.max),
+				WithMTU(200),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = client.Close()
+				_ = server.Close()
+			})
+			require.NoError(t, client.Start(t.Context()))
+			require.NoError(t, server.Start(t.Context()))
+
+			clientDone, serverDone := false, false
+			largestBatch := 0
+			for range 64 {
+				drainDetachedEvents(t, client, server, clientAddr, serverAddr, &clientDone, nil, &largestBatch)
+				drainDetachedEvents(t, server, client, serverAddr, clientAddr, &serverDone, nil, &largestBatch)
+				if clientDone && serverDone {
+					break
+				}
+			}
+			require.True(t, clientDone)
+			require.True(t, serverDone)
+			require.Greater(t, largestBatch, 1)
+
+			for _, payload := range [][]byte{[]byte("first application record"), []byte("second application record")} {
+				n, writeErr := client.Write(payload)
+				require.NoError(t, writeErr)
+				require.Equal(t, len(payload), n)
+				var received []byte
+				drainDetachedEvents(t, client, server, clientAddr, serverAddr, nil, nil, nil)
+				drainDetachedEvents(t, server, client, serverAddr, clientAddr, nil, &received, nil)
+				require.Equal(t, payload, received)
+			}
+		})
+	}
+}
+
+func TestDetachedConnLifecycle(t *testing.T) {
+	serverAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 5555}
+	client, err := DetachedClient(serverAddr, WithInsecureSkipVerify(true))
+	require.NoError(t, err)
+	startedClient := client
+	t.Cleanup(func() { _ = startedClient.Close() })
+	require.ErrorIs(t, client.HandleDatagram([]byte{0}, serverAddr), dtlserrors.ErrHandshakeInProgress)
+	_, err = client.Write([]byte("early"))
+	require.ErrorIs(t, err, dtlserrors.ErrHandshakeInProgress)
+	require.NoError(t, client.Start(t.Context()))
+	require.ErrorIs(t, client.Start(t.Context()), errDetachedConnStarted)
+
+	client, err = DetachedClient(nil)
+	require.ErrorIs(t, err, dtlserrors.ErrNilRemoteAddr)
+	require.Nil(t, client)
+}
+
+func TestDetachedConnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	client, err := DetachedClient(
+		&net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 5555},
+		WithInsecureSkipVerify(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, client.Start(ctx))
+	for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+	}
+	cancel()
+	requireDetachedEventReady(t, client)
+
+	var closedErr error
+	for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+		if event.Kind == DetachedClosed {
+			closedErr = event.Err
+		}
+	}
+	require.ErrorIs(t, closedErr, context.Canceled)
+}
+
+func TestDetachedConnEventReadyCoalesces(t *testing.T) {
+	conn := &DetachedConn{eventReady: make(chan struct{}, 1)}
+	conn.publishEvent(DetachedEvent{Kind: DetachedApplicationData})
+	conn.publishEvent(DetachedEvent{Kind: DetachedHandshakeDone})
+
+	requireDetachedEventReady(t, conn)
+	select {
+	case <-conn.EventReady():
+		require.Fail(t, "multiple readiness signals for one nonempty queue")
+	default:
+	}
+	require.Equal(t, DetachedApplicationData, conn.NextEvent().Kind)
+	require.Equal(t, DetachedHandshakeDone, conn.NextEvent().Kind)
+	require.Equal(t, DetachedNoEvent, conn.NextEvent().Kind)
+
+	conn.publishEvent(DetachedEvent{Kind: DetachedApplicationData})
+	require.Equal(t, DetachedApplicationData, conn.NextEvent().Kind)
+	require.Equal(t, DetachedNoEvent, conn.NextEvent().Kind)
+	select {
+	case <-conn.EventReady():
+		require.Fail(t, "stale readiness signal after draining events")
+	default:
+	}
+
+	conn.publishEvent(DetachedEvent{Kind: DetachedHandshakeDone})
+	requireDetachedEventReady(t, conn)
+}
+
+func TestDetachedConnAutonomousRetransmit(t *testing.T) {
+	for name, version := range map[string]protocol.Version{"DTLS12": protocol.Version1_2, "DTLS13": protocol.Version1_3} {
+		t.Run(name, func(t *testing.T) {
+			client, err := DetachedClient(
+				&net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 5555},
+				WithInsecureSkipVerify(true),
+				WithMinVersion(version),
+				WithMaxVersion(version),
+				WithFlightInterval(100*time.Millisecond),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = client.Close() })
+			require.NoError(t, client.Start(t.Context()))
+
+			initialWrites := 0
+			for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+				if event.Kind == DetachedWriteDatagrams {
+					require.NotEmpty(t, event.Datagrams)
+					initialWrites++
+				}
+			}
+			require.Equal(t, 1, initialWrites)
+			select {
+			case <-client.EventReady():
+				require.Fail(t, "stale readiness signal before retransmission")
+			default:
+			}
+
+			requireDetachedEventReady(t, client)
+
+			retransmitWrites := 0
+			for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+				if event.Kind == DetachedWriteDatagrams {
+					require.NotEmpty(t, event.Datagrams)
+					retransmitWrites++
+				}
+			}
+			require.Equal(t, 1, retransmitWrites)
+			select {
+			case <-client.EventReady():
+				require.Fail(t, "stale readiness signal after retransmission")
+			default:
+			}
+		})
+	}
+}
+
+func TestDetachedConnValidInputCancelsPendingRetransmit(t *testing.T) { //nolint:cyclop
+	certificate, err := selfsign.GenerateSelfSigned()
+	require.NoError(t, err)
+	clientAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 4444}
+	serverAddr := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 5555}
+
+	for name, version := range map[string]protocol.Version{"DTLS12": protocol.Version1_2, "DTLS13": protocol.Version1_3} {
+		t.Run(name, func(t *testing.T) {
+			client, err := DetachedClient(serverAddr,
+				WithInsecureSkipVerify(true),
+				WithMinVersion(version),
+				WithMaxVersion(version),
+				WithFlightInterval(time.Hour),
+			)
+			require.NoError(t, err)
+			server, err := DetachedServer(clientAddr,
+				WithCertificates(certificate),
+				WithMinVersion(version),
+				WithMaxVersion(version),
+				WithFlightInterval(time.Hour),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = client.Close()
+				_ = server.Close()
+			})
+
+			timers := make(chan *detachedTimer, 8)
+			client.conn.handshakeConfig.TimerFactory = func(d time.Duration) dtlsconfig.Timer {
+				timer := client.newTimer(d).(*detachedTimer) //nolint:forcetypeassert // test factory always returns this type
+				timers <- timer
+
+				return timer
+			}
+
+			require.NoError(t, server.Start(t.Context()))
+			require.NoError(t, client.Start(t.Context()))
+
+			var clientFlight [][]byte
+			for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+				if event.Kind == DetachedWriteDatagrams {
+					clientFlight = append(clientFlight, event.Datagrams...)
+				}
+			}
+			require.NotEmpty(t, clientFlight)
+			initialTimer := <-timers
+
+			// Keep the valid input operation ahead of the pending timer callback.
+			// Stop must claim the timer while fire is waiting for driveMu.
+			client.driveMu.Lock()
+			locked := true
+			defer func() {
+				if locked {
+					client.driveMu.Unlock()
+				}
+			}()
+
+			for _, datagram := range clientFlight {
+				require.NoError(t, server.HandleDatagram(datagram, clientAddr))
+			}
+			var serverFlight [][]byte
+			for event := server.NextEvent(); event.Kind != DetachedNoEvent; event = server.NextEvent() {
+				if event.Kind == DetachedWriteDatagrams {
+					serverFlight = append(serverFlight, event.Datagrams...)
+				}
+			}
+			require.NotEmpty(t, serverFlight)
+
+			fireDone := make(chan struct{})
+			go func() {
+				initialTimer.fire()
+				close(fireDone)
+			}()
+			for _, datagram := range serverFlight {
+				select {
+				case client.inbound <- addrPkt{rAddr: serverAddr, data: datagram}:
+				case <-client.terminal:
+					require.NoError(t, client.terminalErr)
+				}
+				require.NoError(t, client.waitUntilBlocked())
+			}
+			require.True(t, initialTimer.claimed.Load())
+
+			immediateWrites := 0
+			for event := client.NextEvent(); event.Kind != DetachedNoEvent; event = client.NextEvent() {
+				if event.Kind == DetachedWriteDatagrams {
+					immediateWrites++
+				}
+			}
+			require.Positive(t, immediateWrites)
+
+			client.driveMu.Unlock()
+			locked = false
+			select {
+			case <-fireDone:
+			case <-time.After(time.Second):
+				require.FailNow(t, "timer callback remained blocked after valid input")
+			}
+			select {
+			case <-client.EventReady():
+				require.Fail(t, "canceled retransmit produced an event")
+			default:
+			}
+		})
+	}
+}
+
+func requireDetachedEventReady(t *testing.T, conn *DetachedConn) {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-conn.EventReady():
+	case <-timer.C:
+		require.FailNow(t, "timed out waiting for a detached event")
+	}
+}
+
+func drainDetachedEvents( //nolint:cyclop
+	t *testing.T,
+	source, peer *DetachedConn,
+	sourceAddr, peerAddr net.Addr,
+	handshakeDone *bool,
+	applicationData *[]byte,
+	largestBatch *int,
+) {
+	t.Helper()
+	for event := source.NextEvent(); event.Kind != DetachedNoEvent; event = source.NextEvent() {
+		switch event.Kind {
+		case DetachedWriteDatagrams:
+			require.Equal(t, peerAddr.String(), event.Addr.String())
+			if largestBatch != nil {
+				*largestBatch = max(*largestBatch, len(event.Datagrams))
+			}
+			for _, datagram := range event.Datagrams {
+				require.NoError(t, peer.HandleDatagram(datagram, sourceAddr))
+			}
+		case DetachedApplicationData:
+			if applicationData != nil {
+				*applicationData = append(*applicationData, event.Data...)
+			}
+		case DetachedHandshakeDone:
+			if handshakeDone != nil {
+				require.False(t, *handshakeDone)
+				*handshakeDone = true
+			}
+		case DetachedClosed:
+			require.NoError(t, event.Err)
+		case DetachedNoEvent:
+		}
+	}
+}

--- a/connection_id.go
+++ b/connection_id.go
@@ -67,7 +67,12 @@ func (c returnRoutabilityConn) WriteRRC(ctx context.Context, addr net.Addr, mess
 		return err
 	}
 
-	if _, err = c.conn.nextConn.WriteToContext(ctx, raw, addr); err != nil {
+	if c.conn.detached != nil {
+		c.conn.detached.publishDatagrams([][]byte{raw}, addr)
+	} else {
+		_, err = c.conn.nextConn.WriteToContext(ctx, raw, addr)
+	}
+	if err != nil {
 		if errors.Is(err, context.Canceled) && c.conn.isConnectionClosed() {
 			return ErrConnClosed
 		}

--- a/detached_conn.go
+++ b/detached_conn.go
@@ -1,0 +1,385 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package dtls
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsflight "github.com/pion/dtls/v3/internal/flight"
+	dtlsstate "github.com/pion/dtls/v3/internal/state"
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/alert"
+)
+
+// DetachedEventKind identifies an event produced by a DetachedConn.
+type DetachedEventKind uint8
+
+const (
+	// DetachedNoEvent indicates that no event is available.
+	DetachedNoEvent DetachedEventKind = iota
+	// DetachedWriteDatagrams provides one complete DTLS output batch in
+	// Datagrams and its destination in Addr.
+	DetachedWriteDatagrams
+	// DetachedApplicationData provides plaintext received from the peer in Data.
+	DetachedApplicationData
+	// DetachedHandshakeDone indicates that the handshake has completed.
+	DetachedHandshakeDone
+	// DetachedClosed indicates that the connection has terminated with Err.
+	DetachedClosed
+)
+
+// DetachedEvent is an event produced by a DetachedConn. Fields are populated
+// according to Kind. Its byte slices are owned by the caller.
+type DetachedEvent struct {
+	Kind DetachedEventKind
+
+	Datagrams [][]byte
+	Data      []byte
+	Addr      net.Addr
+	Err       error
+}
+
+// DetachedConn is a DTLS connection whose datagram transport is supplied by
+// its caller. It remains active for application and post-handshake traffic.
+// This API is inspired by crypto/tls.QUICConn, Start, HandleDatagram, Write, and Close must not be
+// called concurrently with one another. EventReady may be selected concurrently.
+// After a driving method returns, call NextEvent until it returns DetachedNoEvent.
+type DetachedConn struct {
+	conn    *Conn
+	inbound chan addrPkt
+	driveMu sync.Mutex
+
+	eventMu    sync.Mutex
+	events     []DetachedEvent
+	nextEvent  int
+	eventReady chan struct{}
+
+	started bool
+	blocked chan struct{}
+
+	established   atomic.Bool
+	quiescentSkip atomic.Bool
+
+	terminalOnce sync.Once
+	terminal     chan struct{}
+	terminalErr  error
+}
+
+var (
+	errDetachedConnStarted = errors.New("DetachedConn.Start called more than once")
+	errNilContext          = errors.New("nil context")
+)
+
+// DetachedClient returns a new detached client connection. Call Start before
+// supplying datagrams.
+func DetachedClient(remoteAddr net.Addr, opts ...ClientOption) (*DetachedConn, error) {
+	if remoteAddr == nil {
+		return nil, dtlserrors.ErrNilRemoteAddr
+	}
+	config, err := buildClientConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if config.psk != nil && config.PSKIdentityHint == nil {
+		return nil, dtlserrors.ErrPSKAndIdentityMustBeSetForClient
+	}
+	if err = validateConfig(config); err != nil {
+		return nil, err
+	}
+
+	return newDetachedConn(remoteAddr, config, true)
+}
+
+// DetachedServer returns a new detached server connection. Call Start before
+// supplying datagrams.
+func DetachedServer(remoteAddr net.Addr, opts ...ServerOption) (*DetachedConn, error) {
+	if remoteAddr == nil {
+		return nil, dtlserrors.ErrNilRemoteAddr
+	}
+	config, err := buildServerConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateConfig(config); err != nil {
+		return nil, err
+	}
+	if config.OnConnectionAttempt != nil {
+		if err = config.OnConnectionAttempt(remoteAddr); err != nil {
+			return nil, err
+		}
+	}
+
+	return newDetachedConn(remoteAddr, config, false)
+}
+
+func newDetachedConn(remoteAddr net.Addr, config *dtlsConfig, isClient bool) (*DetachedConn, error) {
+	configValues, err := newConnConfigValues(config)
+	if err != nil {
+		return nil, err
+	}
+
+	detached := &DetachedConn{
+		blocked:    make(chan struct{}),
+		eventReady: make(chan struct{}, 1),
+		inbound:    make(chan addrPkt),
+		terminal:   make(chan struct{}),
+	}
+	handshakeConfig := newHandshakeConfig(config, configValues, nil)
+	detached.conn = newConn(nil, remoteAddr, configValues, handshakeConfig, isClient)
+	detached.conn.detached = detached
+	detached.conn.handshakeConfig.TimerFactory = detached.newTimer
+	detached.conn.setRemoteEpoch(0)
+	detached.conn.setLocalEpoch(0)
+
+	return detached, nil
+}
+
+// Start starts the handshake and runs it until it needs peer input. It may
+// produce events and must be called at most once.
+func (c *DetachedConn) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errNilContext
+	}
+	c.driveMu.Lock()
+	defer c.driveMu.Unlock()
+
+	if c.started {
+		return errDetachedConnStarted
+	}
+	c.started = true
+
+	go func() {
+		if err := c.conn.HandshakeContext(ctx); err != nil {
+			c.terminate(err, true) //nolint:contextcheck
+		}
+	}()
+
+	return c.waitUntilBlocked()
+}
+
+// HandleDatagram supplies one datagram received from addr and runs DTLS until
+// it is blocked again. It may produce events. A nil addr uses the connection's
+// current remote address. It does not retain datagram after returning.
+func (c *DetachedConn) HandleDatagram(datagram []byte, addr net.Addr) error {
+	c.driveMu.Lock()
+	defer c.driveMu.Unlock()
+
+	if !c.started {
+		return dtlserrors.ErrHandshakeInProgress
+	}
+	if err := c.currentError(); err != nil {
+		return err
+	}
+	if addr == nil {
+		addr = c.conn.RemoteAddr()
+	}
+
+	select {
+	case c.inbound <- addrPkt{rAddr: addr, data: datagram}:
+	case <-c.terminal:
+		return c.terminalErr
+	}
+
+	return c.waitUntilBlocked()
+}
+
+// Write encrypts plaintext application data and may produce events. The
+// handshake must be complete.
+func (c *DetachedConn) Write(data []byte) (int, error) {
+	c.driveMu.Lock()
+	defer c.driveMu.Unlock()
+
+	if err := c.currentError(); err != nil {
+		return 0, err
+	}
+	if !c.established.Load() {
+		return 0, dtlserrors.ErrHandshakeInProgress
+	}
+
+	version := dtlsstate.CommonState(c.conn.state).LocalVersion
+	err := c.conn.writeApplicationData(context.Background(), []*dtlsflight.Outbound{{
+		Content:    &protocol.ApplicationData{Data: data},
+		Protection: dtlsflight.ProtectionCiphertext,
+	}})
+	n := 0
+	if err == nil {
+		n = len(data)
+	}
+	if version == protocol.Version1_3 {
+		if quiescentErr := c.waitUntilBlocked(); err == nil {
+			err = quiescentErr
+		}
+	}
+
+	return n, err
+}
+
+// EventReady is signaled when NextEvent may return an event and may be selected
+// alongside transport input. Signals are coalesced
+// It's the caller's responsibility to drain NextEvent until it returns DetachedNoEvent.
+func (c *DetachedConn) EventReady() <-chan struct{} { return c.eventReady }
+
+// NextEvent returns the next pending event, or DetachedNoEvent when the queue
+// is empty.
+func (c *DetachedConn) NextEvent() DetachedEvent {
+	c.eventMu.Lock()
+	defer c.eventMu.Unlock()
+
+	if c.nextEvent == len(c.events) {
+		c.events = c.events[:0]
+		c.nextEvent = 0
+		select {
+		case <-c.eventReady:
+		default:
+		}
+
+		return DetachedEvent{Kind: DetachedNoEvent}
+	}
+	event := c.events[c.nextEvent]
+	c.events[c.nextEvent] = DetachedEvent{}
+	c.nextEvent++
+
+	return event
+}
+
+// ConnectionState returns the current DTLS connection state.
+func (c *DetachedConn) ConnectionState() (State, bool) { return c.conn.ConnectionState() }
+
+// SelectedSRTPProtectionProfile returns the negotiated SRTP profile.
+func (c *DetachedConn) SelectedSRTPProtectionProfile() (SRTPProtectionProfile, bool) {
+	return c.conn.SelectedSRTPProtectionProfile()
+}
+
+// RemoteSRTPMasterKeyIdentifier returns the peer's negotiated SRTP MKI.
+func (c *DetachedConn) RemoteSRTPMasterKeyIdentifier() ([]byte, bool) {
+	return c.conn.RemoteSRTPMasterKeyIdentifier()
+}
+
+// Close closes the detached connection.
+func (c *DetachedConn) Close() error {
+	c.driveMu.Lock()
+	defer c.driveMu.Unlock()
+
+	return c.conn.Close()
+}
+
+func (c *DetachedConn) publishDatagrams(datagrams [][]byte, addr net.Addr) {
+	c.publishEvent(DetachedEvent{Kind: DetachedWriteDatagrams, Datagrams: datagrams, Addr: addr})
+}
+
+func (c *DetachedConn) publishApplicationData(data []byte) {
+	c.publishEvent(DetachedEvent{Kind: DetachedApplicationData, Data: data})
+}
+
+func (c *DetachedConn) publishEvent(event DetachedEvent) {
+	c.eventMu.Lock()
+	c.events = append(c.events, event)
+	select {
+	case c.eventReady <- struct{}{}:
+	default:
+	}
+	c.eventMu.Unlock()
+}
+
+func (c *DetachedConn) markQuiescent() {
+	if c.conn.isHandshakeCompletedSuccessfully() && c.established.CompareAndSwap(false, true) {
+		c.publishEvent(DetachedEvent{Kind: DetachedHandshakeDone})
+	}
+
+	select {
+	case c.blocked <- struct{}{}:
+	case <-c.terminal:
+	}
+}
+
+func (c *DetachedConn) waitUntilBlocked() error {
+	select {
+	case <-c.blocked:
+		return c.currentError()
+	case <-c.terminal:
+		return c.terminalErr
+	}
+}
+
+func (c *DetachedConn) connectionTerminated(err error) {
+	var receivedAlert *alertError
+	if errors.As(err, &receivedAlert) && receivedAlert.Description == alert.CloseNotify {
+		err = ErrConnClosed
+	}
+	c.terminate(err, false)
+}
+
+func (c *DetachedConn) terminate(err error, closeConn bool) {
+	if err == nil {
+		err = ErrConnClosed
+	}
+	c.terminalOnce.Do(func() {
+		c.terminalErr = err
+		if closeConn {
+			_ = c.conn.close(false) //nolint:contextcheck
+		}
+		c.publishEvent(DetachedEvent{Kind: DetachedClosed, Err: err})
+		close(c.terminal)
+	})
+}
+
+func (c *DetachedConn) currentError() error {
+	select {
+	case <-c.terminal:
+		return c.terminalErr
+	default:
+		return nil
+	}
+}
+
+func (c *DetachedConn) readDatagram(ctx context.Context, buffer []byte) (int, net.Addr, error) {
+	select {
+	case packet := <-c.inbound:
+		return copy(buffer, packet.data), packet.rAddr, nil
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+	case <-c.terminal:
+		return 0, nil, c.terminalErr
+	}
+}
+
+func (c *DetachedConn) newTimer(d time.Duration) dtlsconfig.Timer {
+	timer := &detachedTimer{owner: c, ch: make(chan time.Time, 1)}
+	timer.timer = time.AfterFunc(d, timer.fire)
+
+	return timer
+}
+
+type detachedTimer struct {
+	owner   *DetachedConn
+	ch      chan time.Time
+	timer   *time.Timer
+	claimed atomic.Bool
+}
+
+func (t *detachedTimer) C() <-chan time.Time { return t.ch }
+
+func (t *detachedTimer) fire() {
+	t.owner.driveMu.Lock()
+	defer t.owner.driveMu.Unlock()
+	if !t.claimed.CompareAndSwap(false, true) {
+		return
+	}
+
+	t.ch <- time.Now()
+	_ = t.owner.waitUntilBlocked()
+}
+
+func (t *detachedTimer) Stop() {
+	if t.claimed.CompareAndSwap(false, true) {
+		t.timer.Stop()
+	}
+}

--- a/internal/config/handshake.go
+++ b/internal/config/handshake.go
@@ -134,9 +134,37 @@ type HandshakeConfig struct {
 	ResumeState                   *internalstate.State
 	MinVersion                    protocol.Version
 	MaxVersion                    protocol.Version
+	TimerFactory                  func(time.Duration) Timer
 
 	nameToCertificate map[string]*tls.Certificate
 	mu                sync.Mutex
+}
+
+// Timer is the timer surface used by the handshake state machines.
+type Timer interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type systemTimer struct {
+	timer *time.Timer
+}
+
+func (t *systemTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *systemTimer) Stop() {
+	t.timer.Stop()
+}
+
+// NewTimer returns a handshake timer.
+func (c *HandshakeConfig) NewTimer(d time.Duration) Timer {
+	if c.TimerFactory != nil {
+		return c.TimerFactory(d)
+	}
+
+	return &systemTimer{timer: time.NewTimer(d)}
 }
 
 func (c *HandshakeConfig) WriteKeyLog(label string, clientRandom, secret []byte) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -43,6 +43,7 @@ var (
 	ErrInvalidPrivateKey                    = stderrors.New("invalid private key type")
 	ErrInvalidSignatureAlgorithm            = stderrors.New("invalid signature algorithm")
 	ErrInvalidExtendedMasterSecretType      = stderrors.New("invalid extended master secret type")
+	ErrNilRemoteAddr                        = stderrors.New("remote address cannot be nil")
 	ErrInvalidCertificateSignatureAlgorithm = stderrors.New(
 		"certificate uses a signature algorithm that is not allowed",
 	)

--- a/internal/handshake/fsm12.go
+++ b/internal/handshake/fsm12.go
@@ -148,7 +148,8 @@ func (s *fsm12) send(ctx context.Context, c Conn) (State, error) {
 }
 
 func (s *fsm12) wait(ctx context.Context, conn Conn) (State, error) { //nolint:gocognit,cyclop
-	retransmitTimer := time.NewTimer(s.retransmitInterval)
+	retransmitTimer := s.cfg.NewTimer(s.retransmitInterval)
+	defer retransmitTimer.Stop()
 	for {
 		select {
 		case state := <-conn.RecvHandshake():
@@ -195,7 +196,7 @@ func (s *fsm12) wait(ctx context.Context, conn Conn) (State, error) { //nolint:g
 
 			return StatePreparing, nil
 
-		case <-retransmitTimer.C:
+		case <-retransmitTimer.C():
 			return handleRetransmitTimeout(s.retransmit, &s.retransmitInterval, s.cfg), nil
 		case <-ctx.Done():
 			return handleWaitCancellation(&s.retransmitInterval, s.cfg, ctx.Err())

--- a/internal/handshake/fsm13.go
+++ b/internal/handshake/fsm13.go
@@ -282,7 +282,7 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) {
 		}
 	}()
 
-	retransmitTimer := time.NewTimer(s.retransmitInterval)
+	retransmitTimer := s.cfg.NewTimer(s.retransmitInterval)
 	defer retransmitTimer.Stop()
 	for {
 		select {
@@ -300,7 +300,7 @@ func (s *fsm13) wait(ctx context.Context, conn Conn) (State, error) {
 
 			return transition.state, nil
 
-		case <-retransmitTimer.C:
+		case <-retransmitTimer.C():
 			return handleRetransmitTimeout(s.retransmit, &s.retransmitInterval, s.cfg), nil
 		case <-ctx.Done():
 			return handleWaitCancellation(&s.retransmitInterval, s.cfg, ctx.Err())

--- a/internal/handshake/post_handshake.go
+++ b/internal/handshake/post_handshake.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	dtlsciphersuite "github.com/pion/dtls/v3/internal/ciphersuite"
+	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
 	dtlsflight "github.com/pion/dtls/v3/internal/flight"
 	dtlsstate "github.com/pion/dtls/v3/internal/state"
@@ -336,7 +337,7 @@ func (p *postHandshake) registerTransmission(flight *reliablePostHandshakeFlight
 	}
 }
 
-func (p *postHandshake) nextTimer() (*time.Timer, <-chan time.Time) {
+func (p *postHandshake) nextTimer() (dtlsconfig.Timer, <-chan time.Time) {
 	var next time.Time
 	for _, flight := range p.flights {
 		if next.IsZero() || flight.NextRetransmit.Before(next) {
@@ -348,9 +349,9 @@ func (p *postHandshake) nextTimer() (*time.Timer, <-chan time.Time) {
 	}
 
 	delay := max(time.Until(next), 0)
-	timer := time.NewTimer(delay)
+	timer := p.cfg.NewTimer(delay)
 
-	return timer, timer.C
+	return timer, timer.C()
 }
 
 func (p *postHandshake) handlePostHandshakeReceive(


### PR DESCRIPTION
#### Description
Edit: this API initially only implemented the handshake phase, but now it's extended to full conn replacement. 

This API adds a transport-agnostic interface for driving a DTLS connection manually. It avoids exporting the intercept/inject API proposed in [#766](https://github.com/pion/dtls/pull/766), and callers do not need to parse DTLS flights or infer handshake batch boundaries, particularly difficult with DTLS 1.3.
The API is inspired by [crypto/tls.QUICConn](https://cs.opensource.google/go/go/+/go1.27.0:src/crypto/tls/quic.go;l=44).

- `DetachedClient` and `DetachedServer` create and configure a detached DTLS connection.
- `Start` begins the handshake and runs until peer input is required.
- `HandleDatagram` supplies a datagram received from the peer and processes it until DTLS is blocked again.
- `Write` encrypts application data after the handshake.
- `EventReady` signals that output is available.
- `NextEvent` returns complete output datagram batches, received application data, handshake completion, or connection termination.
- `Close` closes the connection.

Unlike the first proposal `DetachedConn` remains in use after the handshake, for pion/webrtc, this will replace packetconn inside the ice write, and removes the need for "mux".

~I didn't add tests for the API in cause we want to modify it through the review. But I'll add tests before it's merged.~
