### PR TITLE
Reassemble re-fragmented handshake retransmits

### DIFF
--- a/fragment_buffer.go
+++ b/fragment_buffer.go
@@ -4,6 +4,9 @@
 package dtls
 
 import (
+	"slices"
+	"sort"
+
 	"github.com/pion/dtls/v3/pkg/protocol"
 	"github.com/pion/dtls/v3/pkg/protocol/handshake"
 	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
@@ -15,16 +18,79 @@ const (
 	fragmentBufferMaxCount = 1000
 )
 
-type fragment struct {
-	recordLayerHeader recordlayer.Header
-	handshakeHeader   handshake.Header
-	data              []byte
+// fragmentRange is the payload of one handshake fragment.
+type fragmentRange struct {
+	offset uint32
+	data   []byte
 }
 
+func (r fragmentRange) end() uint32 {
+	return r.offset + uint32(len(r.data)) //nolint:gosec // G115: fragment lengths are 24 bit.
+}
+
+// fragments holds what has been received of one handshake message. A peer may
+// fragment a retransmitted message differently from the original transmission
+// (RFC 6347 Section 4.2.3), so fragments can overlap. ranges is sorted by
+// offset and never holds a fragment that another one fully covers, which
+// makes its ends increase as well; covered is the length of the contiguous
+// prefix of the message received so far and is advanced as fragments arrive,
+// so completeness is known without scanning.
 type fragments struct {
-	fragmentByOffset map[uint32]*fragment
-	fragmentsLength  uint32
-	handshakeLength  uint32
+	ranges          []fragmentRange
+	covered         uint32
+	handshakeType   handshake.Type
+	handshakeLength uint32
+	// From the first fragment received at offset 0.
+	handshakeHeader handshake.Header
+	epoch           uint16
+	hasStart        bool
+}
+
+// add stores a fragment and returns the change in stored fragment count and
+// bytes, which is negative when the fragment replaces smaller ones.
+func (f *fragments) add(offset uint32, data []byte) (fragmentDelta, byteDelta int) {
+	frag := fragmentRange{offset: offset, data: data}
+
+	// First fragment starting at or after offset.
+	i := sort.Search(len(f.ranges), func(k int) bool { return f.ranges[k].offset >= offset })
+	if f.covers(i, frag) {
+		return 0, 0
+	}
+
+	// ranges[i:j] start inside the new fragment and end inside it: covered.
+	j := i
+	for j < len(f.ranges) && f.ranges[j].end() <= frag.end() {
+		fragmentDelta--
+		byteDelta -= len(f.ranges[j].data)
+		j++
+	}
+	f.ranges = slices.Replace(f.ranges, i, j, frag)
+	f.advanceCovered(i)
+
+	return fragmentDelta + 1, byteDelta + len(data)
+}
+
+// covers reports whether a stored fragment already carries every byte of
+// frag, whose insertion index is i. Since ends increase with offsets, only
+// the fragment before i and one starting at the same offset can.
+func (f *fragments) covers(i int, frag fragmentRange) bool {
+	if i > 0 && f.ranges[i-1].end() >= frag.end() {
+		return true
+	}
+
+	return i < len(f.ranges) && f.ranges[i].offset == frag.offset && f.ranges[i].end() >= frag.end()
+}
+
+// advanceCovered extends the covered prefix after inserting ranges[i]. Only
+// a fragment touching the prefix can extend it, possibly through fragments
+// received earlier that start within its reach.
+func (f *fragments) advanceCovered(i int) {
+	if f.ranges[i].offset > f.covered {
+		return
+	}
+	for k := i; k < len(f.ranges) && f.ranges[k].offset <= f.covered; k++ {
+		f.covered = max(f.covered, f.ranges[k].end())
+	}
 }
 
 type fragmentBuffer struct {
@@ -49,6 +115,7 @@ func (f *fragmentBuffer) size() int {
 // Attempts to push a DTLS packet to the fragmentBuffer
 // when it returns true it means the fragmentBuffer has inserted and the buffer shouldn't be handled
 // when an error returns it is fatal, and the DTLS connection should be stopped.
+// The fragments keep referencing buf, so it must not be reused by the caller.
 func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err error) { //nolint:cyclop
 	if f.size()+len(buf) >= fragmentBufferMaxSize || f.totalFragmentCount >= fragmentBufferMaxCount {
 		return false, false, errFragmentBufferOverflow
@@ -64,45 +131,50 @@ func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err e
 		return false, false, nil
 	}
 
-	frag := new(fragment)
-	for buf = buf[recordlayer.FixedHeaderSize:]; len(buf) != 0; frag = new(fragment) { //nolint:gosec // G602
-		if err := frag.handshakeHeader.Unmarshal(buf); err != nil {
+	for buf = buf[recordlayer.FixedHeaderSize:]; len(buf) != 0; { //nolint:gosec // G602
+		var header handshake.Header
+		if err := header.Unmarshal(buf); err != nil {
 			return false, false, err
 		}
 
 		// Fragment is a retransmission. We have already assembled it before successfully
-		isRetransmit = frag.handshakeHeader.FragmentOffset == 0 &&
-			frag.handshakeHeader.MessageSequence < f.currentMessageSequenceNumber
+		isRetransmit = header.FragmentOffset == 0 && header.MessageSequence < f.currentMessageSequenceNumber
 
-		end := int(handshake.HeaderLength + frag.handshakeHeader.FragmentLength)
+		end := int(handshake.HeaderLength + header.FragmentLength)
 		if end > len(buf) {
 			return false, false, errBufferTooSmall
 		}
-		if frag.handshakeHeader.MessageSequence < f.currentMessageSequenceNumber {
-			buf = buf[end:]
+		data := buf[handshake.HeaderLength:end]
+		buf = buf[end:]
 
+		// Already assembled, or claims bytes outside the message.
+		if header.MessageSequence < f.currentMessageSequenceNumber ||
+			header.FragmentOffset > header.Length ||
+			header.FragmentLength > header.Length-header.FragmentOffset {
 			continue
 		}
 
-		messageFragments, ok := f.cache[frag.handshakeHeader.MessageSequence]
+		messageFragments, ok := f.cache[header.MessageSequence]
 		if !ok {
-			messageFragments = &fragments{
-				fragmentByOffset: map[uint32]*fragment{}, handshakeLength: frag.handshakeHeader.Length,
-			}
-			f.cache[frag.handshakeHeader.MessageSequence] = messageFragments
+			messageFragments = &fragments{handshakeType: header.Type, handshakeLength: header.Length}
+			f.cache[header.MessageSequence] = messageFragments
+		} else if header.Type != messageFragments.handshakeType || header.Length != messageFragments.handshakeLength {
+			// Disagrees with the message's earlier fragments; admitting it
+			// would break the bounds pop relies on.
+			continue
+		}
+		if header.FragmentOffset == 0 && !messageFragments.hasStart {
+			messageFragments.handshakeHeader = header
+			messageFragments.epoch = recordLayerHeader.Epoch
+			messageFragments.hasStart = true
+		}
+		if len(data) == 0 {
+			continue
 		}
 
-		// Discard all headers, when rebuilding the packet we will re-build
-		frag.data = append([]byte{}, buf[handshake.HeaderLength:end]...)
-		frag.recordLayerHeader = recordLayerHeader
-
-		if _, ok = messageFragments.fragmentByOffset[frag.handshakeHeader.FragmentOffset]; !ok {
-			messageFragments.fragmentByOffset[frag.handshakeHeader.FragmentOffset] = frag
-			messageFragments.fragmentsLength += frag.handshakeHeader.FragmentLength
-			f.totalBufferSize += int(frag.handshakeHeader.FragmentLength)
-			f.totalFragmentCount++
-		}
-		buf = buf[end:]
+		fragmentDelta, byteDelta := messageFragments.add(header.FragmentOffset, data)
+		f.totalFragmentCount += fragmentDelta
+		f.totalBufferSize += byteDelta
 	}
 
 	return true, isRetransmit, nil
@@ -110,42 +182,30 @@ func (f *fragmentBuffer) push(buf []byte) (isHandshake, isRetransmit bool, err e
 
 func (f *fragmentBuffer) pop() (content []byte, epoch uint16) {
 	frags, ok := f.cache[f.currentMessageSequenceNumber]
-	if !ok {
+	if !ok || frags.covered < frags.handshakeLength {
 		return nil, 0
 	}
 
-	if frags.fragmentsLength != frags.handshakeLength {
-		return nil, 0
-	}
-
-	var rawMessage []byte
-	targetOffset := uint32(0)
-	for i := 0; i < len(frags.fragmentByOffset) && targetOffset < frags.handshakeLength; i++ {
-		if frag, ok := frags.fragmentByOffset[targetOffset]; ok {
-			rawMessage = append(rawMessage, frag.data...)
-			targetOffset = frag.handshakeHeader.FragmentOffset + frag.handshakeHeader.FragmentLength
-		} else {
-			return nil, 0
-		}
-	}
-
-	if int(frags.handshakeLength) != len(rawMessage) {
-		return nil, 0
-	}
-
-	firstHeader := frags.fragmentByOffset[0].handshakeHeader
+	firstHeader := frags.handshakeHeader
 	firstHeader.FragmentOffset = 0
 	firstHeader.FragmentLength = firstHeader.Length
 
 	rawHeader, _ := firstHeader.Marshal()
 
-	messageEpoch := frags.fragmentByOffset[0].recordLayerHeader.Epoch
-
-	f.totalBufferSize -= int(frags.fragmentsLength)
-	f.totalFragmentCount -= len(frags.fragmentByOffset)
+	// The message is contiguous, so each fragment continues at or before
+	// where the previous one ended.
+	content = make([]byte, 0, len(rawHeader)+int(frags.handshakeLength))
+	content = append(content, rawHeader...)
+	cursor := uint32(0)
+	for _, frag := range frags.ranges {
+		content = append(content, frag.data[cursor-frag.offset:]...)
+		cursor = frag.end()
+		f.totalBufferSize -= len(frag.data)
+	}
+	f.totalFragmentCount -= len(frags.ranges)
 
 	delete(f.cache, f.currentMessageSequenceNumber)
 	f.currentMessageSequenceNumber++
 
-	return append(rawHeader, rawMessage...), messageEpoch
+	return content, frags.epoch
 }

--- a/fragment_buffer_test.go
+++ b/fragment_buffer_test.go
@@ -6,7 +6,11 @@ package dtls
 import (
 	"testing"
 
+	"github.com/pion/dtls/v3/pkg/protocol"
+	"github.com/pion/dtls/v3/pkg/protocol/handshake"
+	"github.com/pion/dtls/v3/pkg/protocol/recordlayer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFragmentBuffer(t *testing.T) {
@@ -198,4 +202,232 @@ func TestFragmentBuffer_UnmarshalInvalid(t *testing.T) {
 		0x16, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x03,
 	})
 	assert.Error(t, err, "Pushing a buffer with partial handshake header should return an error")
+}
+
+func testMessageBody(size int) []byte {
+	body := make([]byte, size)
+	for i := range body {
+		body[i] = byte(i * 7) //nolint:gosec // Test data.
+	}
+
+	return body
+}
+
+// handshakeFragmentRecord builds one DTLS record carrying the
+// [offset, offset+length) slice of a handshake message body.
+func handshakeFragmentRecord(t *testing.T, msgSeq uint16, body []byte, offset, length uint32) []byte {
+	t.Helper()
+
+	header := handshake.Header{
+		Type:            handshake.TypeCertificate,
+		Length:          uint32(len(body)), //nolint:gosec // G115
+		MessageSequence: msgSeq,
+		FragmentOffset:  offset,
+		FragmentLength:  length,
+	}
+	payload, err := header.Marshal()
+	require.NoError(t, err)
+	payload = append(payload, body[offset:offset+length]...)
+
+	record := recordlayer.Header{
+		ContentType:    protocol.ContentTypeHandshake,
+		Version:        protocol.Version1_2,
+		ContentLen:     uint16(len(payload)), //nolint:gosec // G115
+		SequenceNumber: uint64(msgSeq),
+	}
+	rawRecord, err := record.Marshal()
+	require.NoError(t, err)
+
+	return append(rawRecord, payload...)
+}
+
+func reassembledMessage(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	header := handshake.Header{
+		Type:           handshake.TypeCertificate,
+		Length:         uint32(len(body)), //nolint:gosec // G115
+		FragmentLength: uint32(len(body)), //nolint:gosec // G115
+	}
+	rawHeader, err := header.Marshal()
+	require.NoError(t, err)
+
+	return append(rawHeader, body...)
+}
+
+func pushFragments(t *testing.T, buffer *fragmentBuffer, body []byte, frags [][2]uint32) {
+	t.Helper()
+
+	for _, frag := range frags {
+		isHandshake, _, err := buffer.push(handshakeFragmentRecord(t, 0, body, frag[0], frag[1]))
+		require.NoError(t, err)
+		assert.True(t, isHandshake)
+	}
+}
+
+// A 700 byte message is sent in 256 byte fragments and the middle one is
+// lost. The peer retransmits it in 300 byte fragments, which RFC 6347
+// Section 4.2.3 allows, so the message must be reassembled from the two
+// differently aligned sets of fragments.
+func TestFragmentBuffer_RetransmitWithDifferentBoundaries(t *testing.T) {
+	body := testMessageBody(700)
+	buffer := newFragmentBuffer()
+
+	pushFragments(t, buffer, body, [][2]uint32{{0, 256}, {512, 188}}) // {256, 256} is lost.
+	out, _ := buffer.pop()
+	assert.Nil(t, out, "message must not be reassembled while bytes are missing")
+
+	pushFragments(t, buffer, body, [][2]uint32{{0, 300}, {300, 300}, {600, 100}})
+	// {0, 300} replaced {0, 256}; {600, 100} was already covered by {512, 188}.
+	assert.Equal(t, 300+188+300, buffer.size())
+	assert.Equal(t, 3, buffer.totalFragmentCount)
+
+	out, epoch := buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+	assert.Equal(t, uint16(0), epoch)
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+
+	out, _ = buffer.pop()
+	assert.Nil(t, out)
+}
+
+func TestFragmentBuffer_OverlappingFragmentsReassemble(t *testing.T) {
+	body := testMessageBody(500)
+	buffer := newFragmentBuffer()
+
+	// Out of order, overlapping, duplicated, shorter at a cached offset and a
+	// strict superset of an earlier fragment.
+	pushFragments(t, buffer, body, [][2]uint32{
+		{200, 100}, {150, 100}, {200, 100}, {200, 50}, {0, 250}, {400, 100}, {300, 150},
+	})
+
+	out, _ := buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+}
+
+func TestFragmentBuffer_LongerFragmentReplacesCachedOffset(t *testing.T) {
+	body := testMessageBody(10)
+	buffer := newFragmentBuffer()
+
+	pushFragments(t, buffer, body, [][2]uint32{{0, 4}, {0, 10}})
+	assert.Equal(t, 10, buffer.size())
+	assert.Equal(t, 1, buffer.totalFragmentCount)
+
+	out, _ := buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+}
+
+func TestFragmentBuffer_OutOfBoundsFragmentIgnored(t *testing.T) {
+	body := testMessageBody(100)
+	buffer := newFragmentBuffer()
+
+	for _, header := range []handshake.Header{
+		{Type: handshake.TypeCertificate, Length: 100, FragmentOffset: 80, FragmentLength: 50}, // Ends past the message.
+		{Type: handshake.TypeCertificate, Length: 100, FragmentOffset: 120, FragmentLength: 0}, // Starts past the message.
+	} {
+		payload, err := header.Marshal()
+		require.NoError(t, err)
+		payload = append(payload, make([]byte, header.FragmentLength)...)
+
+		record := recordlayer.Header{
+			ContentType: protocol.ContentTypeHandshake,
+			Version:     protocol.Version1_2,
+			ContentLen:  uint16(len(payload)), //nolint:gosec // G115
+		}
+		rawRecord, err := record.Marshal()
+		require.NoError(t, err)
+
+		isHandshake, _, err := buffer.push(append(rawRecord, payload...))
+		require.NoError(t, err)
+		assert.True(t, isHandshake)
+	}
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+	out, _ := buffer.pop()
+	assert.Nil(t, out)
+
+	// The valid fragments still complete the message.
+	pushFragments(t, buffer, body, [][2]uint32{{0, 60}, {60, 40}})
+	out, _ = buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+}
+
+func TestFragmentBuffer_CoveredPrefixBridgesEarlierFragments(t *testing.T) {
+	body := testMessageBody(200)
+	buffer := newFragmentBuffer()
+
+	// [100, 150) is out of reach until [0, 120) arrives and bridges to it, and
+	// the message is only complete once [150, 200) is bridged as well.
+	pushFragments(t, buffer, body, [][2]uint32{{100, 50}, {0, 120}})
+	out, _ := buffer.pop()
+	assert.Nil(t, out)
+
+	pushFragments(t, buffer, body, [][2]uint32{{150, 50}})
+	out, _ = buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+}
+
+func TestFragmentBuffer_CoveringFragmentReplacesSmallerOnes(t *testing.T) {
+	body := testMessageBody(300)
+	buffer := newFragmentBuffer()
+
+	pushFragments(t, buffer, body, [][2]uint32{{50, 50}, {100, 50}, {200, 100}})
+	assert.Equal(t, 200, buffer.size())
+	assert.Equal(t, 3, buffer.totalFragmentCount)
+
+	// Covers the first two entirely and overlaps the third.
+	pushFragments(t, buffer, body, [][2]uint32{{0, 250}})
+	assert.Equal(t, 350, buffer.size())
+	assert.Equal(t, 2, buffer.totalFragmentCount)
+
+	out, _ := buffer.pop()
+	assert.Equal(t, reassembledMessage(t, body), out)
+	assert.Zero(t, buffer.size())
+	assert.Zero(t, buffer.totalFragmentCount)
+}
+
+func TestFragmentBuffer_FragmentDisagreeingWithMessageIgnored(t *testing.T) {
+	body := testMessageBody(100)
+
+	for name, header := range map[string]handshake.Header{
+		// Claims [150, 200) of a longer message: within its own bounds, but
+		// beyond the cached message, where it would break reassembly.
+		"length": {Type: handshake.TypeCertificate, Length: 300, FragmentOffset: 150, FragmentLength: 50},
+		"type":   {Type: handshake.TypeServerHello, Length: 100, FragmentOffset: 50, FragmentLength: 50},
+	} {
+		t.Run(name, func(t *testing.T) {
+			buffer := newFragmentBuffer()
+			pushFragments(t, buffer, body, [][2]uint32{{0, 100}})
+
+			payload, err := header.Marshal()
+			require.NoError(t, err)
+			payload = append(payload, make([]byte, header.FragmentLength)...)
+
+			record := recordlayer.Header{
+				ContentType: protocol.ContentTypeHandshake,
+				Version:     protocol.Version1_2,
+				ContentLen:  uint16(len(payload)), //nolint:gosec // G115
+			}
+			rawRecord, err := record.Marshal()
+			require.NoError(t, err)
+
+			isHandshake, _, err := buffer.push(append(rawRecord, payload...))
+			require.NoError(t, err)
+			assert.True(t, isHandshake)
+			assert.Equal(t, 100, buffer.size())
+			assert.Equal(t, 1, buffer.totalFragmentCount)
+
+			out, _ := buffer.pop()
+			assert.Equal(t, reassembledMessage(t, body), out)
+			assert.Zero(t, buffer.size())
+			assert.Zero(t, buffer.totalFragmentCount)
+		})
+	}
 }


### PR DESCRIPTION
#### Description

A retransmitted handshake message may be fragmented differently from the original (RFC 6347 Section 4.2.3). The fragment buffer kept the first fragment seen at each offset and only completed a message when the fragment lengths added up, so after one lost datagram the handshake never finished. OpenSSL servers with a small MTU, such as OvenMediaEngine, trigger this.

Keep the longer fragment at a cached offset, ignore fragments that fall outside the message, and complete a message once every byte is covered.

#### Reference issue
Fixing this would be a client-side mitigation for https://github.com/OvenMediaLabs/OvenMediaEngine/issues/2329 (tl;dr; OME forces DTLS handshakes to be split into 256 byte fragments due it defaulting to a small MTU, upon losing a fragment the handshake will fail for pion/dtls based clients).