### PR TITLE
Bound MTU and receive-buffer to 65535

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,12 @@ import (
 	"github.com/pion/logging"
 )
 
-const defaultMTU = 1200 // bytes
+const (
+	minMTU     = 1
+	defaultMTU = 1200 // bytes
+
+	minReceiveBufferSize = 1
+)
 
 var defaultCurves = []elliptic.Curve{ //nolint:gochecknoglobals
 	elliptic.X25519MLKEM768,

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -121,8 +121,8 @@ var (
 	ErrNilVerifyConnection = stderrors.New(
 		"verify connection option requires a non-nil callback",
 	)
-	ErrInvalidMTU                    = stderrors.New("MTU must be positive")
-	ErrInvalidReceiveBufferSize      = stderrors.New("receive buffer size must be positive")
+	ErrInvalidMTU                    = stderrors.New("MTU must be between 1 and 65535 bytes")
+	ErrInvalidReceiveBufferSize      = stderrors.New("receive buffer size must be between 1 and 65535 bytes")
 	ErrInvalidReplayProtectionWindow = stderrors.New(
 		"replay protection window must be non-negative",
 	)

--- a/internal/net/buffer.go
+++ b/internal/net/buffer.go
@@ -25,6 +25,9 @@ import (
 	"github.com/pion/transport/v4/deadline"
 )
 
+// MaxInboundDatagramSize is the largest complete datagram DTLS will accept.
+const MaxInboundDatagramSize = 65535
+
 // ErrTimeout indicates that deadline was reached before operation could be
 // completed.
 var ErrTimeout = dtlserrors.ErrNetBufferTimeout

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsnet "github.com/pion/dtls/v3/internal/net"
 	cryptosuite "github.com/pion/dtls/v3/pkg/crypto/ciphersuite"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/protocol"
@@ -360,11 +361,11 @@ func WithLoggerFactory(factory logging.LoggerFactory) Option {
 	})
 }
 
-// WithMTU sets the maximum transmission unit.
-// Returns an error if the MTU is not positive.
+// WithMTU sets the size used for handshake fragmentation and record packing.
+// The default is 1200 bytes.
 func WithMTU(mtu int) Option {
 	return sharedOption(func(c *dtlsConfig) error {
-		if mtu <= 0 {
+		if mtu < minMTU || mtu > dtlsnet.MaxInboundDatagramSize {
 			return dtlserrors.ErrInvalidMTU
 		}
 		c.MTU = mtu
@@ -381,10 +382,10 @@ func WithMTU(mtu int) Option {
 //
 // This does not change the kernel socket receive buffer (SO_RCVBUF); use
 // net.UDPConn.SetReadBuffer for that.
-// Returns an error if the size is not positive.
+// Returns an error if the buffer size is not positive or greater than the 65535.
 func WithReceiveBufferSize(size int) Option {
 	return sharedOption(func(c *dtlsConfig) error {
-		if size <= 0 {
+		if size < minReceiveBufferSize || size > dtlsnet.MaxInboundDatagramSize {
 			return dtlserrors.ErrInvalidReceiveBufferSize
 		}
 		c.ReceiveBufferSize = size

--- a/options_test.go
+++ b/options_test.go
@@ -13,6 +13,7 @@ import (
 
 	dtlsconfig "github.com/pion/dtls/v3/internal/config"
 	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsnet "github.com/pion/dtls/v3/internal/net"
 	cryptosuite "github.com/pion/dtls/v3/pkg/crypto/ciphersuite"
 	"github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
@@ -226,8 +227,19 @@ func TestInvalidNumericOptionsReturnError(t *testing.T) {
 		options []Option
 		want    error
 	}{
-		"InvalidFlightInterval":         {[]Option{WithFlightInterval(0), WithFlightInterval(-time.Second)}, dtlserrors.ErrInvalidFlightInterval},
-		"InvalidMTU":                    {[]Option{WithMTU(0), WithMTU(-100)}, dtlserrors.ErrInvalidMTU},
+		"InvalidFlightInterval": {[]Option{WithFlightInterval(0), WithFlightInterval(-time.Second)}, dtlserrors.ErrInvalidFlightInterval},
+		"InvalidMTU": {[]Option{
+			WithMTU(-1),
+			WithMTU(0),
+			WithMTU(dtlsnet.MaxInboundDatagramSize + 1),
+			WithMTU(1 << 20),
+		}, dtlserrors.ErrInvalidMTU},
+		"InvalidReceiveBufferSize": {[]Option{
+			WithReceiveBufferSize(-1),
+			WithReceiveBufferSize(0),
+			WithReceiveBufferSize(dtlsnet.MaxInboundDatagramSize + 1),
+			WithReceiveBufferSize(1 << 20),
+		}, dtlserrors.ErrInvalidReceiveBufferSize},
 		"InvalidReplayProtectionWindow": {[]Option{WithReplayProtectionWindow(-1)}, dtlserrors.ErrInvalidReplayProtectionWindow},
 	}
 	for name, test := range tests {
@@ -255,6 +267,34 @@ func TestInvalidNumericOptionsReturnError(t *testing.T) {
 			require.ErrorIs(t, clientOptionsError(t, option), dtlserrors.ErrUnsupportedProtocolVersion)
 		}
 	})
+}
+
+func TestBoundedNumericOptionValues(t *testing.T) {
+	tests := map[string]struct {
+		option Option
+		check  func(*dtlsConfig)
+	}{
+		"MinimumMTU": {WithMTU(minMTU), func(config *dtlsConfig) {
+			require.Equal(t, minMTU, config.MTU)
+		}},
+		"MaximumMTU": {WithMTU(dtlsnet.MaxInboundDatagramSize), func(config *dtlsConfig) {
+			require.Equal(t, dtlsnet.MaxInboundDatagramSize, config.MTU)
+		}},
+		"MinimumReceiveBufferSize": {WithReceiveBufferSize(minReceiveBufferSize), func(config *dtlsConfig) {
+			require.Equal(t, minReceiveBufferSize, config.ReceiveBufferSize)
+		}},
+		"MaximumReceiveBufferSize": {WithReceiveBufferSize(dtlsnet.MaxInboundDatagramSize), func(config *dtlsConfig) {
+			require.Equal(t, dtlsnet.MaxInboundDatagramSize, config.ReceiveBufferSize)
+		}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config, err := buildConfig(test.option)
+			require.NoError(t, err)
+			test.check(config)
+		})
+	}
 }
 
 func TestX25519MLKEM768RequiresDTLS13(t *testing.T) {

--- a/receive_buffer_size_test.go
+++ b/receive_buffer_size_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	dtlserrors "github.com/pion/dtls/v3/internal/errors"
+	dtlsnet "github.com/pion/dtls/v3/internal/net"
 	"github.com/pion/dtls/v3/pkg/crypto/selfsign"
 	"github.com/pion/transport/v4/test"
 	"github.com/stretchr/testify/assert"
@@ -98,12 +100,14 @@ func TestReceiveBufferSizeLargeDatagram(t *testing.T) {
 }
 
 func TestWithReceiveBufferSizeValidation(t *testing.T) {
-	for _, size := range []int{0, -1} {
+	for _, size := range []int{-1, 0, dtlsnet.MaxInboundDatagramSize + 1, 1 << 20} {
 		_, err := buildConfig(WithReceiveBufferSize(size))
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, dtlserrors.ErrInvalidReceiveBufferSize)
 	}
 
-	config, err := buildConfig(WithReceiveBufferSize(16384))
-	assert.NoError(t, err)
-	assert.Equal(t, 16384, config.ReceiveBufferSize)
+	for _, size := range []int{minReceiveBufferSize, 16384, dtlsnet.MaxInboundDatagramSize} {
+		config, err := buildConfig(WithReceiveBufferSize(size))
+		assert.NoError(t, err)
+		assert.Equal(t, size, config.ReceiveBufferSize)
+	}
 }


### PR DESCRIPTION
#### Description
#1016 makes the receive buffer configurable, but unbounded, Our MTU is also unbounded Both are really hard to support, this bounds both values to uint16 max value which is reasnable limit around UDP max limit and easy to support
Even if it's not realistic for users to set value this high, This avoids undefined behavior.

relates to #1053 
